### PR TITLE
[Fix]: `Cost by App` and `Cost by Env` panels on dashboard

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.21.1",
         "@clickhouse/client": "^1.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/client/src/constants/traces.ts
+++ b/src/client/src/constants/traces.ts
@@ -74,6 +74,19 @@ export const TraceMapping: Record<TraceMappingKeyType, TraceMappingValueType> =
 			path: "StatusCode",
 			isRoot: true,
 		},
+		applicationName: {
+			label: "App Name",
+			type: "string",
+			path: "service.name",
+			isRoot: true,
+		},
+		environment: {
+			label: "Environment",
+			type: "string",
+			path: "deployment.environment",
+			icon: Container,
+			isRoot: true,
+		},
 
 		// Exception
 		serviceName: {
@@ -122,19 +135,6 @@ export const TraceMapping: Record<TraceMappingKeyType, TraceMappingValueType> =
 			path: "system",
 			prefix: SpanAttributesGenAIPrefix,
 			icon: PyramidIcon,
-		},
-		applicationName: {
-			label: "App Name",
-			type: "string",
-			path: "name",
-			prefix: "service",
-		},
-		environment: {
-			label: "Environment",
-			type: "string",
-			path: "environment",
-			prefix: "deployment",
-			icon: Container,
 		},
 		type: {
 			label: "Type",

--- a/src/client/src/constants/traces.ts
+++ b/src/client/src/constants/traces.ts
@@ -126,14 +126,14 @@ export const TraceMapping: Record<TraceMappingKeyType, TraceMappingValueType> =
 		applicationName: {
 			label: "App Name",
 			type: "string",
-			path: "application_name",
-			prefix: SpanAttributesGenAIPrefix,
+			path: "name",
+			prefix: "service",
 		},
 		environment: {
 			label: "Environment",
 			type: "string",
 			path: "environment",
-			prefix: SpanAttributesGenAIPrefix,
+			prefix: "deployment",
 			icon: Container,
 		},
 		type: {


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
<img width="1489" alt="Screenshot 2025-05-08 at 4 36 51 PM" src="https://github.com/user-attachments/assets/d642f7b7-9f4d-497d-9ad0-b3f9cec3ed63" />



### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix the configuration for application name and environment tracking in the dashboard's Cost panels

Bug Fixes:
- Updated attribute paths and prefixes for application name and environment tracking in traces constants

Chores:
- Bumped client package version to 1.13.1