### PR TITLE
[Fix]: Typescript error to remove post install script.

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.4.0",
+  "version": "1.4.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.4.0",
+      "version": "1.4.0-beta.1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.25.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -18,7 +18,10 @@
     "dist",
     "README.md",
     "LICENSE",
-    "package.json"
+    "package.json",
+    "tsconfig.json",
+    "eslint.config.mjs",
+    ".prettierrc.json"
   ],
   "description": "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications, facilitating the integration of observability into your GenAI-driven projects",
   "main": "dist/index.js",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -11,8 +11,7 @@
     "url": "https://github.com/openlit/openlit"
   },
   "scripts": {
-    "build": "tsc --build",
-    "postinstall": "npm run build"
+    "build": "tsc --build"
   },
   "files": [
     "dist",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.4.0",
+  "version": "1.4.0-beta.1",
   "homepage": "https://github.com/openlit/openlit#readme",
   "bugs": {
     "url": "https://github.com/openlit/openlit/issues",


### PR DESCRIPTION
### Overview:
- Removed postinstall script and added files tsconfig, eslint and prettier to the files section


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [ ] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Updates the package configuration to remove the postinstall script and include configuration files in the published package.

Build:
- Removes the `postinstall` script, which ran `npm run build` after installation.

Chores:
- Adds `tsconfig.json`, `eslint.config.mjs`, and `.prettierrc.json` to the files included in the published package.