### PR TITLE
Fixed potential bug in async_chat_completions function

### DIFF
--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -521,7 +521,8 @@ def async_chat_completions(version, environment, application_name,
                         self._llmresponse += content
                 self._response_id = chunked.get('id')
                 self._response_model = chunked.get('model')
-                self._finish_reason = chunked.get('choices')[0].get('finish_reason')
+                if len(chunked.get('choices')) > 0:
+                    self._finish_reason = chunked.get('choices')[0].get('finish_reason')
                 self._openai_response_service_tier = chunked.get('service_tier') or 'auto'
                 self._openai_system_fingerprint = chunked.get('system_fingerprint')
                 return chunk


### PR DESCRIPTION
…length of the choices array is checked before accessing it.

### Overview:
<!-- What does this PR do? Link issues here -->
Fix a bug.

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [ ] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [ ] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Check that chunked.get('choices') is non-empty before accessing its first element in the async_openai __anext__ method to avoid errors.