### PR TITLE
[Fix]: Use `general_tokens` instead of `openai_tokens` in LangChain chains

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.32.8"
+version = "1.32.9"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 repository = "https://github.com/openlit/openlit/tree/main/openlit/python"

--- a/sdk/python/src/openlit/instrumentation/langchain/langchain.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/langchain.py
@@ -523,9 +523,9 @@ def chat(gen_ai_endpoint, version, environment, application_name,
                     doc.page_content for doc in response.get("input_documents", [])
                     if isinstance(doc.page_content, str)
                     ]
-                    input_tokens = sum(general_tokens(text, model) for text in input_texts)
+                    input_tokens = sum(general_tokens(text) for text in input_texts)
                     output_text = response.get("output_text", "")
-                    output_tokens = general_tokens(output_text, model)
+                    output_tokens = general_tokens(output_text)
 
                 # Calculate cost of the operation
                 cost = get_chat_model_cost(


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
- general_tokens function used to calculate tokens in langchain chains takes only one argument (text), removed the model argument from the function call to resolve the exception

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->
<img width="361" alt="image" src="https://github.com/user-attachments/assets/cb32530e-f36c-4b23-a00a-8bc8769522dd">


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix an exception in langchain chains by removing the unnecessary model argument from the general_tokens function call and update the package version to 1.32.9.

Bug Fixes:
- Remove the model argument from the general_tokens function call to fix an exception in langchain chains.

Chores:
- Bump the version of the openlit package from 1.32.8 to 1.32.9.