### PR TITLE
[Fix]: litellm link in doc

### DIFF
--- a/docs/latest/integrations/introduction.mdx
+++ b/docs/latest/integrations/introduction.mdx
@@ -175,7 +175,7 @@ Start integrating and monitoring your applications with OpenLIT effortlessly. Ch
   </Card>
   <Card
       title="LiteLLM"
-      href="/latest/integrations/liellm"
+      href="/latest/integrations/litellm"
       iconType="duotone"
     >
   </Card>


### PR DESCRIPTION
#### Overview:
What does this PR do? Link issues here.

Fixes the link on the `integrations/introduction` overview page to litellm

#### Checklist:
- [x ] PR name follows conventional commits format: `[Feat]: ...` or `[Fix]: ....`
- [  ] Added visuals for changes
- [ x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
