### PR TITLE
[Feat]: Capture LLM Prompts and Responses in Trace Events

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.16.2"
+version = "1.17.0"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
@@ -130,7 +130,7 @@ def messages(gen_ai_endpoint, version, environment, application_name, tracer,
                         span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_K,
                                             kwargs.get("top_k", ""))
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            finish_reason)
+                                            [finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -140,10 +140,18 @@ def messages(gen_ai_endpoint, version, environment, application_name, tracer,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -234,7 +242,7 @@ def messages(gen_ai_endpoint, version, environment, application_name, tracer,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_K,
                                         kwargs.get("top_k", ""))
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response.stop_reason)
+                                        [response.stop_reason])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         response.usage.input_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -244,11 +252,21 @@ def messages(gen_ai_endpoint, version, environment, application_name, tracer,
                                         response.usage.output_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
+
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.content[0].text if response.content else "")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.content[0].text if response.content else "",
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
@@ -130,7 +130,7 @@ def async_messages(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_K,
                                             kwargs.get("top_k", ""))
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            finish_reason)
+                                            [finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -140,10 +140,18 @@ def async_messages(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -234,7 +242,7 @@ def async_messages(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_K,
                                         kwargs.get("top_k", ""))
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response.stop_reason)
+                                        [response.stop_reason])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         response.usage.input_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -245,10 +253,19 @@ def async_messages(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.content[0].text if response.content else "")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.content[0].text if response.content else "",
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -144,10 +144,18 @@ def converse(gen_ai_endpoint, version, environment, application_name, tracer,
                                 cost)
 
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                        response["output"]["message"]["content"][0]["text"])
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response["output"]["message"]["content"][0]["text"],
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -96,7 +96,6 @@ def converse(gen_ai_endpoint, version, environment, application_name, tracer,
 
                 try:
                     message_prompt = method_kwargs.get("messages", "")
-                    print(message_prompt)
                     formatted_messages = []
                     for message in message_prompt:
                         role = message["role"]
@@ -153,6 +152,7 @@ def converse(gen_ai_endpoint, version, environment, application_name, tracer,
                         span.add_event(
                             name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
                             attributes={
+                                # pylint: disable=line-too-long
                                 SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response["output"]["message"]["content"][0]["text"],
                             },
                         )

--- a/sdk/python/src/openlit/instrumentation/cohere/cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/cohere.py
@@ -89,8 +89,12 @@ def embed(gen_ai_endpoint, version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -205,7 +209,7 @@ def chat(gen_ai_endpoint, version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_ID,
                                     response.generation_id)
                 span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                    response.finish_reason)
+                                    [response.finish_reason])
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                     response.meta.billed_units.input_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -215,11 +219,20 @@ def chat(gen_ai_endpoint, version, environment, application_name, tracer,
                                     response.meta.billed_units.output_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
+                
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get("message", ""))
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                        response.text)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("message", ""),
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.text,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -348,7 +361,7 @@ def chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_ID,
                                         response_id)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        finish_reason)
+                                        [finish_reason])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         prompt_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -358,10 +371,18 @@ def chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("message", ""))
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("message", ""),
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/cohere/cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/cohere.py
@@ -219,7 +219,7 @@ def chat(gen_ai_endpoint, version, environment, application_name, tracer,
                                     response.meta.billed_units.output_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
-                
+
                 if trace_content:
                     span.add_event(
                         name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,

--- a/sdk/python/src/openlit/instrumentation/elevenlabs/async_elevenlabs.py
+++ b/sdk/python/src/openlit/instrumentation/elevenlabs/async_elevenlabs.py
@@ -80,8 +80,12 @@ def async_generate(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        str(kwargs.get("text", "")))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: str(kwargs.get("text", "")),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/elevenlabs/elevenlabs.py
+++ b/sdk/python/src/openlit/instrumentation/elevenlabs/elevenlabs.py
@@ -86,8 +86,12 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        str(kwargs.get("text", "")))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: str(kwargs.get("text", "")),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/gpt4all/gpt4all.py
+++ b/sdk/python/src/openlit/instrumentation/gpt4all/gpt4all.py
@@ -107,10 +107,18 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                             True)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         prompt_tokens)
@@ -195,10 +203,18 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            response)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response,
+                            },
+                        )
 
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         prompt_tokens)
@@ -313,8 +329,12 @@ def embed(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/groq/async_groq.py
+++ b/sdk/python/src/openlit/instrumentation/groq/async_groq.py
@@ -141,10 +141,18 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -237,8 +245,12 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
 
                     # Set span attributes when tools is not passed to the function call
                     if "tools" not in kwargs:
@@ -254,23 +266,31 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].message.content)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
                                 attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].message.content)
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].message.content,
+                                    },
+                                )
                                 i += 1
 
                             # Return original response

--- a/sdk/python/src/openlit/instrumentation/mistral/async_mistral.py
+++ b/sdk/python/src/openlit/instrumentation/mistral/async_mistral.py
@@ -103,7 +103,7 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                     False)
                 span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                    response.choices[0].finish_reason)
+                                    [response.choices[0].finish_reason])
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                     response.usage.prompt_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -113,10 +113,19 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.choices[0].message.content if response.choices[0].message.content else "")
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            # pylint: disable=line-too-long
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content if response.choices[0].message.content else "",
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -260,7 +269,7 @@ def async_chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         True)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        finish_reason)
+                                        [finish_reason])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         prompt_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -270,10 +279,18 @@ def async_chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -378,8 +395,12 @@ def async_embeddings(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/mistral/mistral.py
+++ b/sdk/python/src/openlit/instrumentation/mistral/mistral.py
@@ -102,7 +102,7 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                     False)
                 span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                    response.choices[0].finish_reason)
+                                    [response.choices[0].finish_reason])
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                     response.usage.prompt_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -112,10 +112,19 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.choices[0].message.content if response.choices[0].message.content else "")
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        # pylint: disable=line-too-long
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content if response.choices[0].message.content else "",
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -259,7 +268,7 @@ def chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         True)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        finish_reason)
+                                        [finish_reason])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                         prompt_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -269,10 +278,18 @@ def chat_stream(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -377,8 +394,12 @@ def embeddings(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
@@ -364,6 +364,7 @@ def async_generate(gen_ai_endpoint, version, environment, application_name,
                             span.add_event(
                                 name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
                                 attributes={
+                                    # pylint: disable=line-too-long
                                     SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
                                 },
                             )

--- a/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
@@ -120,10 +120,18 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -198,10 +206,18 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            response['message']['content'])
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response['message']['content'],
+                            },
+                        )
 
                     # Calculate cost of the operation
                     cost = 0
@@ -216,7 +232,7 @@ def async_chat(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                         total_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response["done_reason"])
+                                        [response["done_reason"]])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
 
@@ -345,10 +361,18 @@ def async_generate(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                kwargs.get("prompt", ""))
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -404,10 +428,18 @@ def async_generate(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            response['response'])
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response['response'],
+                            },
+                        )
 
                     # Calculate cost of the operation
                     cost = 0
@@ -422,7 +454,7 @@ def async_generate(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                         total_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response["done_reason"])
+                                        [response["done_reason"]])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
 
@@ -525,8 +557,12 @@ def async_embeddings(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get('prompt', ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/ollama/ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/ollama.py
@@ -120,10 +120,18 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -198,10 +206,18 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            response['message']['content'])
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response['message']['content'],
+                            },
+                        )
 
                     # Calculate cost of the operation
                     cost = 0
@@ -216,7 +232,7 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                         total_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response["done_reason"])
+                                        [response["done_reason"]])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
 
@@ -345,10 +361,18 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                kwargs.get("prompt", ""))
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -404,10 +428,18 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            response['response'])
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response['response'],
+                            },
+                        )
 
                     # Calculate cost of the operation
                     cost = 0
@@ -422,7 +454,7 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                         total_tokens)
                     span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                        response["done_reason"])
+                                        [response["done_reason"]])
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
 
@@ -525,8 +557,12 @@ def embeddings(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get('prompt', ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/ollama/ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/ollama.py
@@ -364,6 +364,7 @@ def generate(gen_ai_endpoint, version, environment, application_name,
                             span.add_event(
                                 name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
                                 attributes={
+                                    # pylint: disable=line-too-long
                                     SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
                                 },
                             )

--- a/sdk/python/src/openlit/instrumentation/openai/async_azure_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_azure_openai.py
@@ -856,7 +856,7 @@ def azure_async_image_generate(gen_ai_endpoint, version, environment, applicatio
                         )
                         attribute_name = f"gen_ai.response.image.{images_count}"
                         span.add_event(
-                            name=SemanticConvetion.attribute_name,
+                            name=attribute_name,
                             attributes={
                                 SemanticConvetion.GEN_AI_CONTENT_COMPLETION: getattr(items, image),
                             },

--- a/sdk/python/src/openlit/instrumentation/openai/async_azure_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_azure_openai.py
@@ -143,10 +143,18 @@ def azure_async_chat_completions(gen_ai_endpoint, version, environment, applicat
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -238,8 +246,12 @@ def azure_async_chat_completions(gen_ai_endpoint, version, environment, applicat
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
 
                     # Set span attributes when tools is not passed to the function call
                     if "tools" not in kwargs:
@@ -255,23 +267,31 @@ def azure_async_chat_completions(gen_ai_endpoint, version, environment, applicat
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].message.content)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
-                                attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].message.content)
+                                attribute_name = f"gen_ai.content.completion.{i}"
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].message.content,
+                                    },
+                                )
                                 i += 1
 
                             # Return original response
@@ -284,8 +304,12 @@ def azure_async_chat_completions(gen_ai_endpoint, version, environment, applicat
                                                     response.usage.prompt_tokens,
                                                     response.usage.completion_tokens)
 
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            "Function called with tools")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION:  "Function called with tools",
+                            },
+                        )
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             response.usage.prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -443,10 +467,18 @@ def azure_async_completions(gen_ai_endpoint, version, environment, application_n
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -519,8 +551,12 @@ def azure_async_completions(gen_ai_endpoint, version, environment, application_n
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
 
                     # Set span attributes when tools is not passed to the function call
                     if "tools" not in kwargs:
@@ -536,23 +572,31 @@ def azure_async_completions(gen_ai_endpoint, version, environment, application_n
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].text)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].text,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
-                                attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].text)
+                                attribute_name = f"gen_ai.content.completion.{i}"
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].text,
+                                    },
+                                )
                                 i += 1
                             return response
 
@@ -563,8 +607,12 @@ def azure_async_completions(gen_ai_endpoint, version, environment, application_n
                                                     response.usage.prompt_tokens,
                                                     response.usage.completion_tokens)
 
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            "Function called with tools")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: "Function called with tools",
+                            },
+                        )
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             response.usage.prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -679,8 +727,12 @@ def azure_async_embedding(gen_ai_endpoint, version, environment, application_nam
                                     response.usage.total_tokens)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST, cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get("input", ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("input", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -796,12 +848,19 @@ def azure_async_image_generate(gen_ai_endpoint, version, environment, applicatio
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_USER,
                                         kwargs.get("user", ""))
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
-
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
                         attribute_name = f"gen_ai.response.image.{images_count}"
-                        span.set_attribute(attribute_name,
-                                            getattr(items, image))
+                        span.add_event(
+                            name=SemanticConvetion.attribute_name,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: getattr(items, image),
+                            },
+                        )
 
                     images_count+=1
 

--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -144,10 +144,18 @@ def async_chat_completions(gen_ai_endpoint, version, environment, application_na
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -240,8 +248,12 @@ def async_chat_completions(gen_ai_endpoint, version, environment, application_na
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -259,23 +271,31 @@ def async_chat_completions(gen_ai_endpoint, version, environment, application_na
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].message.content)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
-                                attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].message.content)
+                                attribute_name = f"gen_ai.content.completion.{i}"
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].message.content,
+                                    },
+                                )
                                 i += 1
 
                             # Return original response
@@ -288,8 +308,12 @@ def async_chat_completions(gen_ai_endpoint, version, environment, application_na
                                                     pricing_info, response.usage.prompt_tokens,
                                                     response.usage.completion_tokens)
 
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            "Function called with tools")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: "Function called with tools",
+                            },
+                        )
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             response.usage.prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -405,8 +429,12 @@ def async_embedding(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get("input", ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("input", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -611,12 +639,19 @@ def async_image_generate(gen_ai_endpoint, version, environment, application_name
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_USER,
                                         kwargs.get("user", ""))
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
-
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
                         attribute_name = f"gen_ai.response.image.{images_count}"
-                        span.set_attribute(attribute_name,
-                                            getattr(items, image))
+                        span.add_event(
+                            name=attribute_name,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: getattr(items, image),
+                            },
+                        )
 
                     images_count+=1
 
@@ -729,11 +764,13 @@ def async_image_variatons(gen_ai_endpoint, version, environment, application_nam
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IMAGE_QUALITY,
                                         "standard")
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get(SemanticConvetion.GEN_AI_TYPE_IMAGE, ""))
-
                         attribute_name = f"gen_ai.response.image.{images_count}"
-                        span.set_attribute(attribute_name, getattr(items, image))
+                        span.add_event(
+                            name=attribute_name,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: getattr(items, image),
+                            },
+                        )
 
                     images_count+=1
 
@@ -838,8 +875,12 @@ def async_audio_create(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get("input", ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("input", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/openai/azure_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/azure_openai.py
@@ -143,10 +143,18 @@ def azure_chat_completions(gen_ai_endpoint, version, environment, application_na
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -238,6 +246,13 @@ def azure_chat_completions(gen_ai_endpoint, version, environment, application_na
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                    if trace_content:
                         span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
                                             prompt)
 
@@ -255,23 +270,31 @@ def azure_chat_completions(gen_ai_endpoint, version, environment, application_na
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].message.content)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].message.content,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
-                                attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].message.content)
+                                attribute_name = f"gen_ai.content.completion.{i}"
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].message.content,
+                                    },
+                                )
                                 i += 1
 
                             # Return original response
@@ -284,8 +307,12 @@ def azure_chat_completions(gen_ai_endpoint, version, environment, application_na
                                                     response.usage.prompt_tokens,
                                                     response.usage.completion_tokens)
 
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            "Function called with tools")
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: "Function called with tools",
+                            },
+                        )
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
                                             response.usage.prompt_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
@@ -441,10 +468,18 @@ def azure_completions(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -517,8 +552,12 @@ def azure_completions(gen_ai_endpoint, version, environment, application_name,
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
 
                     # Set span attributes when tools is not passed to the function call
                     if "tools" not in kwargs:
@@ -534,23 +573,31 @@ def azure_completions(gen_ai_endpoint, version, environment, application_name,
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_TOTAL_TOKENS,
                                             response.usage.total_tokens)
                         span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                            response.choices[0].finish_reason)
+                                            [response.choices[0].finish_reason])
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
 
                         # Set span attributes for when n = 1 (default)
                         if "n" not in kwargs or kwargs["n"] == 1:
                             if trace_content:
-                                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                    response.choices[0].text)
+                                span.add_event(
+                                    name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[0].text,
+                                    },
+                                )
 
                         # Set span attributes for when n > 0
                         else:
                             i = 0
                             while i < kwargs["n"] and trace_content is True:
-                                attribute_name = f"gen_ai.completion.{i}"
-                                span.set_attribute(attribute_name,
-                                                    response.choices[i].text)
+                                attribute_name = f"gen_ai.content.completion.{i}"
+                                span.add_event(
+                                    name=attribute_name,
+                                    attributes={
+                                        SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.choices[i].text,
+                                    },
+                                )
                                 i += 1
                             return response
 
@@ -678,8 +725,12 @@ def azure_embedding(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        kwargs.get("input", ""))
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("input", ""),
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -795,12 +846,19 @@ def azure_image_generate(gen_ai_endpoint, version, environment, application_name
                     span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_USER,
                                         kwargs.get("user", ""))
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            kwargs.get("prompt", ""))
-
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: kwargs.get("prompt", ""),
+                            },
+                        )
                         attribute_name = f"gen_ai.response.image.{images_count}"
-                        span.set_attribute(attribute_name,
-                                            getattr(items, image))
+                        span.add_event(
+                            name=attribute_name,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: getattr(items, image),
+                            },
+                        )
 
                     images_count+=1
 

--- a/sdk/python/src/openlit/instrumentation/transformers/transformers.py
+++ b/sdk/python/src/openlit/instrumentation/transformers/transformers.py
@@ -109,11 +109,12 @@ def text_wrap(gen_ai_endpoint, version, environment, application_name,
                         span.add_event(
                             name=attribute_name,
                             attributes={
+                                # pylint: disable=line-too-long
                                 SemanticConvetion.GEN_AI_CONTENT_COMPLETION: completion["generated_text"],
                             },
                         )
                     completion_tokens += general_tokens(completion["generated_text"])
- 
+
                     i=i+1
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
                                    completion_tokens)

--- a/sdk/python/src/openlit/instrumentation/transformers/transformers.py
+++ b/sdk/python/src/openlit/instrumentation/transformers/transformers.py
@@ -88,29 +88,32 @@ def text_wrap(gen_ai_endpoint, version, environment, application_name,
                                    forward_params.get("top_p", "null"))
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_MAX_TOKENS,
                                    forward_params.get("max_length", -1))
-                span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                   prompt)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
-                                    prompt_tokens)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
+                                prompt_tokens)
 
                 i = 0
                 completion_tokens = 0
                 for completion in response:
                     if len(response) > 1:
-                        attribute_name = f"gen_ai.completion.{i}"
+                        attribute_name = f"gen_ai.content.completion.{i}"
                     else:
-                        attribute_name = SemanticConvetion.GEN_AI_CONTENT_COMPLETION
-                    if i == 0:
-                        if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            completion["generated_text"])
-                        completion_tokens += general_tokens(completion["generated_text"])
-                    else:
-                        if trace_content:
-                            span.set_attribute(attribute_name,
-                                            completion["generated_text"])
-                        completion_tokens += general_tokens(completion["generated_text"])
+                        attribute_name = SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT
+                    if trace_content:
+                        span.add_event(
+                            name=attribute_name,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: completion["generated_text"],
+                            },
+                        )
+                    completion_tokens += general_tokens(completion["generated_text"])
+ 
                     i=i+1
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COMPLETION_TOKENS,
                                    completion_tokens)

--- a/sdk/python/src/openlit/instrumentation/vertexai/async_vertexai.py
+++ b/sdk/python/src/openlit/instrumentation/vertexai/async_vertexai.py
@@ -103,10 +103,18 @@ def generate_content_async(gen_ai_endpoint, version, environment, application_na
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -181,10 +189,19 @@ def generate_content_async(gen_ai_endpoint, version, environment, application_na
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                           prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.candidates[0].content.parts[0].text)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.candidates[0].content.parts[0].text,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -316,10 +333,18 @@ def send_message_async(gen_ai_endpoint, version, environment, application_name, 
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -394,11 +419,18 @@ def send_message_async(gen_ai_endpoint, version, environment, application_name, 
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                           prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                           response.candidates[0].content.parts[0].text)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.candidates[0].content.parts[0].text,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -516,10 +548,18 @@ def predict_async(gen_ai_endpoint, version, environment, application_name, trace
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.text)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.text,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -648,10 +688,18 @@ def predict_streaming_async(gen_ai_endpoint, version, environment, application_n
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -765,10 +813,18 @@ def start_chat_async(gen_ai_endpoint, version, environment, application_name, tr
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.text)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.text,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -895,10 +951,18 @@ def start_chat_streaming_async(gen_ai_endpoint, version, environment, applicatio
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -1006,8 +1070,12 @@ def embeddings_async(gen_ai_endpoint, version, environment, application_name, tr
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/vertexai/async_vertexai.py
+++ b/sdk/python/src/openlit/instrumentation/vertexai/async_vertexai.py
@@ -428,6 +428,7 @@ def send_message_async(gen_ai_endpoint, version, environment, application_name, 
                         span.add_event(
                             name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
                             attributes={
+                                # pylint: disable=line-too-long
                                 SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.candidates[0].content.parts[0].text,
                             },
                         )

--- a/sdk/python/src/openlit/instrumentation/vertexai/vertexai.py
+++ b/sdk/python/src/openlit/instrumentation/vertexai/vertexai.py
@@ -103,10 +103,18 @@ def generate_content(gen_ai_endpoint, version, environment, application_name, tr
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -181,10 +189,19 @@ def generate_content(gen_ai_endpoint, version, environment, application_name, tr
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                           prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.candidates[0].content.parts[0].text)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.candidates[0].content.parts[0].text,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -316,10 +333,18 @@ def send_message(gen_ai_endpoint, version, environment, application_name, tracer
                         span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                             cost)
                         if trace_content:
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                                prompt)
-                            span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                                llmresponse)
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                                },
+                            )
+                            span.add_event(
+                                name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                                attributes={
+                                    SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                                },
+                            )
 
                         span.set_status(Status(StatusCode.OK))
 
@@ -394,11 +419,19 @@ def send_message(gen_ai_endpoint, version, environment, application_name, tracer
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                           prompt)
-                        # pylint: disable=line-too-long
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                           response.candidates[0].content.parts[0].text)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.candidates[0].content.parts[0].text,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -516,10 +549,18 @@ def predict(gen_ai_endpoint, version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.text)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.text,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -648,10 +689,18 @@ def predict_streaming(gen_ai_endpoint, version, environment, application_name, t
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -765,10 +814,18 @@ def start_chat(gen_ai_endpoint, version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
-                    # pylint: disable=line-too-long
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION, response.text)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_COMPLETION: response.text,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 
@@ -895,10 +952,18 @@ def start_chat_streaming(gen_ai_endpoint, version, environment, application_name
                     span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                         cost)
                     if trace_content:
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                            prompt)
-                        span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_COMPLETION,
-                                            llmresponse)
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                            },
+                        )
+                        span.add_event(
+                            name=SemanticConvetion.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                SemanticConvetion.GEN_AI_CONTENT_COMPLETION: llmresponse,
+                            },
+                        )
 
                     span.set_status(Status(StatusCode.OK))
 
@@ -1006,8 +1071,12 @@ def embeddings(gen_ai_endpoint, version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_COST,
                                     cost)
                 if trace_content:
-                    span.set_attribute(SemanticConvetion.GEN_AI_CONTENT_PROMPT,
-                                        prompt)
+                    span.add_event(
+                        name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
+                        },
+                    )
 
                 span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -70,7 +70,9 @@ class SemanticConvetion:
     GEN_AI_RESPONSE_IMAGE = "gen_ai.response.image"  # Not used directly in code yet
 
     # GenAI Content
+    GEN_AI_CONTENT_PROMPT_EVENT = "gen_ai.content.prompt"
     GEN_AI_CONTENT_PROMPT = "gen_ai.prompt"
+    GEN_AI_CONTENT_COMPLETION_EVENT = "gen_ai.content.completion"
     GEN_AI_CONTENT_COMPLETION = "gen_ai.completion"
     GEN_AI_CONTENT_REVISED_PROMPT = "gen_ai.content.revised_prompt"
 
@@ -94,7 +96,7 @@ class SemanticConvetion:
     GEN_AI_SYSTEM_COHERE = "cohere"
     GEN_AI_SYSTEM_MISTRAL = "mistral"
     GEN_AI_SYSTEM_BEDROCK = "bedrock"
-    GEN_AI_SYSTEM_VERTEXAI = "vertexai"
+    GEN_AI_SYSTEM_VERTEXAI = "vertex_ai"
     GEN_AI_SYSTEM_GROQ = "groq"
     GEN_AI_SYSTEM_OLLAMA = "ollama"
     GEN_AI_SYSTEM_GPT4ALL = "gpt4all"

--- a/src/client/src/constants/traces.ts
+++ b/src/client/src/constants/traces.ts
@@ -264,8 +264,8 @@ export const TraceMapping: Record<
 	prompt: {
 		label: "Prompt",
 		type: "string",
-		path: ["events[0].attributes", "gen.ai.prompt"],
-		prefix: SpanAttributesGenAIPrefix,
+		path: ["events", "0", "attributes", "gen.ai.prompt"],
+		isRoot: true,
 	},
 	finishReason: {
 		label: "Finish Reason",
@@ -276,8 +276,8 @@ export const TraceMapping: Record<
 	response: {
 		label: "Response",
 		type: "string",
-		path: ["events[1].attributes", "gen.ai.completion"],
-		prefix: SpanAttributesGenAIPrefix,
+		path: ["events", "1", "attributes", "gen.ai.completion"],
+		isRoot: true,
 	},
 	randomSeed: {
 		label: "Random seed",

--- a/src/client/src/constants/traces.ts
+++ b/src/client/src/constants/traces.ts
@@ -264,7 +264,7 @@ export const TraceMapping: Record<
 	prompt: {
 		label: "Prompt",
 		type: "string",
-		path: "prompt",
+		path: ["events[0].attributes", "gen.ai.prompt"],
 		prefix: SpanAttributesGenAIPrefix,
 	},
 	finishReason: {
@@ -276,7 +276,7 @@ export const TraceMapping: Record<
 	response: {
 		label: "Response",
 		type: "string",
-		path: "completion",
+		path: ["events[1].attributes", "gen.ai.completion"],
 		prefix: SpanAttributesGenAIPrefix,
 	},
 	randomSeed: {

--- a/src/client/src/constants/traces.ts
+++ b/src/client/src/constants/traces.ts
@@ -264,7 +264,7 @@ export const TraceMapping: Record<
 	prompt: {
 		label: "Prompt",
 		type: "string",
-		path: ["events", "0", "attributes", "gen.ai.prompt"],
+		path: ["Events.Attributes", "0", "gen_ai.prompt"],
 		isRoot: true,
 	},
 	finishReason: {
@@ -276,7 +276,7 @@ export const TraceMapping: Record<
 	response: {
 		label: "Response",
 		type: "string",
-		path: ["events", "1", "attributes", "gen.ai.completion"],
+		path: ["Events.Attributes", "1", "gen_ai.completion"],
 		isRoot: true,
 	},
 	randomSeed: {


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
This PR places LLM Prompts and Responses in Trace Events rather than the Span Attributes to better align with the OTel GenAI Semantic conventions.

Related https://github.com/openlit/openlit/issues/342#issuecomment-2262063994

### Changes:
<!-- Describe the changes and additional notes about your changes -->
 - Prompt is now captured under event name `gen_ai.content.prompt` with Event attribute name as `gen_ai.prompt`
 - Completions is now captured under event name `gen_ai.content.completion` with Event attribute name as `gen_ai.completion`
 - Make `gen_ai.response.finish_reasons` as `string[]`	
 
 ```
 "events": [
        {
            "name": "gen_ai.content.prompt",
            "timestamp": "2024-08-01T07:09:15.763840Z",
            "attributes": {
                "gen_ai.prompt": "user: text: How are you?\n"
            }
        },
        {
            "name": "gen_ai.content.completion",
            "timestamp": "2024-08-01T07:09:15.763877Z",
            "attributes": {
                "gen_ai.completion": "I am Amazon Titan, a large language model built by AWS. It is designed to assist you with tasks and answer any questions you may have. How may I help you?"
            }
        }
    ],
```    
 
### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->
NA

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
