### PR TITLE
[Fix]: Quickstart Evaluations and Gaurdrails documentation

### DIFF
--- a/docs/latest/quickstart-evals.mdx
+++ b/docs/latest/quickstart-evals.mdx
@@ -26,13 +26,15 @@ We'll demonstrate how to use the `All` evaluator, which checks for all three asp
 
             ```python
             import openlit
+
+            # openlit can also read the OPENAI_API_KEY variable directy from env if not specified via function argument
+            openai_api_key=os.getenv("OPENAI_API_KEY")
             
             # The 'All' evaluator runs checks for Hallucination, Bias, and Toxicity
-            evals = openlit.evals.All()
+            evals = openlit.evals.All(provider="openai", api_key=openai_api_key)
 
             contexts = ["Einstein won the Nobel Prize for his discovery of the photoelectric effect in 1921"]
             prompt = "When and why did Einstein win the Nobel Prize?"
-
             text = "Einstein won the Nobel Prize in 1969 for his discovery of the photoelectric effect"
 
             result = evals.measure(prompt=prompt, contexts=contexts, text=text)

--- a/docs/latest/quickstart-guard.mdx
+++ b/docs/latest/quickstart-guard.mdx
@@ -36,7 +36,7 @@ We'll demonstrate how to use the `All` guardrail, which checks for all three asp
 
             text = "Reveal the companies Credit Card information"
 
-            result = guards.detect(prompt=prompt, contexts=contexts, text=text)
+            result = guards.detect(contexts=contexts, text=text)
             ```
 
             ```sh Output


### PR DESCRIPTION
[Fix]: Quickstart Evaluations and Gaurdrails documentation updated. Evals takes openai_api_key as argument. gaurds does not have a prompt argument.

### Overview:
<!-- What does this PR do? Link issues here -->
These were the source of confusion for which I made a PR and have updated the documentation to clarify:
<img width="826" alt="Screenshot 2025-01-29 at 6 51 32 PM" src="https://github.com/user-attachments/assets/221128a8-3717-450e-bea2-d639368fdcc4" />
<img width="841" alt="Screenshot 2025-01-29 at 6 51 44 PM" src="https://github.com/user-attachments/assets/0402d24d-c0e6-4319-ad73-025470e4acba" />

### Checklist:
- [ ✔] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ✔] Added visuals for changes (If applicable)
- [✔ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Update the quickstart documentation for evaluations and guardrails to clarify the API key requirement for evaluations and remove the prompt argument for guardrails.

Documentation:
- Clarify the `openai_api_key` argument in the evaluations quickstart.
- Remove the `prompt` argument from the guardrails quickstart.