### PR TITLE
[Fix] GenAI system name in litellm and crewai OpenTelemetry instrumentations

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -17,8 +17,8 @@
     }
   },
   "topbarCtaButton": {
-    "name": "Website",
-    "url": "https://openlit.io/"
+    "type": "github",
+    "url": "https://github.com/openlit/openlit"
   },
   "modeToggle": {
     "default": "light"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.30.0"
+version = "1.30.1"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/crewai/crewai.py
+++ b/sdk/python/src/openlit/instrumentation/crewai/crewai.py
@@ -36,9 +36,9 @@ def crew_wrap(gen_ai_endpoint, version, environment, application_name,
         gen_ai_endpoint: Endpoint identifier for logging and tracing.
         version: Version of the monitoring package.
         environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the OpenAI API.
+        application_name: Name of the application using the CrewAI Agent.
         tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of OpenAI usage.
+        pricing_info: Information used for calculating the cost of CrewAI usage.
         trace_content: Flag indicating whether to trace the actual content.
 
     Returns:
@@ -70,9 +70,9 @@ def crew_wrap(gen_ai_endpoint, version, environment, application_name,
                 # Set base span attribues
                 span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
                 span.set_attribute(SemanticConvetion.GEN_AI_SYSTEM,
-                                    SemanticConvetion.GEN_AI_SYSTEM_OPENAI)
+                                    SemanticConvetion.GEN_AI_SYSTEM_CREWAI)
                 span.set_attribute(SemanticConvetion.GEN_AI_TYPE,
-                                    SemanticConvetion.GEN_AI_TYPE_CHAT)
+                                    SemanticConvetion.GEN_AI_TYPE_AGENT)
                 span.set_attribute(SemanticConvetion.GEN_AI_ENDPOINT,
                                     gen_ai_endpoint)
 

--- a/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
@@ -26,9 +26,9 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
         gen_ai_endpoint: Endpoint identifier for logging and tracing.
         version: Version of the monitoring package.
         environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the OpenAI API.
+        application_name: Name of the application using the LiteLLM SDK.
         tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of OpenAI usage.
+        pricing_info: Information used for calculating the cost of LiteLLM usage.
         trace_content: Flag indicating whether to trace the actual content.
 
     Returns:
@@ -38,7 +38,6 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
     class TracedAsyncStream:
         """
         Wrapper for streaming responses to collect metrics and trace data.
-        Wraps the 'openai.AsyncStream' response to collect message IDs and aggregated response.
 
         This class implements the '__aiter__' and '__anext__' methods that
         handle asynchronous streaming responses.
@@ -125,7 +124,7 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
                     # Set Span attributes
                     self._span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
                     self._span.set_attribute(SemanticConvetion.GEN_AI_SYSTEM,
-                                        SemanticConvetion.GEN_AI_SYSTEM_OPENAI)
+                                        SemanticConvetion.GEN_AI_SYSTEM_LITELLM)
                     self._span.set_attribute(SemanticConvetion.GEN_AI_TYPE,
                                         SemanticConvetion.GEN_AI_TYPE_CHAT)
                     self._span.set_attribute(SemanticConvetion.GEN_AI_ENDPOINT,
@@ -185,7 +184,7 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
                             SemanticConvetion.GEN_AI_APPLICATION_NAME:
                                 application_name,
                             SemanticConvetion.GEN_AI_SYSTEM:
-                                SemanticConvetion.GEN_AI_SYSTEM_OPENAI,
+                                SemanticConvetion.GEN_AI_SYSTEM_LITELLM,
                             SemanticConvetion.GEN_AI_ENVIRONMENT:
                                 environment,
                             SemanticConvetion.GEN_AI_TYPE:
@@ -268,7 +267,7 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
                     # Set base span attribues
                     span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
                     span.set_attribute(SemanticConvetion.GEN_AI_SYSTEM,
-                                        SemanticConvetion.GEN_AI_SYSTEM_OPENAI)
+                                        SemanticConvetion.GEN_AI_SYSTEM_LITELLM)
                     span.set_attribute(SemanticConvetion.GEN_AI_TYPE,
                                         SemanticConvetion.GEN_AI_TYPE_CHAT)
                     span.set_attribute(SemanticConvetion.GEN_AI_ENDPOINT,
@@ -379,7 +378,7 @@ def acompletion(gen_ai_endpoint, version, environment, application_name,
                             SemanticConvetion.GEN_AI_APPLICATION_NAME:
                                 application_name,
                             SemanticConvetion.GEN_AI_SYSTEM:
-                                SemanticConvetion.GEN_AI_SYSTEM_OPENAI,
+                                SemanticConvetion.GEN_AI_SYSTEM_LITELLM,
                             SemanticConvetion.GEN_AI_ENVIRONMENT:
                                 environment,
                             SemanticConvetion.GEN_AI_TYPE:

--- a/sdk/python/src/openlit/instrumentation/litellm/litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/litellm.py
@@ -26,9 +26,9 @@ def completion(gen_ai_endpoint, version, environment, application_name,
         gen_ai_endpoint: Endpoint identifier for logging and tracing.
         version: Version of the monitoring package.
         environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the OpenAI API.
+        application_name: Name of the application using the LiteLLM SDK.
         tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of OpenAI usage.
+        pricing_info: Information used for calculating the cost of LiteLLM usage.
         trace_content: Flag indicating whether to trace the actual content.
 
     Returns:
@@ -38,7 +38,6 @@ def completion(gen_ai_endpoint, version, environment, application_name,
     class TracedSyncStream:
         """
         Wrapper for streaming responses to collect metrics and trace data.
-        Wraps the 'openai.AsyncStream' response to collect message IDs and aggregated response.
 
         This class implements the '__aiter__' and '__anext__' methods that
         handle asynchronous streaming responses.
@@ -125,7 +124,7 @@ def completion(gen_ai_endpoint, version, environment, application_name,
                     # Set Span attributes
                     self._span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
                     self._span.set_attribute(SemanticConvetion.GEN_AI_SYSTEM,
-                                        SemanticConvetion.GEN_AI_SYSTEM_OPENAI)
+                                        SemanticConvetion.GEN_AI_SYSTEM_LITELLM)
                     self._span.set_attribute(SemanticConvetion.GEN_AI_TYPE,
                                         SemanticConvetion.GEN_AI_TYPE_CHAT)
                     self._span.set_attribute(SemanticConvetion.GEN_AI_ENDPOINT,
@@ -185,7 +184,7 @@ def completion(gen_ai_endpoint, version, environment, application_name,
                             SemanticConvetion.GEN_AI_APPLICATION_NAME:
                                 application_name,
                             SemanticConvetion.GEN_AI_SYSTEM:
-                                SemanticConvetion.GEN_AI_SYSTEM_OPENAI,
+                                SemanticConvetion.GEN_AI_SYSTEM_LITELLM,
                             SemanticConvetion.GEN_AI_ENVIRONMENT:
                                 environment,
                             SemanticConvetion.GEN_AI_TYPE:
@@ -268,7 +267,7 @@ def completion(gen_ai_endpoint, version, environment, application_name,
                     # Set base span attribues
                     span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
                     span.set_attribute(SemanticConvetion.GEN_AI_SYSTEM,
-                                        SemanticConvetion.GEN_AI_SYSTEM_OPENAI)
+                                        SemanticConvetion.GEN_AI_SYSTEM_LITELLM)
                     span.set_attribute(SemanticConvetion.GEN_AI_TYPE,
                                         SemanticConvetion.GEN_AI_TYPE_CHAT)
                     span.set_attribute(SemanticConvetion.GEN_AI_ENDPOINT,
@@ -379,7 +378,7 @@ def completion(gen_ai_endpoint, version, environment, application_name,
                             SemanticConvetion.GEN_AI_APPLICATION_NAME:
                                 application_name,
                             SemanticConvetion.GEN_AI_SYSTEM:
-                                SemanticConvetion.GEN_AI_SYSTEM_OPENAI,
+                                SemanticConvetion.GEN_AI_SYSTEM_LITELLM,
                             SemanticConvetion.GEN_AI_ENVIRONMENT:
                                 environment,
                             SemanticConvetion.GEN_AI_TYPE:

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -88,6 +88,7 @@ class SemanticConvetion:
     GEN_AI_TYPE_FINETUNING = "fine_tuning"
     GEN_AI_TYPE_VECTORDB = "vectordb"
     GEN_AI_TYPE_FRAMEWORK = "framework"
+    GEN_AI_TYPE_AGENT = "agent"
 
     GEN_AI_SYSTEM_HUGGING_FACE = "huggingface"
     GEN_AI_SYSTEM_OPENAI = "openai"
@@ -108,6 +109,8 @@ class SemanticConvetion:
     GEN_AI_SYSTEM_LLAMAINDEX = "llama_index"
     GEN_AI_SYSTEM_HAYSTACK = "haystack"
     GEN_AI_SYSTEM_EMBEDCHAIN = "embedchain"
+    GEN_AI_SYSTEM_LITELLM = "litellm"
+    GEN_AI_SYSTEM_CREWAI = "crewai"
 
     # Vector DB
     DB_REQUESTS = "db.total.requests"


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix the system name references in the LiteLLM and CrewAI OpenTelemetry instrumentations to correctly identify 'LiteLLM' and 'CrewAI' systems. Update the SemanticConvetion class to include 'agent' as a new type. Modify the documentation to change the topbar CTA button to link to GitHub. Increment the package version to 1.30.1.

Bug Fixes:
- Correct the system name references in the LiteLLM and CrewAI OpenTelemetry instrumentations from 'OpenAI' to 'LiteLLM' and 'CrewAI' respectively.

Enhancements:
- Add 'agent' as a new type in the SemanticConvetion class to support CrewAI system.

Documentation:
- Update the topbar CTA button in the documentation from 'Website' to 'GitHub' with a new URL.

Chores:
- Bump the version of the openlit package from 1.30.0 to 1.30.1 in the pyproject.toml file.