### PR TITLE
[Feat]: Add `GET` for  `/api/connections` endpoint in Ingester

### DIFF
--- a/docs/0.1/api-reference/endpoint/connections/get.mdx
+++ b/docs/0.1/api-reference/endpoint/connections/get.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Connections'
+openapi: 'GET /api/connections'
+---

--- a/docs/0.1/api-reference/endpoint/connections/get.mdx
+++ b/docs/0.1/api-reference/endpoint/connections/get.mdx
@@ -2,3 +2,5 @@
 title: 'Get Connections'
 openapi: 'GET /api/connections'
 ---
+
+This functionality was introduced to the Doku Ingester in version `0.1.2`

--- a/docs/0.1/api-reference/openiapi.yml
+++ b/docs/0.1/api-reference/openiapi.yml
@@ -43,6 +43,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/json201Response'
+    get:
+      summary: Get Connections details
+      operationId: getConnection
+      tags:
+        - Connection
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Connection details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionDetailsResponse'
+        '404':
+          description: Unauthorized request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/json401Response'
   /api/keys:
     get:
       summary: Get a list of API keys
@@ -143,7 +163,32 @@ components:
         ApiKey:
           type: string
           description: API Key for the Observability Platform. Example - `glc*******`
-
+    ConnectionDetailsResponse:
+      type: object
+      properties:
+        connections:
+          type: object
+          properties:
+            apiKey:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+            id:
+              type: string
+            logsUrl:
+              type: string
+            logsUsername:
+              type: string
+            metricsUrl:
+              type: string
+            metricsUsername:
+              type: string
+            platform:
+              type: string
+        status:
+          type: integer
+          example: 200
     json201Response:
       type: object
       required:

--- a/docs/latest/api-reference/endpoint/connections/get.mdx
+++ b/docs/latest/api-reference/endpoint/connections/get.mdx
@@ -2,3 +2,5 @@
 title: 'Get Connection'
 openapi: 'GET /api/connections'
 ---
+
+This functionality was introduced to the Doku Ingester in version `0.1.2`

--- a/docs/latest/api-reference/endpoint/connections/get.mdx
+++ b/docs/latest/api-reference/endpoint/connections/get.mdx
@@ -1,0 +1,4 @@
+---
+title: 'Get Connection'
+openapi: 'GET /api/connections'
+---

--- a/docs/latest/api-reference/openiapi.yml
+++ b/docs/latest/api-reference/openiapi.yml
@@ -43,6 +43,26 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/json201Response'
+    get:
+      summary: Get Connections details
+      operationId: getConnection
+      tags:
+        - Connection
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: Connection details retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectionDetailsResponse'
+        '404':
+          description: Unauthorized request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/json401Response'
   /api/keys:
     get:
       summary: Get a list of API keys
@@ -143,7 +163,32 @@ components:
         ApiKey:
           type: string
           description: API Key for the Observability Platform. Example - `glc*******`
-
+    ConnectionDetailsResponse:
+      type: object
+      properties:
+        connections:
+          type: object
+          properties:
+            apiKey:
+              type: string
+            created_at:
+              type: string
+              format: date-time
+            id:
+              type: string
+            logsUrl:
+              type: string
+            logsUsername:
+              type: string
+            metricsUrl:
+              type: string
+            metricsUsername:
+              type: string
+            platform:
+              type: string
+        status:
+          type: integer
+          example: 200
     json201Response:
       type: object
       required:

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -172,7 +172,8 @@
           "icon": "link",
           "pages": [
             "latest/api-reference/endpoint/connections/create",
-            "latest/api-reference/endpoint/connections/delete"
+            "latest/api-reference/endpoint/connections/delete",
+            "latest/api-reference/endpoint/connections/get"
           ],
           "version": "latest"
         }
@@ -310,7 +311,8 @@
           "icon": "link",
           "pages": [
             "0.1/api-reference/endpoint/connections/create",
-            "0.1/api-reference/endpoint/connections/delete"
+            "0.1/api-reference/endpoint/connections/delete",
+            "0.1/api-reference/endpoint/connections/get"
           ],
           "version": "0.1"
         }

--- a/src/ingester/api/handlers.go
+++ b/src/ingester/api/handlers.go
@@ -176,21 +176,21 @@ func getConnectionsHandler(w http.ResponseWriter, r *http.Request) {
 			sendJSONResponse(w, http.StatusUnauthorized, errMsgAuthFailed)
 			return
 		}
-		sendJSONResponse(w, http.StatusBadRequest, "Error getting connection: " +err.Error())
+		sendJSONResponse(w, http.StatusBadRequest, "Error getting connection: "+err.Error())
 		return
 	}
 
 	response := map[string]interface{}{
-        "status":      http.StatusOK,
-        "connections": observability,
-    }
+		"status":      http.StatusOK,
+		"connections": observability,
+	}
 
-    w.Header().Set("Content-Type", "application/json")
-    w.WriteHeader(http.StatusOK) // Setting the status code here is actually superfluous since `Encode` will write it as well.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK) // Setting the status code here is actually superfluous since `Encode` will write it as well.
 
-    if err := json.NewEncoder(w).Encode(response); err != nil {
-        http.Error(w, "Error encoding JSON", http.StatusInternalServerError)
-    }
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Error encoding JSON", http.StatusInternalServerError)
+	}
 }
 
 // generateAPIKeyHandler handles the creation of a new API Key

--- a/src/ingester/api/handlers.go
+++ b/src/ingester/api/handlers.go
@@ -163,6 +163,36 @@ func deleteConnectionsHandler(w http.ResponseWriter, r *http.Request) {
 	sendJSONResponse(w, http.StatusOK, "Connection deleted successfully")
 }
 
+// getConnectionsHandler handles the retrieval of a new Connection
+func getConnectionsHandler(w http.ResponseWriter, r *http.Request) {
+
+	observability, err := db.GetConnection(getAuthKey(r))
+	if err != nil {
+		if err.Error() == "NOTFOUND" {
+			sendJSONResponse(w, http.StatusNotFound, "No existing Connection found")
+			return
+		}
+		if err.Error() == "AUTHFAILED" {
+			sendJSONResponse(w, http.StatusUnauthorized, errMsgAuthFailed)
+			return
+		}
+		sendJSONResponse(w, http.StatusBadRequest, "Error getting connection: " +err.Error())
+		return
+	}
+
+	response := map[string]interface{}{
+        "status":      http.StatusOK,
+        "connections": observability,
+    }
+
+    w.Header().Set("Content-Type", "application/json")
+    w.WriteHeader(http.StatusOK) // Setting the status code here is actually superfluous since `Encode` will write it as well.
+
+    if err := json.NewEncoder(w).Encode(response); err != nil {
+        http.Error(w, "Error encoding JSON", http.StatusInternalServerError)
+    }
+}
+
 // generateAPIKeyHandler handles the creation of a new API Key
 func generateAPIKeyHandler(w http.ResponseWriter, r *http.Request) {
 	var request APIKeyRequest
@@ -276,6 +306,8 @@ func APIKeyHandler(w http.ResponseWriter, r *http.Request) {
 // ConnectionsHandler handles all 'Connections' tasks recieved on `/api/connections` endpoint.
 func ConnectionsHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
+	case "GET":
+		getConnectionsHandler(w, r)
 	case "POST":
 		generateConnectionsHandler(w, r)
 	case "DELETE":

--- a/src/ingester/db/db.go
+++ b/src/ingester/db/db.go
@@ -572,7 +572,7 @@ func GetConnection(existingAPIKey string) (map[string]interface{}, error) {
 	row := db.QueryRow(ctx, query)
 
 	var id, platform, metricsUrl, logsUrl, apiKey, metricsUsername, logsUsername string
-	var createdAt time.Time 
+	var createdAt time.Time
 
 	// Scan the results into variables.
 	err = row.Scan(&id, &platform, &metricsUrl, &logsUrl, &apiKey, &metricsUsername, &logsUsername, &createdAt)

--- a/src/ingester/main.go
+++ b/src/ingester/main.go
@@ -84,7 +84,7 @@ func main() {
 	r.HandleFunc("/api/push", api.DataHandler).Methods("POST")
 	r.HandleFunc("/api/keys", api.APIKeyHandler).Methods("GET", "POST", "DELETE")
 	r.HandleFunc("/", api.BaseEndpoint).Methods("GET")
-	r.HandleFunc("/api/connections", api.ConnectionsHandler).Methods("POST", "DELETE")
+	r.HandleFunc("/api/connections", api.ConnectionsHandler).Methods("POST", "DELETE", "GET")
 
 	// Define and start the HTTP server
 	server := &http.Server{


### PR DESCRIPTION
#### Overview:
This PR adds a GET method support for `/api/connections` endpoint in Ingester

---

#### Changes:
- Add GET method support for `/api/connections` endpoint in Ingester 
- Update OpenAPI spec and docs for adding this endpoint
---

#### Visuals:
NA

---

#### Checklist:
- [x] PR name follows conventional commits format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (Needed if you made changes to Doku Client or Connections in Doku Ingester)
- [x] Checked Doku [contribution guidelines](https://github.com/dokulabs/doku/blob/main/CONTRIBUTING.md)
