### PR TITLE
[Fix]: Use same collection name in Milvus Test

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,11 +5,11 @@ on:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
-  pull_request_target:
-    branches: [ "main" ]
-    paths:
-      - 'sdk/python/**'
   workflow_dispatch:
+  workflow_run:
+    workflows: [Pylint]
+    types:
+      - completed
   schedule:
     - cron: '0 0 1-31/15 * *'
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,11 +5,11 @@ on:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
-  workflow_dispatch:
   workflow_run:
     workflows: [Pylint]
     types:
       - completed
+  workflow_dispatch:
   schedule:
     - cron: '0 0 1-31/15 * *'
 

--- a/sdk/python/tests/test_milvus.py
+++ b/sdk/python/tests/test_milvus.py
@@ -27,7 +27,7 @@ client = MilvusClient(
 # Initialize environment and application name for OpenLIT monitoring
 openlit.init(environment="openlit-testing", application_name="openlit-python-test")
 
-COLLECTION_NAME = "openlit"+str(os.getenv("GITHUB_RUN_ID"))+str(os.getenv("GITHUB_RUN_ATTEMPT"))
+COLLECTION_NAME = "openlit"
 
 def test_db_milvus():
     """
@@ -51,13 +51,13 @@ def test_db_milvus():
       AssertionError: If the responses from ChromaDB operations do not meet the expected outcomes.
     """
 
-    # Create a new collection
-    collection = client.create_collection(
-      collection_name=COLLECTION_NAME,
-      dimension=5
-    )
+    # # Create a new collection
+    # collection = client.create_collection(
+    #   collection_name=COLLECTION_NAME,
+    #   dimension=5
+    # )
 
-    assert collection is None
+    # assert collection is None
 
     data=[
       # pylint: disable=line-too-long
@@ -122,7 +122,7 @@ def test_db_milvus():
 
     assert isinstance(delt, dict)
 
-    # Delete collection
-    client.drop_collection(
-      collection_name=COLLECTION_NAME,
-    )
+    # # Delete collection
+    # client.drop_collection(
+    #   collection_name=COLLECTION_NAME,
+    # )


### PR DESCRIPTION
#### Overview:
This PR uses the same Collection name in Milvus test and avoid creation and deletion of collection for each workflow run

---

#### Changes:
- `test_milvus.py` has collection create and delete commands commented

---

#### Visuals:
NA

---

#### Checklist:
- [x] PR name follows conventional commits format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
