### PR TITLE
[Fix]: Reduce Doku Client image size

### DIFF
--- a/src/client/Dockerfile
+++ b/src/client/Dockerfile
@@ -1,5 +1,8 @@
-# Use an official Node runtime as a base image
-FROM node:20 as builder
+# Use an alpine as a base image
+FROM alpine as builder
+
+# Installing node and npm
+RUN apk add --update nodejs npm
 
 # Set the working directory in the container
 WORKDIR /app/client
@@ -10,15 +13,18 @@ COPY . .
 # Install dependencies & Build the Next.js application
 RUN npm install && npm run build
 
+
 # Use a smaller image for production
-FROM node:20
+FROM alpine
+
+RUN apk add --update nodejs npm
 
 # Set the working directory in the container
 WORKDIR /app/client
 
 # Copy only necessary files from the builder stage
 COPY --from=builder /app/client/.next ./.next
-COPY --from=builder /app/client/node_modules ./node_modules
+# COPY --from=builder /app/client/node_modules ./node_modules
 COPY --from=builder /app/client/package.json ./package.json
 COPY --from=builder /app/client/package-lock.json ./package-lock.json
 COPY --from=builder /app/client/public ./public
@@ -27,9 +33,11 @@ COPY --from=builder /app/client/prisma ./prisma
 # Execute entrypoint script to generate NextAuth.js secret and run commands
 COPY --from=builder /app/client/entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
+# Installing extra packages
+RUN apk --no-cache add bash openssl
 
 # Expose the port that Next.js will run on
 EXPOSE 3000
 
 # Run Prisma migrations using npx
-CMD ["./entrypoint.sh"]
+CMD ["/app/client/entrypoint.sh"]

--- a/src/client/entrypoint.sh
+++ b/src/client/entrypoint.sh
@@ -17,11 +17,12 @@ echo "INIT_DB_PORT=${INIT_DB_PORT}" >> /etc/environment
 echo "INIT_DB_DATABASE=${INIT_DB_DATABASE}" >> /etc/environment
 
 # Run Prisma migrations and generate prisma client
-npx prisma migrate deploy
-npx prisma generate
+npm install -g prisma
+prisma migrate deploy
+prisma generate
 
 # Run the seed 
-npx prisma db seed
+prisma db seed
 
 # Start the Next.js application
 exec node --max_old_space_size=512 $(which npm) start

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -44,6 +44,6 @@
     "typescript": "^5.3.3"
   },
   "prisma": {
-    "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} prisma/seed.ts"
+    "seed": "node prisma/seed.js"
   }
 }

--- a/src/client/prisma/seed.js
+++ b/src/client/prisma/seed.js
@@ -1,6 +1,7 @@
-import { PrismaClient } from "@prisma/client";
+const { PrismaClient } = require("@prisma/client");
 const prisma = new PrismaClient();
 async function main() {
+	console.log("Inside seeding.....");
 	// const defaultPassword = "dokulabsuser"; ⤵
 	const hashedPassword =
 		"$2a$10$XmL4Q45wWgPzMJXlM5L70eFyYvUGgIeRRm5f4.OOlcaIM/sQB6j/S";
@@ -49,6 +50,7 @@ async function main() {
 			},
 		});
 	}
+	console.log("Seeding End.....");
 }
 main()
 	.then(async () => {
@@ -57,5 +59,4 @@ main()
 	.catch(async (e) => {
 		console.error(e);
 		await prisma.$disconnect();
-		process.exit(1);
 	});

--- a/src/client/tsconfig.json
+++ b/src/client/tsconfig.json
@@ -27,6 +27,6 @@
       "@/constants/*": ["./src/constants/*"],
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "prisma/seed.js"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
#### Overview:
This PR  reduces client docker image size from 2.14 GB to 402.84 MB.

---

#### Changes:
- Changed the docker image from `node:20` to `alpine`
- Installed `node`, `npm` inside the image to make everything work
- Updated the `seed.ts` to `seed.js` as it was restarting the container again and again due to `ts-node` error

Fixes #136

---

#### Visuals:
<img width="970" alt="Screenshot 2024-03-23 at 1 30 18 PM" src="https://github.com/dokulabs/doku/assets/150420377/42c6bd2e-e04b-44f7-84fc-c2d409e30e0e">

---

#### Checklist:
- [x] PR name follows conventional commits format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (Needed if you made changes to Doku Client or Connections in Doku Ingester)
- [x] Checked Doku [contribution guidelines](https://github.com/dokulabs/doku/blob/main/CONTRIBUTING.md)
