### PR TITLE
[Fix]: Telemetry environment variable fixed for acces on client and server

### DIFF
--- a/src/client/next.config.js
+++ b/src/client/next.config.js
@@ -1,9 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	env: {
-		TELEMETRY_ENABLED: process.env.TELEMETRY_ENABLED,
-		POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
-		POSTHOG_API_HOST: process.env.POSTHOG_API_HOST,
+		NEXT_PUBLIC_TELEMETRY_ENABLED: process.env.TELEMETRY_ENABLED,
+		NEXT_PUBLIC_POSTHOG_API_KEY: process.env.POSTHOG_API_KEY,
+		NEXT_PUBLIC_POSTHOG_API_HOST: process.env.POSTHOG_API_HOST,
 	},
 	images: {
 		remotePatterns: [

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.11.4",
+      "version": "1.11.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.21.1",
         "@clickhouse/client": "^1.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/client/src/components/(playground)/posthog.tsx
+++ b/src/client/src/components/(playground)/posthog.tsx
@@ -3,8 +3,7 @@ import { PostHogProvider } from "posthog-js/react";
 import { ReactNode } from "react";
 
 const POSTHOG_OPTIONS: Partial<PostHogConfig> = {
-	api_host: process.env.POSTHOG_API_HOST,
-	// debug: process.env.NODE_ENV !== "production",
+	api_host: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
 	autocapture: false,
 };
 
@@ -13,10 +12,10 @@ export default function CustomPostHogProvider({
 }: {
 	children: ReactNode;
 }) {
-	if (process.env.TELEMETRY_ENABLED) {
+	if (process.env.NEXT_PUBLIC_TELEMETRY_ENABLED) {
 		return (
 			<PostHogProvider
-				apiKey={process.env.POSTHOG_API_KEY}
+				apiKey={process.env.NEXT_PUBLIC_POSTHOG_API_KEY}
 				options={POSTHOG_OPTIONS}
 			>
 				{children}

--- a/src/client/src/lib/posthog.ts
+++ b/src/client/src/lib/posthog.ts
@@ -6,8 +6,8 @@ type EventMessage = Parameters<PostHog["capture"]>[0];
 export default class PostHogServer {
 	static client: PostHog;
 	static createClient() {
-		this.client = new PostHog(process.env.POSTHOG_API_KEY!, {
-			host: process.env.POSTHOG_API_HOST,
+		this.client = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_API_KEY!, {
+			host: process.env.NEXT_PUBLIC_POSTHOG_API_HOST,
 			flushAt: 1,
 			flushInterval: 0,
 		});
@@ -15,7 +15,7 @@ export default class PostHogServer {
 
 	static capture(options: EventMessage) {
 		try {
-			if (process.env.TELEMETRY_ENABLED) {
+			if (process.env.NEXT_PUBLIC_TELEMETRY_ENABLED) {
 				if (!this.client) {
 					this.createClient();
 				}


### PR DESCRIPTION
### Overview:
The env variables were not working because of which variable names to be exposed to the client and server needed an update. The prefix `NEXT_PUBLIC_` was added to all the exposing env variables.


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Fix environment variable names for client and server by adding the 'NEXT_PUBLIC_' prefix to ensure they are correctly exposed.