### PR TITLE
[Bug]: Add correct defaults when token values are not found

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.22.1"
+version = "1.22.2"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/langchain/langchain.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/langchain.py
@@ -481,8 +481,8 @@ def chat(gen_ai_endpoint, version, environment, application_name,
             response = wrapped(*args, **kwargs)
 
             try:
-                input_tokens = response.response_metadata["prompt_eval_count"] or 0
-                output_tokens = response.response_metadata["eval_count"] or 0
+                input_tokens = response.response_metadata.get("prompt_eval_count", 0)
+                output_tokens = response.response_metadata.get("eval_count", 0)
 
                 # Calculate cost of the operation
                 cost = get_chat_model_cost(


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
Fixed Token value extraction in LangChain

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->
NA

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix token value extraction in LangChain by providing default values when token counts are missing in the response metadata.

Bug Fixes:
- Ensure default values are used for token counts when they are not found in the response metadata.

<!-- Generated by sourcery-ai[bot]: end summary -->