### PR TITLE
[Fix]: Langchain defaults for Chat generation in achat function

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.24.0"
+version = "1.24.1"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/langchain/langchain.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/langchain.py
@@ -622,7 +622,7 @@ def achat(gen_ai_endpoint, version, environment, application_name,
             try:
                 input_tokens = response.response_metadata.get("prompt_eval_count", 0)
                 output_tokens = response.response_metadata.get("eval_count", 0)
-                
+
                 prompt = "" if isinstance(args[0], list) else args[0]
                 model = getattr(instance, 'model_name', getattr(instance, 'model', 'gpt-4'))
                 # Calculate cost of the operation
@@ -650,7 +650,6 @@ def achat(gen_ai_endpoint, version, environment, application_name,
                                     str(getattr(instance, 'top_k',1)))
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_P,
                                     str(getattr(instance, 'top_p',1)))
-                
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                     False)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,

--- a/sdk/python/src/openlit/instrumentation/langchain/langchain.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/langchain.py
@@ -622,10 +622,12 @@ def achat(gen_ai_endpoint, version, environment, application_name,
             try:
                 input_tokens = response.response_metadata.get("prompt_eval_count", 0)
                 output_tokens = response.response_metadata.get("eval_count", 0)
-
+                
+                prompt = "" if isinstance(args[0], list) else args[0]
+                model = getattr(instance, 'model_name', getattr(instance, 'model', 'gpt-4'))
                 # Calculate cost of the operation
                 cost = get_chat_model_cost(
-                    str(getattr(instance, 'model')),
+                    model,
                     pricing_info, input_tokens, output_tokens
                 )
 
@@ -641,15 +643,14 @@ def achat(gen_ai_endpoint, version, environment, application_name,
                 span.set_attribute(SemanticConvetion.GEN_AI_APPLICATION_NAME,
                                     application_name)
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_MODEL,
-                                    str(getattr(instance, 'model')))
+                                    model)
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TEMPERATURE,
-                                    str(getattr(instance, 'temperature')))
+                                    str(getattr(instance, 'temperature',1)))
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_K,
-                                    str(getattr(instance, 'top_k')))
+                                    str(getattr(instance, 'top_k',1)))
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_TOP_P,
-                                    str(getattr(instance, 'top_p')))
-                span.set_attribute(SemanticConvetion.GEN_AI_RESPONSE_FINISH_REASON,
-                                    [response.response_metadata["done_reason"]])
+                                    str(getattr(instance, 'top_p',1)))
+                
                 span.set_attribute(SemanticConvetion.GEN_AI_REQUEST_IS_STREAM,
                                     False)
                 span.set_attribute(SemanticConvetion.GEN_AI_USAGE_PROMPT_TOKENS,
@@ -664,7 +665,7 @@ def achat(gen_ai_endpoint, version, environment, application_name,
                     span.add_event(
                         name=SemanticConvetion.GEN_AI_CONTENT_PROMPT_EVENT,
                         attributes={
-                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: args[0],
+                            SemanticConvetion.GEN_AI_CONTENT_PROMPT: prompt,
                         },
                     )
                     span.add_event(
@@ -689,7 +690,7 @@ def achat(gen_ai_endpoint, version, environment, application_name,
                         SemanticConvetion.GEN_AI_TYPE:
                             SemanticConvetion.GEN_AI_TYPE_CHAT,
                         SemanticConvetion.GEN_AI_REQUEST_MODEL:
-                            str(getattr(instance, 'model'))
+                            model
                     }
 
                     metrics["genai_requests"].add(1, attributes)


### PR DESCRIPTION
### Overview:
Fixed Langchain defaults for Chat generation in achat function.
Fix added to resolve the attribute error "ChatOpenAI' object has no attribute 'model" in langchain.py. A fix was previously provided for this issue as part of PR (https://github.com/openlit/openlit/pull/426). But this fix was only added in the chat function. I have replicated the same fix to the achat function.

### Visuals (if applicable):
NA

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix the attribute error in the achat function by replicating the previous fix from the chat function, ensuring the correct model attribute is used and providing default values for model parameters.

Bug Fixes:
- Fix the attribute error in the achat function by ensuring the correct model attribute is used, defaulting to 'gpt-4' if not specified.