### PR TITLE
fix: updated request time to timezone specific

### DIFF
--- a/src/client/src/components/(playground)/request/request-details.tsx
+++ b/src/client/src/components/(playground)/request/request-details.tsx
@@ -61,6 +61,8 @@ export default function RequestDetails() {
 		isException
 	);
 
+	const date = new Date(`${normalizedItem.time}Z`);
+
 	return (
 		<Sheet open onOpenChange={onClose}>
 			<SheetContent className="max-w-none sm:max-w-none w-1/2 bg-stone-200 dark:bg-stone-200">
@@ -94,7 +96,7 @@ export default function RequestDetails() {
 								<TagItem
 									icon={CalendarDays}
 									title="Request Time : "
-									value={format(normalizedItem.time, "MMM do, y  HH:mm:ss a")}
+									value={format(date, "MMM do, y  HH:mm:ss a")}
 								/>
 								<TagItem
 									icon={Clock}

--- a/src/client/src/components/(playground)/request/trace.tsx
+++ b/src/client/src/components/(playground)/request/trace.tsx
@@ -67,7 +67,7 @@ export default function Trace({ item, isLoading }: RenderRowProps) {
 		? getDisplayKeysForException()
 		: getRequestTableDisplayKeys(normalizedItem.type);
 
-	console.log(normalizedItem, item);
+	const date = new Date(`${normalizedItem.time}Z`);
 
 	return (
 		<div className="flex flex-col">
@@ -76,7 +76,7 @@ export default function Trace({ item, isLoading }: RenderRowProps) {
 					<div className="flex items-center pr-3">
 						<CalendarDays size="16" />
 						<p className="text-xs leading-none ml-2">
-							{format(normalizedItem.time, "MMM do, y  HH:mm:ss a")}
+							{format(date, "MMM do, y  HH:mm:ss a")}
 						</p>
 					</div>
 					<div className="flex items-center pl-3 border-l border-stone-200">


### PR DESCRIPTION
### Overview:
Now on the UI for request details & request trace, the time would be visible in timezone specific instead of UTC.

FIxes #373 

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [ ] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the display of request times in the UI to show timezone-specific times instead of UTC in the request details and trace components.

Bug Fixes:
- Update request time display to be timezone-specific instead of UTC in the request details and trace components.

<!-- Generated by sourcery-ai[bot]: end summary -->