### PR TITLE
[Fix]: Ensure `fetch_pricing_info()` is called once during initialization

### DIFF
--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -78,7 +78,7 @@ class OpenlitConfig:
         """Resets configuration to default values."""
         cls.environment = "default"
         cls.application_name = "default"
-        cls.pricing_info = fetch_pricing_info()
+        cls.pricing_info = {}
         cls.tracer = None
         cls.metrics_dict = {}
         cls.otlp_endpoint = None


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
In the OpenlitConfig, It seems that `update_config()` will still be called f`etch_pricing_info()` again. 
It seem to be twice HTTP remote calls now, so look forward to reducing one.
So `reset_to_defaults()` change `cls.pricing_info = fetch_pricing_info()` to `cls.pricing_info = {}`.

Fixes https://github.com/openlit/openlit/issues/267

### Changes:
<!-- Describe the changes and additional notes about your changes -->
In the OpenlitConfig, `reset_to_defaults()` change `cls.pricing_info = fetch_pricing_info()` to `cls.pricing_info = {}`.

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
