### PR TITLE
[Fix]: Fix extraction of GPU name and UUID in OTel instrumentation

### DIFF
--- a/otel-gpu-collector/dockerfile
+++ b/otel-gpu-collector/dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . .
 
 # Install necessary Python packages
-RUN pip install --no-cache-dir --no-binary :psutil: psutil openlit nvidia-ml-py amdsmi
+RUN pip install --no-cache-dir --no-binary :psutil: psutil==6.1.0 nvidia-ml-py==12.560.30 amdsmi==6.2.4 openlit
 
 # Expose any required ports, if necessary
 EXPOSE 80

--- a/otel-gpu-collector/dockerfile
+++ b/otel-gpu-collector/dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . .
 
 # Install necessary Python packages
-RUN pip install --no-cache-dir --no-binary :psutil: psutil openlit
+RUN pip install --no-cache-dir --no-binary :psutil: psutil openlit nvidia-ml-py amdsmi
 
 # Expose any required ports, if necessary
 EXPOSE 80

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.28.0"
+version = "1.29.0"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/gpu/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/gpu/__init__.py
@@ -142,8 +142,8 @@ class GPUInstrumentor(BaseInstrumentor):
                     SemanticConvetion.GEN_AI_APPLICATION_NAME: application_name,
                     SemanticConvetion.GEN_AI_ENVIRONMENT: environment,
                     SemanticConvetion.GPU_INDEX: str(gpu_index),
-                    SemanticConvetion.GPU_UUID: safe_decode(pynvml.nvmlDeviceGetUUID(handle).decode('utf-8')),
-                    SemanticConvetion.GPU_NAME: safe_decode(pynvml.nvmlDeviceGetName(handle).decode('utf-8'))
+                    SemanticConvetion.GPU_UUID: safe_decode(pynvml.nvmlDeviceGetUUID(handle)),
+                    SemanticConvetion.GPU_NAME: safe_decode(pynvml.nvmlDeviceGetName(handle))
                 }
                 yield Observation(get_metric_value(handle, metric_name), attributes)
 

--- a/sdk/python/src/openlit/instrumentation/gpu/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/gpu/__init__.py
@@ -131,14 +131,19 @@ class GPUInstrumentor(BaseInstrumentor):
                         logger.error("Error collecting metric %s for GPU %d: %s", metric_name,
                                                                                   gpu_index, e)
                     return 0
+                
+                def safe_decode(byte_string):
+                    if isinstance(byte_string, bytes):
+                        return byte_string.decode('utf-8')
+                    return byte_string
 
                 attributes = {
                     TELEMETRY_SDK_NAME: "openlit",
                     SemanticConvetion.GEN_AI_APPLICATION_NAME: application_name,
                     SemanticConvetion.GEN_AI_ENVIRONMENT: environment,
                     SemanticConvetion.GPU_INDEX: str(gpu_index),
-                    SemanticConvetion.GPU_UUID: pynvml.nvmlDeviceGetUUID(handle).decode('utf-8'),
-                    SemanticConvetion.GPU_NAME: pynvml.nvmlDeviceGetName(handle).decode('utf-8')
+                    SemanticConvetion.GPU_UUID: safe_decode(pynvml.nvmlDeviceGetUUID(handle).decode('utf-8')),
+                    SemanticConvetion.GPU_NAME: safe_decode(pynvml.nvmlDeviceGetName(handle).decode('utf-8'))
                 }
                 yield Observation(get_metric_value(handle, metric_name), attributes)
 

--- a/sdk/python/src/openlit/instrumentation/gpu/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/gpu/__init__.py
@@ -131,7 +131,7 @@ class GPUInstrumentor(BaseInstrumentor):
                         logger.error("Error collecting metric %s for GPU %d: %s", metric_name,
                                                                                   gpu_index, e)
                     return 0
-                
+
                 def safe_decode(byte_string):
                     if isinstance(byte_string, bytes):
                         return byte_string.decode('utf-8')


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix the extraction of GPU name and UUID in the OpenTelemetry instrumentation by implementing a safe decoding function. Update the Dockerfile to include additional Python packages required for GPU monitoring. Bump the version of the 'openlit' package to 1.29.0.

Bug Fixes:
- Fix the extraction of GPU name and UUID by introducing a safe decoding function to handle byte strings.

Build:
- Add 'nvidia-ml-py' and 'amdsmi' packages to the Dockerfile to ensure necessary dependencies are installed.