### PR TITLE
[Feat]: Add more filters for service.name and environment

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.13.1",
+      "version": "1.13.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.21.1",
         "@clickhouse/client": "^1.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/client/src/components/(playground)/filter/traces-filter.tsx
+++ b/src/client/src/components/(playground)/filter/traces-filter.tsx
@@ -58,6 +58,8 @@ const DynamicFilters = ({
 			case "models":
 			case "providers":
 			case "traceTypes":
+			case "applicationNames":
+			case "environments":
 				if (operationType === "add") {
 					setSelectedFilterValues((s) => {
 						const typeArray = s[type] || [];
@@ -168,6 +170,32 @@ const DynamicFilters = ({
 						maxValue={filterConfig.maxCost}
 						onChange={updateSelectedValues}
 						type="maxCost"
+					/>
+				) : null}
+				{filterConfig?.applicationNames?.length ? (
+					<ComboDropdown
+						options={filterConfig?.applicationNames.map((a) => ({
+							label: a,
+							value: a,
+						}))}
+						title="Application Names"
+						type="applicationNames"
+						updateSelectedValues={updateSelectedValues}
+						selectedValues={selectedFilterValues.applicationNames}
+						clearItem={clearFilter}
+					/>
+				) : null}
+				{filterConfig?.environments?.length ? (
+					<ComboDropdown
+						options={filterConfig?.environments.map((e) => ({
+							label: e,
+							value: e,
+						}))}
+						title="Environments"
+						type="environments"
+						updateSelectedValues={updateSelectedValues}
+						selectedValues={selectedFilterValues.environments}
+						clearItem={clearFilter}
 					/>
 				) : null}
 			</div>

--- a/src/client/src/helpers/server/platform.ts
+++ b/src/client/src/helpers/server/platform.ts
@@ -222,6 +222,26 @@ export const getFilterWhereCondition = (
 					)}']) BETWEEN 0 AND ${filter.selectedConfig.maxCost.toFixed(10)}`
 				);
 			}
+
+			if (filter.selectedConfig.applicationNames?.length) {
+				whereArray.push(
+					`ResourceAttributes['${getTraceMappingKeyFullPath(
+						"applicationName"
+					)}'] IN (${filter.selectedConfig.applicationNames
+						.map((applicationName) => `'${applicationName}'`)
+						.join(", ")})`
+				);
+			}
+
+			if (filter.selectedConfig.environments?.length) {
+				whereArray.push(
+					`ResourceAttributes['${getTraceMappingKeyFullPath(
+						"environment"
+					)}'] IN (${filter.selectedConfig.environments
+						.map((environment) => `'${environment}'`)
+						.join(", ")})`
+				);
+			}
 		}
 
 		if (filter.notOrEmpty && filter.notOrEmpty?.length > 0) {
@@ -239,7 +259,9 @@ export const getFilterWhereCondition = (
 			});
 		}
 
-		const { statusCode = ["STATUS_CODE_OK", "STATUS_CODE_UNSET", "Ok", "Unset"] } = filter;
+		const {
+			statusCode = ["STATUS_CODE_OK", "STATUS_CODE_UNSET", "Ok", "Unset"],
+		} = filter;
 		whereArray.push(
 			`StatusCode IN (${statusCode.map((type) => `'${type}'`).join(", ")})`
 		);

--- a/src/client/src/lib/platform/llm/cost.ts
+++ b/src/client/src/lib/platform/llm/cost.ts
@@ -71,7 +71,7 @@ export async function getAverageCost(params: MetricParams) {
 }
 
 export async function getCostByApplication(params: MetricParams) {
-	const keyPathApplicationName = `SpanAttributes['${getTraceMappingKeyFullPath(
+	const keyPathApplicationName = `ResourceAttributes['${getTraceMappingKeyFullPath(
 		"applicationName"
 	)}']`;
 	const keyPathCost = `SpanAttributes['${getTraceMappingKeyFullPath("cost")}']`;
@@ -90,7 +90,7 @@ export async function getCostByApplication(params: MetricParams) {
 }
 
 export async function getCostByEnvironment(params: MetricParams) {
-	const keyPathEnvironment = `SpanAttributes['${getTraceMappingKeyFullPath(
+	const keyPathEnvironment = `ResourceAttributes['${getTraceMappingKeyFullPath(
 		"environment"
 	)}']`;
 	const keyPathCost = `SpanAttributes['${getTraceMappingKeyFullPath("cost")}']`;

--- a/src/client/src/lib/platform/request/index.ts
+++ b/src/client/src/lib/platform/request/index.ts
@@ -125,6 +125,18 @@ export async function getRequestsConfig(params: MetricParams) {
 
 	select.push(`CAST(COUNT(*) AS INTEGER) AS totalRows`);
 
+	select.push(
+		`arrayFilter(x -> x != '', ARRAY_AGG(DISTINCT ResourceAttributes['${getTraceMappingKeyFullPath(
+			"applicationName"
+		)}'])) AS applicationNames`
+	);
+
+	select.push(
+		`arrayFilter(x -> x != '', ARRAY_AGG(DISTINCT ResourceAttributes['${getTraceMappingKeyFullPath(
+			"environment"
+		)}'])) AS environments`
+	);
+
 	const query = `SELECT ${select.join(", ")} FROM ${OTEL_TRACES_TABLE_NAME} 
 			WHERE ${getFilterWhereCondition(params)}`;
 

--- a/src/client/src/lib/platform/vector/application.ts
+++ b/src/client/src/lib/platform/vector/application.ts
@@ -3,7 +3,7 @@ import { MetricParams, OTEL_TRACES_TABLE_NAME, dataCollector } from "../common";
 import { getFilterWhereCondition } from "@/helpers/server/platform";
 
 export async function getResultGenerationByApplication(params: MetricParams) {
-	const key = `SpanAttributes['${getTraceMappingKeyFullPath(
+	const key = `ResourceAttributes['${getTraceMappingKeyFullPath(
 		"applicationName"
 	)}']`;
 	const query = `SELECT 

--- a/src/client/src/lib/platform/vector/environment.ts
+++ b/src/client/src/lib/platform/vector/environment.ts
@@ -3,7 +3,7 @@ import { MetricParams, OTEL_TRACES_TABLE_NAME, dataCollector } from "../common";
 import { getFilterWhereCondition } from "@/helpers/server/platform";
 
 export async function getResultGenerationByEnvironment(params: MetricParams) {
-	const keyPathEnvironment = `SpanAttributes['${getTraceMappingKeyFullPath(
+	const keyPathEnvironment = `ResourceAttributes['${getTraceMappingKeyFullPath(
 		"environment"
 	)}']`;
 	const query = `SELECT 

--- a/src/client/src/store/filter.ts
+++ b/src/client/src/store/filter.ts
@@ -86,7 +86,12 @@ const INITIAL_FILTER_DETAILS: FilterType = {
 export const filterStoreSlice: FilterStore = lens((setStore, getStore) => ({
 	details: INITIAL_FILTER_DETAILS,
 	updateFilter: (key: string, value: any, extraParams?: any) => {
-		let object = {};
+		let object: Partial<
+			FilterType & {
+				end: Date;
+				start: Date;
+			}
+		> = {};
 		let resetConfig = false;
 		switch (key) {
 			case "timeLimit.type":
@@ -123,6 +128,8 @@ export const filterStoreSlice: FilterStore = lens((setStore, getStore) => ({
 				selectedConfig:
 					resetConfig || extraParams?.clearFilter
 						? {}
+						: object.selectedConfig
+						? object.selectedConfig
 						: getStore().details.selectedConfig,
 			},
 			config: resetConfig ? undefined : getStore().config,

--- a/src/client/src/types/platform.ts
+++ b/src/client/src/types/platform.ts
@@ -13,6 +13,8 @@ export type FilterWhereConditionType = {
 		maxCost: number;
 		models: string[];
 		traceTypes: string[];
+		applicationNames: string[];
+		environments: string[];
 	}>;
 	notOrEmpty?: { key: string }[];
 	notEmpty?: { key: string }[];

--- a/src/client/src/types/store/filter.ts
+++ b/src/client/src/types/store/filter.ts
@@ -25,6 +25,8 @@ export interface FilterConfig {
 	models: string[];
 	totalRows: number;
 	traceTypes: string[];
+	applicationNames: string[];
+	environments: string[];
 }
 
 export type FilterStore = {


### PR DESCRIPTION
### Overview:
This PR adds changes :
- Adds filters for application names and environment in the request page
- Fixes the existing bug where the selected dynamic filters was not getting removed on de selecting options and applying filters
- Fixes the fetching of environment and application names from `SpanAttributes` to `ResourceAttributes` , there by fixing the dashboard elements . 

This is a breaking change for the dashboard as the fetching of the applicationName and environment from the key is changed from `SpanAttributes` to `ResourceAttributes`. Hence some data might get mis matched as earlier traces might not have data in `ResourceAttributes`.


### Visuals (If applicable):
<img width="1373" alt="Screenshot 2025-05-14 at 12 56 56 AM" src="https://github.com/user-attachments/assets/666de329-ace9-4f59-8856-64d673a2c5a9" />



### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Add Application Names and Environments filters to UI and backend, migrate attribute source to ResourceAttributes, fix filter deselection bug, and update queries and types to support new fields.

New Features:
- Add Application Names and Environments multi-select filters to the request page
- Expose applicationNames and environments aggregates in the requests config query

Bug Fixes:
- Ensure deselected dynamic filters are cleared when reapplying filters

Enhancements:
- Switch applicationName and environment retrieval from SpanAttributes to ResourceAttributes across queries
- Extend filter builder to handle applicationNames and environments and update corresponding type definitions