### PR TITLE
Track LLM Request ID as `llmReqId`

### DIFF
--- a/src/ingester/api/handlers.go
+++ b/src/ingester/api/handlers.go
@@ -144,7 +144,7 @@ func DataHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var err error
-	data["name"], err = auth.AuthenticateRequest(getAuthKey(r))
+	_, err = auth.AuthenticateRequest(getAuthKey(r))
 	if err != nil {
 		handleAPIKeyErrors(w, err, "")
 		return

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -18,11 +18,11 @@ import (
 )
 
 var (
-	once                sync.Once          // once is used to ensure that the database is initialized only once
-	db                  *sql.DB            // db holds the database connection
-	dbConfig            DatabaseConfig     // dbConfig holds the database configuration
-	doku_llm_data_table = "DOKU_TEST_DA" // doku_llm_data_table holds the name of the data table
-	doku_apikeys_table  = "DOKU_TEST_KE" // doku_apikeys_table holds the name of the API keys table
+	once                sync.Once         // once is used to ensure that the database is initialized only once
+	db                  *sql.DB           // db holds the database connection
+	dbConfig            DatabaseConfig    // dbConfig holds the database configuration
+	doku_llm_data_table = "DOKU_LLM_DATA" // doku_llm_data_table holds the name of the data table
+	doku_apikeys_table  = "DOKU_APIKEYS"  // doku_apikeys_table holds the name of the API keys table
 	// validFields represent the fields that are expected in the incoming data.
 	validFields = []string{
 		"name",

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -18,10 +18,11 @@ import (
 )
 
 var (
-	once     sync.Once      // once is used to ensure that the database is initialized only once
-	db       *sql.DB        // db holds the database connection
-	dbConfig DatabaseConfig // dbConfig holds the database configuration
-
+	once                sync.Once          // once is used to ensure that the database is initialized only once
+	db                  *sql.DB            // db holds the database connection
+	dbConfig            DatabaseConfig     // dbConfig holds the database configuration
+	doku_llm_data_table = "DOKU_TEST_DA" // doku_llm_data_table holds the name of the data table
+	doku_apikeys_table  = "DOKU_TEST_KE" // doku_apikeys_table holds the name of the API keys table
 	// validFields represent the fields that are expected in the incoming data.
 	validFields = []string{
 		"name",
@@ -115,8 +116,7 @@ func getCreateDataTableSQL(tableName string) string {
 	CREATE TABLE IF NOT EXISTS %s (
 		time TIMESTAMPTZ NOT NULL,
 		id UUID DEFAULT gen_random_uuid(),
-		llmReqId VARCHAR(50),
-		name VARCHAR(10) NOT NULL,
+		llmReqId TEXT,
 		environment VARCHAR(50) NOT NULL,
 		endpoint VARCHAR(50) NOT NULL,
 		sourceLanguage VARCHAR(50) NOT NULL,
@@ -161,9 +161,9 @@ func tableExists(db *sql.DB, tableName string) (bool, error) {
 // createTable creates a table in the database if it doesn't exist.
 func createTable(db *sql.DB, tableName string, retentionPeriod string) error {
 	var createTableSQL string
-	if tableName == "DOKU_APIKEYS" {
+	if tableName == doku_apikeys_table {
 		createTableSQL = getCreateAPIKeysTableSQL(tableName)
-	} else if tableName == "DOKU_LLM_DATA" {
+	} else if tableName == doku_llm_data_table {
 		createTableSQL = getCreateDataTableSQL(tableName)
 	}
 
@@ -178,7 +178,7 @@ func createTable(db *sql.DB, tableName string, retentionPeriod string) error {
 		}
 		log.Info().Msgf("Table '%s' created in the database", tableName)
 
-		if tableName == "DOKU_APIKEYS" {
+		if tableName == doku_apikeys_table {
 			createIndexSQL := fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_api_key ON %s (api_key);", tableName)
 			_, err = db.Exec(createIndexSQL)
 			if err != nil {
@@ -188,7 +188,7 @@ func createTable(db *sql.DB, tableName string, retentionPeriod string) error {
 		}
 
 		// If the table to create is the data table, convert it into a hypertable
-		if tableName == "DOKU_LLM_DATA" {
+		if tableName == doku_llm_data_table {
 			_, err := db.Exec("SELECT create_hypertable($1, 'time')", tableName)
 			if err != nil {
 				return fmt.Errorf("Error creating hypertable: %w", err)
@@ -269,11 +269,10 @@ func insertDataToDB(data map[string]interface{}) (string, int) {
 	go obsPlatform.SendToPlatform(data)
 
 	// Define the SQL query for data insertion
-	query := fmt.Sprintf("INSERT INTO %s (time, llmReqId, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)", "DOKU_LLM_DATA")
+	query := fmt.Sprintf("INSERT INTO %s (time, llmReqId, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)", doku_llm_data_table)
 
 	// Execute the SQL query
 	_, err := db.Exec(query,
-		data["name"],
 		data["llmReqId"],
 		data["environment"],
 		data["endpoint"],
@@ -325,17 +324,17 @@ func Init(cfg config.Configuration) error {
 	}
 
 	// Create the DATA and API keys table if it doesn't exist.
-	log.Info().Msgf("Creating '%s' and '%s' tables in the database if they don't exist", "DOKU_APIKEYS", "DOKU_LLM_DATA")
+	log.Info().Msgf("Creating '%s' and '%s' tables in the database if they don't exist", doku_apikeys_table, doku_llm_data_table)
 
-	err = createTable(db, "DOKU_APIKEYS", cfg.RentionPeriod)
+	err = createTable(db, doku_apikeys_table, cfg.RentionPeriod)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error creating table %s", "DOKU_APIKEYS")
+		log.Error().Err(err).Msgf("Error creating table %s", doku_apikeys_table)
 		return err
 	}
 
-	err = createTable(db, "DOKU_LLM_DATA", cfg.RentionPeriod)
+	err = createTable(db, doku_llm_data_table, cfg.RentionPeriod)
 	if err != nil {
-		log.Error().Err(err).Msgf("Error creating table %s", "DOKU_APIKEYS")
+		log.Error().Err(err).Msgf("Error creating table %s", doku_apikeys_table)
 		return err
 	}
 	return nil
@@ -354,7 +353,7 @@ func PerformDatabaseInsertion(data map[string]interface{}) (string, int) {
 func CheckAPIKey(apiKey string) (string, error) {
 	var name string
 
-	query := fmt.Sprintf("SELECT name FROM %s WHERE api_key = $1", "DOKU_APIKEYS")
+	query := fmt.Sprintf("SELECT name FROM %s WHERE api_key = $1", doku_apikeys_table)
 	err := db.QueryRow(query, apiKey).Scan(&name)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -369,7 +368,7 @@ func CheckAPIKey(apiKey string) (string, error) {
 func GenerateAPIKey(existingAPIKey, name string) (string, error) {
 	// If there are any existing API keys, authenticate the provided API key before proceeding
 	var count int
-	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", "DOKU_APIKEYS")
+	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM %s", doku_apikeys_table)
 	err := db.QueryRow(countQuery).Scan(&count)
 	if err != nil {
 		log.Error().Err(err).Msg("Error checking API key table")
@@ -393,7 +392,7 @@ func GenerateAPIKey(existingAPIKey, name string) (string, error) {
 	newAPIKey, _ := generateSecureRandomKey()
 
 	// Insert the new API key into the database
-	insertQuery := fmt.Sprintf("INSERT INTO %s (api_key, name) VALUES ($1, $2)", "DOKU_APIKEYS")
+	insertQuery := fmt.Sprintf("INSERT INTO %s (api_key, name) VALUES ($1, $2)", doku_apikeys_table)
 	_, err = db.Exec(insertQuery, newAPIKey, name)
 	if err != nil {
 		log.Error().Err(err).Msg("Error inserting the new API key in the database")
@@ -415,7 +414,7 @@ func GetAPIKeyForName(existingAPIKey, name string) (string, error) {
 
 	// Retrieve the API key for the given name
 	var apiKey string
-	query := fmt.Sprintf("SELECT api_key FROM %s WHERE name = $1", "DOKU_APIKEYS")
+	query := fmt.Sprintf("SELECT api_key FROM %s WHERE name = $1", doku_apikeys_table)
 	err = db.QueryRow(query, name).Scan(&apiKey)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -446,7 +445,7 @@ func DeleteAPIKey(existingAPIKey, name string) error {
 
 	// Delete the API key from the database
 	log.Info().Msgf("Deleting API Key with the name '%s' from the database", name)
-	query := fmt.Sprintf("DELETE FROM %s WHERE api_key = $1", "DOKU_APIKEYS")
+	query := fmt.Sprintf("DELETE FROM %s WHERE api_key = $1", doku_apikeys_table)
 	_, err = db.Exec(query, apiKey)
 	if err != nil {
 		log.Error().Err(err).Msg("Error deleting API key")

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -115,6 +115,7 @@ func getCreateDataTableSQL(tableName string) string {
 	CREATE TABLE IF NOT EXISTS %s (
 		time TIMESTAMPTZ NOT NULL,
 		id UUID DEFAULT gen_random_uuid(),
+		llm_req_id VARCHAR(50) NOT NULL,
 		name VARCHAR(10) NOT NULL,
 		environment VARCHAR(50) NOT NULL,
 		endpoint VARCHAR(50) NOT NULL,
@@ -269,11 +270,12 @@ func insertDataToDB(data map[string]interface{}) (string, int) {
 	go obsPlatform.SendToPlatform(data)
 
 	// Define the SQL query for data insertion
-	query := fmt.Sprintf("INSERT INTO %s (time, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobId, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)", "DOKU_LLM_DATA")
+	query := fmt.Sprintf("INSERT INTO %s (time, llm_req_id, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobId, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)", "DOKU_LLM_DATA")
 
 	// Execute the SQL query
 	_, err := db.Exec(query,
 		data["name"],
+		data["llmReqId"],
 		data["environment"],
 		data["endpoint"],
 		data["sourceLanguage"],

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -43,7 +43,6 @@ var (
 		"revisedPrompt",
 		"image",
 		"audioVoice",
-		"finetuneJobId",
 		"finetuneJobStatus",
 	}
 )
@@ -135,7 +134,6 @@ func getCreateDataTableSQL(tableName string) string {
 		revisedPrompt TEXT,
 		image TEXT,
 		audioVoice TEXT,
-		finetuneJobId TEXT,
 		finetuneJobStatus TEXT
 	);`, tableName)
 }
@@ -271,7 +269,7 @@ func insertDataToDB(data map[string]interface{}) (string, int) {
 	go obsPlatform.SendToPlatform(data)
 
 	// Define the SQL query for data insertion
-	query := fmt.Sprintf("INSERT INTO %s (time, llmReqId, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobId, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)", "DOKU_LLM_DATA")
+	query := fmt.Sprintf("INSERT INTO %s (time, llmReqId, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)", "DOKU_LLM_DATA")
 
 	// Execute the SQL query
 	_, err := db.Exec(query,
@@ -294,7 +292,6 @@ func insertDataToDB(data map[string]interface{}) (string, int) {
 		data["revisedPrompt"],
 		data["image"],
 		data["audioVoice"],
-		data["finetuneJobId"],
 		data["finetuneJobStatus"],
 	)
 	if err != nil {

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -25,6 +25,7 @@ var (
 	// validFields represent the fields that are expected in the incoming data.
 	validFields = []string{
 		"name",
+		"llmReqId",
 		"environment",
 		"endpoint",
 		"sourceLanguage",
@@ -115,7 +116,7 @@ func getCreateDataTableSQL(tableName string) string {
 	CREATE TABLE IF NOT EXISTS %s (
 		time TIMESTAMPTZ NOT NULL,
 		id UUID DEFAULT gen_random_uuid(),
-		llm_req_id VARCHAR(50) NOT NULL,
+		llmReqId VARCHAR(50),
 		name VARCHAR(10) NOT NULL,
 		environment VARCHAR(50) NOT NULL,
 		endpoint VARCHAR(50) NOT NULL,
@@ -270,7 +271,7 @@ func insertDataToDB(data map[string]interface{}) (string, int) {
 	go obsPlatform.SendToPlatform(data)
 
 	// Define the SQL query for data insertion
-	query := fmt.Sprintf("INSERT INTO %s (time, llm_req_id, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobId, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)", "DOKU_LLM_DATA")
+	query := fmt.Sprintf("INSERT INTO %s (time, llmReqId, name, environment, endpoint, sourceLanguage, applicationName, completionTokens, promptTokens, totalTokens, finishReason, requestDuration, usageCost, model, prompt, response, imageSize, revisedPrompt, image, audioVoice, finetuneJobId, finetuneJobStatus) VALUES (NOW(), $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)", "DOKU_LLM_DATA")
 
 	// Execute the SQL query
 	_, err := db.Exec(query,

--- a/src/ingester/obsPlatform/datadog.go
+++ b/src/ingester/obsPlatform/datadog.go
@@ -193,8 +193,8 @@ func configureDataDogData(data map[string]interface{}) {
 				"type": 0,
 				"points": [{ "timestamp": %d, "value": %f }],
 				"resources": [{ "name": "doku-ingester", "type": "host" }],
-				"tags": ["environment:%v", "endpoint:%v", "applicationName:%v", "source:%v", "model:%v", "finetuneJobId:%v"]
-			}`, currentTime, data["requestDuration"], data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"], data["finetuneJobId"]),
+				"tags": ["environment:%v", "endpoint:%v", "applicationName:%v", "source:%v", "model:%v"]
+			}`, currentTime, data["requestDuration"], data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"]),
 		}
 
 		metrics := fmt.Sprintf(`{"series": [%s]}`, strings.Join(metricStrings, ","))

--- a/src/ingester/obsPlatform/grafana-cloud.go
+++ b/src/ingester/obsPlatform/grafana-cloud.go
@@ -103,7 +103,7 @@ func configureGrafanaCloudData(data map[string]interface{}) {
 		}
 	} else if data["endpoint"] == "openai.fine_tuning" {
 		metrics := []string{
-			fmt.Sprintf(`doku_llm,environment=%v,endpoint=%v,applicationName=%v,source=%v,model=%v,finetuneJobId=%v,platform=%v,generation=%v requestDuration=%v`, data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"], data["finetuneJobId"], platform, call_type, data["requestDuration"]),
+			fmt.Sprintf(`doku_llm,environment=%v,endpoint=%v,applicationName=%v,source=%v,model=%v,platform=%v,generation=%v requestDuration=%v`, data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"], platform, call_type, data["requestDuration"]),
 		}
 		var metricsBody = []byte(strings.Join(metrics, "\n"))
 		authHeader := fmt.Sprintf("Bearer %v:%v", grafanaPromUsername, grafanaAccessToken)

--- a/src/ingester/obsPlatform/newrelic.go
+++ b/src/ingester/obsPlatform/newrelic.go
@@ -238,8 +238,8 @@ func configureNewRelicData(data map[string]interface{}) {
 					"type": "gauge",
 					"value": %v,
 					"timestamp": %s,
-					"attributes": {"environment": "%v", "endpoint": "%v", "applicationName": "%v", "source": "%v", "model": "%v", "finetuneJobId": "%v"}
-				}`, data["requestDuration"], currentTime, data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"], data["finetuneJobId"]),
+					"attributes": {"environment": "%v", "endpoint": "%v", "applicationName": "%v", "source": "%v", "model": "%v"}
+				}`, data["requestDuration"], currentTime, data["environment"], data["endpoint"], data["applicationName"], data["sourceLanguage"], data["model"]),
 		}
 		// Join the individual metric strings into a comma-separated string and enclose in a JSON array.
 		jsonData := fmt.Sprintf(`[{"metrics": [%s]}]`, strings.Join(jsonMetrics, ","))


### PR DESCRIPTION
resolves #49 

This PR does the following

- Creates a fixed variable for table name `DOKU_LLM_DATA` and `DOKU_APIKEYS`
- Updates `DOKU_LLM_DATA`  table schema to have `llmReqId`
- Removes `name` from `DOKU_LLM_DATA`  table schema and `data` dict
- Removes `fineTuneJobId` from `DOKU_LLM_DATA`  table schema and `data` dict and consequent usage in export