### PR TITLE
[Feat]: Add OpenTelemetry Instrumentation for Pydantic AI

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.33.23"
+version = "1.34.0"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -66,6 +66,7 @@ from openlit.instrumentation.crawl4ai import Crawl4AIInstrumentor
 from openlit.instrumentation.firecrawl import FireCrawlInstrumentor
 from openlit.instrumentation.letta import LettaInstrumentor
 from openlit.instrumentation.openai_agents import OpenAIAgentsInstrumentor
+from openlit.instrumentation.pydantic_ai import PydanticAIInstrumentor
 from openlit.instrumentation.gpu import GPUInstrumentor
 import openlit.guard
 import openlit.evals
@@ -294,7 +295,8 @@ def init(
         "firecrawl": "firecrawl",
         "letta": "letta",
         "together": "together",
-        "openai-agents": "agents"
+        "openai-agents": "agents",
+        "pydantic_ai": "pydantic_ai"
     }
 
     invalid_instrumentors = [
@@ -414,6 +416,7 @@ def init(
             "letta": LettaInstrumentor(),
             "together": TogetherInstrumentor(),
             "openai-agents": OpenAIAgentsInstrumentor(),
+            "pydantic_ai": PydanticAIInstrumentor(),
         }
 
         # Initialize and instrument only the enabled instrumentors

--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -521,7 +521,10 @@ def async_chat_completions(version, environment, application_name,
                         self._llmresponse += content
                 self._response_id = chunked.get('id')
                 self._response_model = chunked.get('model')
-                self._finish_reason = chunked.get('choices')[0].get('finish_reason')
+                try:
+                    self._finish_reason = chunked.get('choices',[])[0].get('finish_reason')
+                except:
+                    self._finish_reason = "stop"
                 self._openai_response_service_tier = chunked.get('service_tier') or 'auto'
                 self._openai_system_fingerprint = chunked.get('system_fingerprint')
                 return chunk
@@ -573,21 +576,21 @@ def async_chat_completions(version, environment, application_name,
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
                                         request_model)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                        self._kwargs.get("seed", ""))
+                                        str(self._kwargs.get("seed", "")))
                     self._span.set_attribute(SemanticConvention.SERVER_PORT,
                                         self._server_port)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
-                                        self._kwargs.get("frequency_penalty", 0.0))
+                                        str(self._kwargs.get("frequency_penalty", 0.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
                                         self._kwargs.get("max_tokens", -1))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                        self._kwargs.get("presence_penalty", 0.0))
+                                        str(self._kwargs.get("presence_penalty", 0.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                        self._kwargs.get("stop", []))
+                                        str(self._kwargs.get("stop", [])))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                        self._kwargs.get("temperature", 1.0))
+                                        str(self._kwargs.get("temperature", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                        self._kwargs.get("top_p", 1.0))
+                                        str(self._kwargs.get("top_p", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
                                         [self._finish_reason])
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
@@ -601,7 +604,7 @@ def async_chat_completions(version, environment, application_name,
                     self._span.set_attribute(SemanticConvention.SERVER_ADDRESS,
                                         self._server_address)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SERVICE_TIER,
-                                        self._kwargs.get("service_tier", "auto"))
+                                        str(self._kwargs.get("service_tier", "auto")))
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER,
                                         self._openai_response_service_tier)
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT,
@@ -619,7 +622,7 @@ def async_chat_completions(version, environment, application_name,
                     self._span.set_attribute(SERVICE_NAME,
                                         application_name)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_USER,
-                                        self._kwargs.get("user", ""))
+                                        str(self._kwargs.get("user", "")))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
                                         True)
                     self._span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
@@ -760,21 +763,21 @@ def async_chat_completions(version, environment, application_name,
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
                                         request_model)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                        kwargs.get("seed", ""))
+                                        str(kwargs.get("seed", "")))
                     span.set_attribute(SemanticConvention.SERVER_PORT,
                                         server_port)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
-                                        kwargs.get("frequency_penalty", 0.0))
+                                        str(kwargs.get("frequency_penalty", 0.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
                                         kwargs.get("max_tokens", -1))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                        kwargs.get("presence_penalty", 0.0))
+                                        str(kwargs.get("presence_penalty", 0.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                        kwargs.get("stop", []))
+                                        str(kwargs.get("stop", [])))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                        kwargs.get("temperature", 1.0))
+                                        str(kwargs.get("temperature", 1.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                        kwargs.get("top_p", 1.0))
+                                        str(kwargs.get("top_p", 1.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
                                         response_dict.get("id"))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
@@ -786,7 +789,7 @@ def async_chat_completions(version, environment, application_name,
                     span.set_attribute(SemanticConvention.SERVER_ADDRESS,
                                         server_address)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SERVICE_TIER,
-                                        kwargs.get("service_tier", "auto"))
+                                        str(kwargs.get("service_tier", "auto")))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER,
                                         response_dict.get('service_tier', 'auto'))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT,
@@ -798,7 +801,7 @@ def async_chat_completions(version, environment, application_name,
                     span.set_attribute(SERVICE_NAME,
                                         application_name)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_USER,
-                                        kwargs.get("user", ""))
+                                        str(kwargs.get("user", "")))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
                                         False)
                     span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,

--- a/sdk/python/src/openlit/instrumentation/openai/openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/openai.py
@@ -148,17 +148,17 @@ def responses(version, environment, application_name,
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
                                         request_model)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                        self._kwargs.get("seed", ""))
+                                        str(self._kwargs.get("seed", "")))
                     self._span.set_attribute(SemanticConvention.SERVER_PORT,
                                         self._server_port)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
-                                        self._kwargs.get("max_output_tokens", -1))
+                                        str(self._kwargs.get("max_output_tokens", -1)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                        self._kwargs.get("stop", []))
+                                        str(self._kwargs.get("stop", [])))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                        self._kwargs.get("temperature", 1.0))
+                                        str(self._kwargs.get("temperature", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                        self._kwargs.get("top_p", 1.0))
+                                        str(self._kwargs.get("top_p", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
                                         [self._finish_reason])
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
@@ -521,7 +521,10 @@ def chat_completions(version, environment, application_name,
                         self._llmresponse += content
                 self._response_id = chunked.get('id')
                 self._response_model = chunked.get('model')
-                self._finish_reason = chunked.get('choices')[0].get('finish_reason')
+                try:
+                    self._finish_reason = chunked.get('choices',[])[0].get('finish_reason')
+                except:
+                    self._finish_reason = "stop"
                 self._openai_response_service_tier = chunked.get('service_tier') or 'auto'
                 self._openai_system_fingerprint = chunked.get('system_fingerprint')
                 return chunk
@@ -573,21 +576,21 @@ def chat_completions(version, environment, application_name,
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
                                         request_model)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                        self._kwargs.get("seed", ""))
+                                        str(self._kwargs.get("seed", "")))
                     self._span.set_attribute(SemanticConvention.SERVER_PORT,
                                         self._server_port)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
-                                        self._kwargs.get("frequency_penalty", 0.0))
+                                        str(self._kwargs.get("frequency_penalty", 0.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
                                         self._kwargs.get("max_tokens", -1))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                        self._kwargs.get("presence_penalty", 0.0))
+                                        str(self._kwargs.get("presence_penalty", 0.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                        self._kwargs.get("stop", []))
+                                        str(self._kwargs.get("stop", [])))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                        self._kwargs.get("temperature", 1.0))
+                                        str(self._kwargs.get("temperature", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                        self._kwargs.get("top_p", 1.0))
+                                        str(self._kwargs.get("top_p", 1.0)))
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
                                         [self._finish_reason])
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
@@ -601,7 +604,7 @@ def chat_completions(version, environment, application_name,
                     self._span.set_attribute(SemanticConvention.SERVER_ADDRESS,
                                         self._server_address)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SERVICE_TIER,
-                                        self._kwargs.get("service_tier", "auto"))
+                                        str(self._kwargs.get("service_tier", "auto")))
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER,
                                         self._openai_response_service_tier)
                     self._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT,
@@ -619,7 +622,7 @@ def chat_completions(version, environment, application_name,
                     self._span.set_attribute(SERVICE_NAME,
                                         application_name)
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_USER,
-                                        self._kwargs.get("user", ""))
+                                        str(self._kwargs.get("user", "")))
                     self._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
                                         True)
                     self._span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
@@ -760,21 +763,21 @@ def chat_completions(version, environment, application_name,
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
                                         request_model)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                        kwargs.get("seed", ""))
+                                        str(kwargs.get("seed", "")))
                     span.set_attribute(SemanticConvention.SERVER_PORT,
                                         server_port)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
-                                        kwargs.get("frequency_penalty", 0.0))
+                                        str(kwargs.get("frequency_penalty", 0.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
-                                        kwargs.get("max_tokens", -1))
+                                        str(kwargs.get("max_tokens", -1)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                        kwargs.get("presence_penalty", 0.0))
+                                        str(kwargs.get("presence_penalty", 0.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                        kwargs.get("stop", []))
+                                        str(kwargs.get("stop", [])))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                        kwargs.get("temperature", 1.0))
+                                        str(kwargs.get("temperature", 1.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                        kwargs.get("top_p", 1.0))
+                                        str(kwargs.get("top_p", 1.0)))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
                                         response_dict.get("id"))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
@@ -786,7 +789,7 @@ def chat_completions(version, environment, application_name,
                     span.set_attribute(SemanticConvention.SERVER_ADDRESS,
                                         server_address)
                     span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SERVICE_TIER,
-                                        kwargs.get("service_tier", "auto"))
+                                        str(kwargs.get("service_tier", "auto")))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER,
                                         response_dict.get('service_tier', 'auto'))
                     span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT,

--- a/sdk/python/src/openlit/instrumentation/openai/openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/openai.py
@@ -522,8 +522,8 @@ def chat_completions(version, environment, application_name,
                 self._response_id = chunked.get('id')
                 self._response_model = chunked.get('model')
                 try:
-                    self._finish_reason = chunked.get('choices',[])[0].get('finish_reason')
-                except:
+                    self._finish_reason = chunked.get('choices', [])[0].get('finish_reason')
+                except (IndexError, AttributeError, TypeError):
                     self._finish_reason = "stop"
                 self._openai_response_service_tier = chunked.get('service_tier') or 'auto'
                 self._openai_system_fingerprint = chunked.get('system_fingerprint')

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/__init__.py
@@ -1,0 +1,55 @@
+"""Initializer of Auto Instrumentation of Pydantic AI Functions"""
+
+from typing import Collection
+import importlib.metadata
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from wrapt import wrap_function_wrapper
+
+from openlit.instrumentation.pydantic_ai.pydantic_ai import (
+    agent_create, agent_run, async_agent_run
+)
+
+_instruments = ('pydantic-ai >= 0.2.17',)
+
+class PydanticAIInstrumentor(BaseInstrumentor):
+    """
+    An instrumentor for Pydantic AI's client library.
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        application_name = kwargs.get('application_name', 'default_application')
+        environment = kwargs.get('environment', 'default_environment')
+        tracer = kwargs.get('tracer')
+        metrics = kwargs.get('metrics_dict')
+        pricing_info = kwargs.get('pricing_info', {})
+        capture_message_content = kwargs.get('capture_message_content', False)
+        disable_metrics = kwargs.get('disable_metrics')
+        version = importlib.metadata.version('pydantic-ai')
+
+        wrap_function_wrapper(
+            'pydantic_ai.agent',
+            'Agent.__init__',
+            agent_create(version, environment, application_name,
+                  tracer, pricing_info, capture_message_content, metrics, disable_metrics),
+        )
+
+        wrap_function_wrapper(
+            'pydantic_ai.agent',
+            'Agent.run_sync',
+            agent_run(version, environment, application_name,
+                  tracer, pricing_info, capture_message_content, metrics, disable_metrics),
+        )
+
+        wrap_function_wrapper(
+            'pydantic_ai.agent',
+            'Agent.run',
+            async_agent_run(version, environment, application_name,
+                  tracer, pricing_info, capture_message_content, metrics, disable_metrics),
+        )
+
+    def _uninstrument(self, **kwargs):
+        # Proper uninstrumentation logic to revert patched methods
+        pass

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
@@ -11,32 +11,13 @@ from openlit.__helpers import (
     get_chat_model_cost,
 )
 from openlit.instrumentation.pydantic_ai.utils import (
-    common_agent_run
+    common_agent_run,
+    common_agent_create
 )
 from openlit.semcov import SemanticConvention
 
 # Initialize logger for logging potential issues and operations
 logger = logging.getLogger(__name__)
-
-def set_span_attributes(span, version, operation_name, environment,
-        application_name, server_address, server_port, request_model, agent_name):
-    """
-    Set common attributes for the span.
-    """
-
-    # Set Span attributes (OTel Semconv)
-    span.set_attribute(TELEMETRY_SDK_NAME, 'openlit')
-    span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_name)
-    span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_PYDANTIC_AI)
-    span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
-    span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
-    span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
-    span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
-
-    # Set Span attributes (Extras)
-    span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
-    span.set_attribute(SERVICE_NAME, application_name)
-    span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
 def agent_create(version, environment, application_name,
     tracer, pricing_info, capture_message_content, metrics, disable_metrics):
@@ -46,66 +27,12 @@ def agent_create(version, environment, application_name,
     """
 
     def wrapper(wrapped, instance, args, kwargs):
-        server_address, server_port = '127.0.0.1', 80
-
-        agent_name = kwargs.get("name", "pydantic_agent")
-        span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT} {agent_name}'
-
-        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-            try:
-                start_time = time.time()
-                response = wrapped(*args, **kwargs)
-                end_time = time.time()
-
-                request_model = args[0] or kwargs.get("model", "google-gla:gemini-1.5-flash")
-                set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
-                    environment, application_name, server_address, server_port, request_model, agent_name)
-                span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(kwargs.get("system_prompt", "")))
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
-
-                span.set_status(Status(StatusCode.OK))
-
-                return response
-
-            except Exception as e:
-                handle_exception(span, e)
-                logger.error('Error in trace creation: %s', e)
-                return response
+        response = wrapped(*args, **kwargs)
+        return common_agent_create(wrapped, instance, args, kwargs, tracer, 
+                                 version, environment, application_name, 
+                                 capture_message_content, response=response)
 
     return wrapper
-
-def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
-                         capture_message_content, response):
-    server_address, server_port = instance.model.base_url, 443
-    agent_name = instance.name or "pydantic_agent"
-    request_model = str(instance.model.model_name)
-    span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK} {agent_name}'
-    
-    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-        try:
-            start_time = time.time()
-            end_time = time.time()
-            set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK,
-                                environment, application_name, server_address, server_port, request_model, agent_name)
-            span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(instance._system_prompts))
-            span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
-
-            if capture_message_content:
-                span.add_event(
-                    name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-                    attributes={
-                        SemanticConvention.GEN_AI_CONTENT_COMPLETION: response.output,
-                    },
-                )
-
-            span.set_status(Status(StatusCode.OK))
-
-            return response
-
-        except Exception as e:
-            handle_exception(span, e)
-            logger.error('Error in trace creation: %s', e)
-            return response
 
 def agent_run(version, environment, application_name,
               tracer, pricing_info, capture_message_content, metrics, disable_metrics):

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
@@ -1,0 +1,136 @@
+"""
+Module for monitoring Pydantic AI API calls.
+"""
+
+import logging
+import time
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from openlit.__helpers import (
+    handle_exception,
+    get_chat_model_cost,
+)
+from openlit.instrumentation.pydantic_ai.utils import (
+    common_agent_run
+)
+from openlit.semcov import SemanticConvention
+
+# Initialize logger for logging potential issues and operations
+logger = logging.getLogger(__name__)
+
+def set_span_attributes(span, version, operation_name, environment,
+        application_name, server_address, server_port, request_model, agent_name):
+    """
+    Set common attributes for the span.
+    """
+
+    # Set Span attributes (OTel Semconv)
+    span.set_attribute(TELEMETRY_SDK_NAME, 'openlit')
+    span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_name)
+    span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_PYDANTIC_AI)
+    span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
+    span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+    span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+    span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
+
+    # Set Span attributes (Extras)
+    span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
+    span.set_attribute(SERVICE_NAME, application_name)
+    span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+
+def agent_create(version, environment, application_name,
+    tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+
+    """
+    Generates a telemetry wrapper for GenAI function call
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        server_address, server_port = '127.0.0.1', 80
+
+        agent_name = kwargs.get("name", "pydantic_agent")
+        span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT} {agent_name}'
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            try:
+                start_time = time.time()
+                response = wrapped(*args, **kwargs)
+                end_time = time.time()
+
+                request_model = args[0] or kwargs.get("model", "google-gla:gemini-1.5-flash")
+                set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+                    environment, application_name, server_address, server_port, request_model, agent_name)
+                span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(kwargs.get("system_prompt", "")))
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
+
+                span.set_status(Status(StatusCode.OK))
+
+                return response
+
+            except Exception as e:
+                handle_exception(span, e)
+                logger.error('Error in trace creation: %s', e)
+                return response
+
+    return wrapper
+
+def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
+                         capture_message_content, response):
+    server_address, server_port = instance.model.base_url, 443
+    agent_name = instance.name or "pydantic_agent"
+    request_model = str(instance.model.model_name)
+    span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK} {agent_name}'
+    
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        try:
+            start_time = time.time()
+            end_time = time.time()
+            set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK,
+                                environment, application_name, server_address, server_port, request_model, agent_name)
+            span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(instance._system_prompts))
+            span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
+
+            if capture_message_content:
+                span.add_event(
+                    name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
+                    attributes={
+                        SemanticConvention.GEN_AI_CONTENT_COMPLETION: response.output,
+                    },
+                )
+
+            span.set_status(Status(StatusCode.OK))
+
+            return response
+
+        except Exception as e:
+            handle_exception(span, e)
+            logger.error('Error in trace creation: %s', e)
+            return response
+
+def agent_run(version, environment, application_name,
+              tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+    """
+    Generates a telemetry wrapper for GenAI function call
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        response = wrapped(*args, **kwargs)
+        return common_agent_run(wrapped, instance, args, kwargs, tracer, 
+                                    version, environment, application_name, 
+                                    capture_message_content, response=response)
+
+    return wrapper
+
+def async_agent_run(version, environment, application_name,
+                    tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+    """
+    Generates a telemetry wrapper for GenAI function call
+    """
+
+    async def wrapper(wrapped, instance, args, kwargs):
+        response = await wrapped(*args, **kwargs)
+        return common_agent_run(wrapped, instance, args, kwargs, tracer, 
+                                          version, environment, application_name, 
+                                          capture_message_content, response=response)
+
+    return wrapper

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
@@ -2,7 +2,6 @@
 Module for monitoring Pydantic AI API calls.
 """
 
-import logging
 from openlit.instrumentation.pydantic_ai.utils import (
     common_agent_run,
     common_agent_create

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/pydantic_ai.py
@@ -3,21 +3,10 @@ Module for monitoring Pydantic AI API calls.
 """
 
 import logging
-import time
-from opentelemetry.trace import SpanKind, Status, StatusCode
-from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
-from openlit.__helpers import (
-    handle_exception,
-    get_chat_model_cost,
-)
 from openlit.instrumentation.pydantic_ai.utils import (
     common_agent_run,
     common_agent_create
 )
-from openlit.semcov import SemanticConvention
-
-# Initialize logger for logging potential issues and operations
-logger = logging.getLogger(__name__)
 
 def agent_create(version, environment, application_name,
     tracer, pricing_info, capture_message_content, metrics, disable_metrics):
@@ -28,8 +17,8 @@ def agent_create(version, environment, application_name,
 
     def wrapper(wrapped, instance, args, kwargs):
         response = wrapped(*args, **kwargs)
-        return common_agent_create(wrapped, instance, args, kwargs, tracer, 
-                                 version, environment, application_name, 
+        return common_agent_create(wrapped, instance, args, kwargs, tracer,
+                                 version, environment, application_name,
                                  capture_message_content, response=response)
 
     return wrapper
@@ -42,8 +31,8 @@ def agent_run(version, environment, application_name,
 
     def wrapper(wrapped, instance, args, kwargs):
         response = wrapped(*args, **kwargs)
-        return common_agent_run(wrapped, instance, args, kwargs, tracer, 
-                                    version, environment, application_name, 
+        return common_agent_run(wrapped, instance, args, kwargs, tracer,
+                                    version, environment, application_name,
                                     capture_message_content, response=response)
 
     return wrapper
@@ -56,8 +45,8 @@ def async_agent_run(version, environment, application_name,
 
     async def wrapper(wrapped, instance, args, kwargs):
         response = await wrapped(*args, **kwargs)
-        return common_agent_run(wrapped, instance, args, kwargs, tracer, 
-                                          version, environment, application_name, 
+        return common_agent_run(wrapped, instance, args, kwargs, tracer,
+                                          version, environment, application_name,
                                           capture_message_content, response=response)
 
     return wrapper

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
@@ -2,7 +2,6 @@
 Pydantic AI OpenTelemetry instrumentation utility functions
 """
 import logging
-import time
 from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
 from opentelemetry.trace import Status, StatusCode, SpanKind
 from openlit.__helpers import (

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
@@ -1,22 +1,37 @@
 """
 Pydantic AI OpenTelemetry instrumentation utility functions
 """
+import logging
 import time
-
 from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
-from opentelemetry.trace import Status, StatusCode
-
+from opentelemetry.trace import Status, StatusCode, SpanKind
 from openlit.__helpers import (
-    calculate_ttft,
-    response_as_dict,
-    calculate_tbt,
-    extract_and_format_input,
-    get_chat_model_cost,
-    create_metrics_attributes,
-    otel_event,
-    concatenate_all_contents
+    handle_exception
 )
 from openlit.semcov import SemanticConvention
+
+# Initialize logger for logging potential issues and operations
+logger = logging.getLogger(__name__)
+
+def set_span_attributes(span, version, operation_name, environment,
+        application_name, server_address, server_port, request_model, agent_name):
+    """
+    Set common attributes for the span.
+    """
+
+    # Set Span attributes (OTel Semconv)
+    span.set_attribute(TELEMETRY_SDK_NAME, 'openlit')
+    span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_name)
+    span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_PYDANTIC_AI)
+    span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
+    span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+    span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+    span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
+
+    # Set Span attributes (Extras)
+    span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
+    span.set_attribute(SERVICE_NAME, application_name)
+    span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
 def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
                          capture_message_content, response):
@@ -51,5 +66,27 @@ def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environme
             logger.error('Error in trace creation: %s', e)
             return response
 
+def common_agent_create(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
+                       capture_message_content, response):
+    server_address, server_port = '127.0.0.1', 80
+    agent_name = kwargs.get("name", "pydantic_agent")
+    span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT} {agent_name}'
+    
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        try:
+            start_time = time.time()
+            end_time = time.time()
+            request_model = args[0] or kwargs.get("model", "google-gla:gemini-1.5-flash")
+            set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+                environment, application_name, server_address, server_port, request_model, agent_name)
+            span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(kwargs.get("system_prompt", "")))
+            span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
 
+            span.set_status(Status(StatusCode.OK))
 
+            return response
+
+        except Exception as e:
+            handle_exception(span, e)
+            logger.error('Error in trace creation: %s', e)
+            return response

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
@@ -1,0 +1,55 @@
+"""
+Pydantic AI OpenTelemetry instrumentation utility functions
+"""
+import time
+
+from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.trace import Status, StatusCode
+
+from openlit.__helpers import (
+    calculate_ttft,
+    response_as_dict,
+    calculate_tbt,
+    extract_and_format_input,
+    get_chat_model_cost,
+    create_metrics_attributes,
+    otel_event,
+    concatenate_all_contents
+)
+from openlit.semcov import SemanticConvention
+
+def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
+                         capture_message_content, response):
+    server_address, server_port = instance.model.base_url, 443
+    agent_name = instance.name or "pydantic_agent"
+    request_model = str(instance.model.model_name)
+    span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK} {agent_name}'
+    
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        try:
+            start_time = time.time()
+            end_time = time.time()
+            set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK,
+                                environment, application_name, server_address, server_port, request_model, agent_name)
+            span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(instance._system_prompts))
+            span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, request_model)
+
+            if capture_message_content:
+                span.add_event(
+                    name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
+                    attributes={
+                        SemanticConvention.GEN_AI_CONTENT_COMPLETION: response.output,
+                    },
+                )
+
+            span.set_status(Status(StatusCode.OK))
+
+            return response
+
+        except Exception as e:
+            handle_exception(span, e)
+            logger.error('Error in trace creation: %s', e)
+            return response
+
+
+

--- a/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/pydantic_ai/utils.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def set_span_attributes(span, version, operation_name, environment,
         application_name, server_address, server_port, request_model, agent_name):
     """
-    Set common attributes for the span.
+    Set common OpenTelemetry span attributes for Pydantic AI operations.
     """
 
     # Set Span attributes (OTel Semconv)
@@ -35,15 +35,17 @@ def set_span_attributes(span, version, operation_name, environment,
 
 def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
                          capture_message_content, response):
+    """
+    Handle telemetry for Pydantic AI agent run operations.
+    """
+
     server_address, server_port = instance.model.base_url, 443
     agent_name = instance.name or "pydantic_agent"
     request_model = str(instance.model.model_name)
     span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK} {agent_name}'
-    
+
     with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
         try:
-            start_time = time.time()
-            end_time = time.time()
             set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK,
                                 environment, application_name, server_address, server_port, request_model, agent_name)
             span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, str(instance._system_prompts))
@@ -68,14 +70,16 @@ def common_agent_run(wrapped, instance, args, kwargs, tracer, version, environme
 
 def common_agent_create(wrapped, instance, args, kwargs, tracer, version, environment, application_name,
                        capture_message_content, response):
+    """
+    Handle telemetry for Pydantic AI agent creation operations.
+    """
+
     server_address, server_port = '127.0.0.1', 80
     agent_name = kwargs.get("name", "pydantic_agent")
     span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT} {agent_name}'
-    
+
     with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
         try:
-            start_time = time.time()
-            end_time = time.time()
             request_model = args[0] or kwargs.get("model", "google-gla:gemini-1.5-flash")
             set_span_attributes(span, version, SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
                 environment, application_name, server_address, server_port, request_model, agent_name)

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -130,6 +130,7 @@ class SemanticConvention:
     GEN_AI_SYSTEM_FIRECRAWL = "firecrawl"
     GEN_AI_SYSTEM_LETTA = "letta"
     GEN_AI_SYSTEM_TOGETHER = "together"
+    GEN_AI_SYSTEM_PYDANTIC_AI = "pydantic_ai"
 
     # GenAI Request Attributes (Extra)
     GEN_AI_REQUEST_IS_STREAM = "gen_ai.request.is_stream"


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Add support for instrumenting Pydantic AI by registering a new PydanticAIInstrumentor and related modules, and harden existing OpenAI telemetry by converting span attributes to strings and handling missing finish reasons.

New Features:
- Introduce Pydantic AI instrumentation with auto-instrumentor, wrappers for agent creation and execution, and utility helpers

Enhancements:
- Cast various OpenAI span attribute values to strings to ensure consistent telemetry data types
- Add try/except fallback for OpenAI streaming finish_reason to default to "stop" when missing