### PR TITLE
[Fix]: bump python sdk dep to ^3.8.0

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.33.14"
+version = "1.33.15"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"
@@ -10,7 +10,7 @@ homepage = "https://github.com/openlit/openlit/tree/main/openlit/python"
 keywords = ["OpenTelemetry", "otel", "otlp","llm", "tracing", "openai", "anthropic", "claude", "cohere", "llm monitoring", "observability", "monitoring", "gpt", "Generative AI", "chatGPT", "gpu"]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.8.0"
 requests = "^2.26.0"
 schedule = "^1.2.2"
 pydantic = "^2.0.0"


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
anthropic requires Python >=3.8

```
(openlit-py3.13) ➜  python git:(main) ✗ poetry install

Updating dependencies
Resolving dependencies... (0.6s)

The current project's supported Python range (>=3.7.1,<4.0.0) is not compatible with some of the required packages Python requirement:
  - anthropic requires Python >=3.8, so it will not be installable for Python >=3.7.1,<3.8

Because no versions of anthropic match >0.42.0,<0.43.0
 and anthropic (0.42.0) requires Python >=3.8, anthropic is forbidden.
So, because openlit depends on anthropic (^0.42.0), version solving failed.

  * Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties

    For anthropic, a possible solution would be to set the `python` property to ">=3.8,<4.0.0"

    https://python-poetry.org/docs/dependency-specification/#python-restricted-dependencies,
    https://python-poetry.org/docs/dependency-specification/#using-environment-markers
```

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [ ] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Build:
- Bump the minimum supported Python version to 3.8 in pyproject.toml.