### PR TITLE
[Feat]: Add Discord link to docs

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -328,6 +328,7 @@
   "footerSocials": {
     "github": "https://github.com/dokulabs/",
     "slack": "https://join.slack.com/t/dokulabs/shared_invite/zt-2etnfttwg-TjP_7BZXfYg84oAukY8QRQ",
-    "twitter": "https://twitter.com/doku_labs"
+    "twitter": "https://twitter.com/doku_labs",
+    "discord": "https://discord.gg/pGKEqmDE"
   }
 }


### PR DESCRIPTION
#### Overview:
This PR adds a link to Doku Discord Community

---

#### Changes:
- Added [discord link](https://discord.gg/pGKEqmDE) in mint.json

---

#### Visuals:
NA

---

#### Checklist:
- [x] PR name follows conventional commits format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (Needed if you made changes to Doku Client or Connections in Doku Ingester)
- [x] Checked Doku [contribution guidelines](https://github.com/dokulabs/doku/blob/main/CONTRIBUTING.md)
