### PR TITLE
[Fix]: Failed to instrument azure-ai-inference: No module named 'azure' error when it should be skipped

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Check if version was updated in pyproject.toml
       run: |
         sudo apt-get install -y python3-tomli
-        current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml'))['tool.poetry']['version'])")
-        main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin)['tool.poetry']['version'])")
+        current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml', 'rb'))['tool.poetry']['version'])")
+        main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin.buffer)['tool.poetry']['version'])")
         echo "Current branch version: $current_version"
         echo "Main branch version: $main_version"
         

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,20 +16,20 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: Check if version was updated in pyproject.toml
-      run: |
-        sudo apt-get install -y python3-tomli
-        current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml', 'rb'))['tool.poetry']['version'])")
-        main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin.buffer)['tool.poetry']['version'])")
-        echo "Current branch version: $current_version"
-        echo "Main branch version: $main_version"
+    # - name: Check if version was updated in pyproject.toml
+    #   run: |
+    #     sudo apt-get install -y python3-tomli
+    #     current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml', 'rb'))['tool.poetry']['version'])")
+    #     main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin.buffer)['tool.poetry']['version'])")
+    #     echo "Current branch version: $current_version"
+    #     echo "Main branch version: $main_version"
         
-        if [ "$current_version" = "$main_version" ]; then
-          echo "Version in pyproject.toml was not updated. Please update the version." >&2
-          exit 1
-        else
-          echo "Version in pyproject.toml was updated."
-        fi
+    #     if [ "$current_version" = "$main_version" ]; then
+    #       echo "Version in pyproject.toml was not updated. Please update the version." >&2
+    #       exit 1
+    #     else
+    #       echo "Version in pyproject.toml was updated."
+    #     fi
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,20 +16,20 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
-    # - name: Check if version was updated in pyproject.toml
-    #   run: |
-    #     sudo apt-get install -y python3-tomli
-    #     current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml', 'rb'))['tool.poetry']['version'])")
-    #     main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin.buffer)['tool.poetry']['version'])")
-    #     echo "Current branch version: $current_version"
-    #     echo "Main branch version: $main_version"
+    - name: Check if version was updated in pyproject.toml
+      run: |
+        sudo apt-get install -y python3-tomli
+        current_version=$(python3 -c "import tomli; print(tomli.load(open('sdk/python/pyproject.toml', 'rb'))['tool.poetry']['version'])")
+        main_version=$(git show origin/main:sdk/python/pyproject.toml | python3 -c "import tomli; import sys; print(tomli.load(sys.stdin.buffer)['tool.poetry']['version'])")
+        echo "Current branch version: $current_version"
+        echo "Main branch version: $main_version"
         
-    #     if [ "$current_version" = "$main_version" ]; then
-    #       echo "Version in pyproject.toml was not updated. Please update the version." >&2
-    #       exit 1
-    #     else
-    #       echo "Version in pyproject.toml was updated."
-    #     fi
+        if [ "$current_version" = "$main_version" ]; then
+          echo "Version in pyproject.toml was not updated. Please update the version." >&2
+          exit 1
+        else
+          echo "Version in pyproject.toml was updated."
+        fi
 
   lint:
     runs-on: ubuntu-latest

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.22.2"
+version = "1.22.3"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -130,6 +130,13 @@ class OpenlitConfig:
         cls.trace_content = trace_content
         cls.disable_metrics = disable_metrics
 
+def module_exists(module_name):
+    """Check if nested modules exist, addressing the dot notation issue."""
+    parts = module_name.split(".")
+    for i in range(1, len(parts) + 1):
+        if find_spec(".".join(parts[:i])) is None:
+            return False
+    return True
 
 def instrument_if_available(
     instrumentor_name,
@@ -150,7 +157,7 @@ def instrument_if_available(
         return
 
     try:
-        if find_spec(module_name) is not None:
+        if module_exists(module_name):
             instrumentor_instance.instrument(
                 environment=config.environment,
                 application_name=config.application_name,
@@ -166,6 +173,7 @@ def instrument_if_available(
             logger.info("Library for %s (%s) not found. Skipping instrumentation", instrumentor_name, module_name)
     except Exception as e:
         logger.error("Failed to instrument %s: %s", instrumentor_name, e)
+
 
 def init(environment="default", application_name="default", tracer=None, otlp_endpoint=None,
          otlp_headers=None, disable_batch=False, trace_content=True, disabled_instrumentors=None,


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
Fix the error that shows Azure was not instrumented even though the SDK is not installed

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->
NA

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the instrumentation error for the Azure AI inference module by implementing a utility function to check for nested module existence, ensuring proper handling when the SDK is not installed.

Bug Fixes:
- Fix the error where the Azure AI inference module was not instrumented due to a missing module error, even when the SDK was not installed.

Enhancements:
- Introduce a utility function `module_exists` to check for the existence of nested modules, addressing issues with dot notation.

<!-- Generated by sourcery-ai[bot]: end summary -->