### PR TITLE
[Feat]: Refactor vLLM OpenTelemetry Instrumentation

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.1"
+version = "1.34.2"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/async_google_ai_studio.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/async_google_ai_studio.py
@@ -59,14 +59,12 @@ def async_generate(version, environment, application_name,
                         version=version,
                 )
 
-                return response
-
             except Exception as e:
                 handle_exception(span, e)
                 logger.error("Error in trace creation: %s", e)
 
-                # Return original response
-                return response
+            # Return original response
+            return response
 
     return wrapper
 

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/google_ai_studio.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/google_ai_studio.py
@@ -59,14 +59,12 @@ def generate(version, environment, application_name,
                         version=version,
                 )
 
-                return response
-
             except Exception as e:
                 handle_exception(span, e)
                 logger.error("Error in trace creation: %s", e)
 
-                # Return original response
-                return response
+            # Return original response
+            return response
 
     return wrapper
 

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -2,10 +2,8 @@
 Google AI Studio OpenTelemetry instrumentation utility functions
 """
 import time
-
 from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
 from opentelemetry.trace import Status, StatusCode
-
 from openlit.__helpers import (
     calculate_ttft,
     response_as_dict,

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -117,6 +117,7 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     scope._span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_GEMINI)
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
     scope._span.set_attribute(SemanticConvention.SERVER_PORT, scope._server_port)
+    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS, scope._server_address)
 
     inference_config = scope._kwargs.get('config', {})
 
@@ -142,7 +143,6 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, scope._input_tokens)
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, scope._output_tokens)
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_REASONING_TOKENS, scope._reasoning_tokens)
-    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS, scope._server_address)
 
     scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
                               'text' if isinstance(scope._llmresponse, str) else 'json')

--- a/sdk/python/src/openlit/instrumentation/vllm/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/__init__.py
@@ -32,7 +32,7 @@ class VLLMInstrumentor(BaseInstrumentor):
 
         # sync chat
         wrap_function_wrapper(
-            "vllm.entrypoints.llm",
+            "vllmm.entrypoints.llm",
             "LLM.generate",
             generate(version, environment, application_name,
                   tracer, pricing_info, capture_message_content, metrics, disable_metrics),

--- a/sdk/python/src/openlit/instrumentation/vllm/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/__init__.py
@@ -32,7 +32,7 @@ class VLLMInstrumentor(BaseInstrumentor):
 
         # sync chat
         wrap_function_wrapper(
-            "vllmm.entrypoints.llm",
+            "vllm.entrypoints.llm",
             "LLM.generate",
             generate(version, environment, application_name,
                   tracer, pricing_info, capture_message_content, metrics, disable_metrics),

--- a/sdk/python/src/openlit/instrumentation/vllm/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/__init__.py
@@ -32,7 +32,7 @@ class VLLMInstrumentor(BaseInstrumentor):
 
         # sync chat
         wrap_function_wrapper(
-            "vllm",
+            "vllm.entrypoints.llm",
             "LLM.generate",
             generate(version, environment, application_name,
                   tracer, pricing_info, capture_message_content, metrics, disable_metrics),

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -2,26 +2,22 @@
 Utility functions for vLLM instrumentation.
 """
 
-import logging
 import time
-from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.trace import Status, StatusCode
 from openlit.__helpers import (
+    calculate_tbt,
     get_chat_model_cost,
     general_tokens,
     create_metrics_attributes,
-    set_server_address_and_port
 )
 from openlit.semcov import SemanticConvention
-
-# Initialize logger for logging potential issues and operations
-logger = logging.getLogger(__name__)
 
 def get_inference_config(args, kwargs):
     """
     Safely extract inference configuration from args or kwargs.
-    Returns None if not found.
     """
+
     if 'sampling_params' in kwargs:
         return kwargs['sampling_params']
     if len(args) > 1:
@@ -33,6 +29,7 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     """
     Process chat request and generate Telemetry
     """
+
     scope._end_time = time.time()
     if len(scope._timestamps) > 1:
         scope._tbt = calculate_tbt(scope._timestamps)
@@ -62,7 +59,7 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
             value = getattr(inference_config, key, None)
             if value is not None:
                 scope._span.set_attribute(attribute, value)
-    
+
     scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, scope._request_model)
     scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "text")
 
@@ -140,7 +137,7 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
             input_tokens + output_tokens, metrics_attributes)
 
 def process_chat_response(instance, response, request_model, pricing_info, server_port, server_address,
-    environment, application_name, metrics, start_time, span, args, kwargs, 
+    environment, application_name, metrics, start_time, span, args, kwargs,
     capture_message_content=False, disable_metrics=False, version="1.0.0"):
     """
     Process chat request and generate Telemetry
@@ -161,4 +158,4 @@ def process_chat_response(instance, response, request_model, pricing_info, serve
     common_chat_logic(self, pricing_info, environment, application_name, metrics,
         capture_message_content, disable_metrics, version, is_stream=False)
 
-    return response 
+    return response

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -17,6 +17,17 @@ from openlit.semcov import SemanticConvention
 # Initialize logger for logging potential issues and operations
 logger = logging.getLogger(__name__)
 
+def get_inference_config(args, kwargs):
+    """
+    Safely extract inference configuration from args or kwargs.
+    Returns None if not found.
+    """
+    if 'sampling_params' in kwargs:
+        return kwargs['sampling_params']
+    if len(args) > 1:
+        return args[1]
+    return None
+
 def common_chat_logic(scope, pricing_info, environment, application_name, metrics,
     capture_message_content, disable_metrics, version, is_stream):
     """
@@ -28,32 +39,40 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
 
     # Set base span attributes
     scope._span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SYSTEM,
-                        SemanticConvention.GEN_AI_SYSTEM_VLLM)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_OPERATION,
-                        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
-    scope._span.set_attribute(SemanticConvention.SERVER_PORT,
-                        scope._server_port)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
-                        scope._request_model)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
-                        scope._request_model)
-    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS,
-                        scope._server_address)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
-                        "text")
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_VLLM)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, scope._request_model)
+    scope._span.set_attribute(SemanticConvention.SERVER_PORT, scope._server_port)
+    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS, scope._server_address)
+
+    # Handle inference configuration
+    inference_config = get_inference_config(scope._args, scope._kwargs)
+    if inference_config:
+        attributes = [
+            (SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, 'frequency_penalty'),
+            (SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, 'max_tokens'),
+            (SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, 'presence_penalty'),
+            (SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, 'stop_sequences'),
+            (SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, 'temperature'),
+            (SemanticConvention.GEN_AI_REQUEST_TOP_P, 'top_p'),
+            (SemanticConvention.GEN_AI_REQUEST_TOP_K, 'top_k'),
+        ]
+
+        for attribute, key in attributes:
+            value = getattr(inference_config, key, None)
+            if value is not None:
+                scope._span.set_attribute(attribute, value)
+    
+    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, scope._request_model)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "text")
 
     # Set base span attributes (Extras)
-    scope._span.set_attribute(DEPLOYMENT_ENVIRONMENT,
-                         environment)
-    scope._span.set_attribute(SERVICE_NAME,
-                        application_name)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
-                        is_stream)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT,
-                        scope._end_time - scope._start_time)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION,
-                        version)
+    scope._span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
+    scope._span.set_attribute(SERVICE_NAME, application_name)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, is_stream)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TBT, scope._tbt)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT, scope._ttft)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
     input_tokens = 0
     output_tokens = 0
@@ -90,14 +109,12 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
                         input_tokens)
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
                         output_tokens)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
+    scope._span.set_attribute(SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE,
                         input_tokens + output_tokens)
 
     # Calculate cost of the operation
-    cost = get_chat_model_cost(scope._request_model, pricing_info,
-                                input_tokens, output_tokens)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST,
-                        cost)
+    cost = get_chat_model_cost(scope._request_model, pricing_info, input_tokens, output_tokens)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -137,10 +154,13 @@ def process_chat_response(instance, response, request_model, pricing_info, serve
     self._response = response
     self._start_time = start_time
     self._span = span
+    self._ttft, self._tbt = self._end_time - self._start_time, 0
     self._server_address = server_address
     self._server_port = server_port
     self._request_model = request_model
     self._timestamps = []
+    self._args = args
+    self._kwargs = kwargs
 
     common_chat_logic(self, pricing_info, environment, application_name, metrics,
         capture_message_content, disable_metrics, version, is_stream=False)

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -60,25 +60,30 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     cost = 0
 
     if capture_message_content:
-        prompt_attributes = {}
-        completion_attributes = {}
+        prompt = ""
+        completion = ""
 
-        for i, output in enumerate(scope._response):
-            prompt_attributes[f"{SemanticConvention.GEN_AI_CONTENT_PROMPT}.{i}"] = output.prompt
-            completion_attributes[f"{SemanticConvention.GEN_AI_CONTENT_COMPLETION}.{i}"] = output.outputs[0].text
+        for output in scope._response:
+            prompt += output.prompt + "\n"
+            if output.outputs and len(output.outputs) > 0:
+                completion += output.outputs[0].text + "\n"
             input_tokens += general_tokens(output.prompt)
             output_tokens += general_tokens(output.outputs[0].text)
 
-        # Add a single event for all prompts
+        # Add a single event for prompt
         scope._span.add_event(
             name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes=prompt_attributes,
+            attributes={
+                SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
+            },
         )
 
-        # Add a single event for all completions
+        # Add a single event for completion
         scope._span.add_event(
             name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes=completion_attributes,
+            attributes={
+                SemanticConvention.GEN_AI_CONTENT_COMPLETION: completion,
+            },
         )
 
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -153,6 +153,7 @@ def process_chat_response(instance, response, request_model, pricing_info, serve
     self = type('GenericScope', (), {})()
     self._response = response
     self._start_time = start_time
+    self._end_time = time.time()
     self._span = span
     self._ttft, self._tbt = self._end_time - self._start_time, 0
     self._server_address = server_address

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -119,7 +119,7 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     scope._span.set_status(Status(StatusCode.OK))
 
     if disable_metrics is False:
-        attributes = create_metrics_attributes(
+        metrics_attributes = create_metrics_attributes(
             service_name=application_name,
             deployment_environment=environment,
             operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
@@ -129,20 +129,15 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
             server_port=scope._server_port,
             response_model=scope._request_model,
         )
-
-        metrics["genai_client_usage_tokens"].record(
-            input_tokens + output_tokens, attributes
-        )
-        metrics["genai_client_operation_duration"].record(
-            scope._end_time - scope._start_time, attributes
-        )
-        metrics["genai_server_ttft"].record(
-            scope._end_time - scope._start_time, attributes
-        )
-        metrics["genai_requests"].add(1, attributes)
-        metrics["genai_completion_tokens"].add(output_tokens, attributes)
-        metrics["genai_prompt_tokens"].add(input_tokens, attributes)
-        metrics["genai_cost"].record(cost, attributes)
+        metrics['genai_client_operation_duration'].record(scope._end_time - scope._start_time, metrics_attributes)
+        metrics['genai_server_tbt'].record(scope._tbt, metrics_attributes)
+        metrics['genai_server_ttft'].record(scope._ttft, metrics_attributes)
+        metrics['genai_requests'].add(1, metrics_attributes)
+        metrics['genai_completion_tokens'].add(scope._output_tokens, metrics_attributes)
+        metrics['genai_prompt_tokens'].add(scope._input_tokens, metrics_attributes)
+        metrics['genai_cost'].record(cost, metrics_attributes)
+        metrics['genai_client_usage_tokens'].record(
+            scope._input_tokens + scope._output_tokens, metrics_attributes)
 
 def process_chat_response(instance, response, request_model, pricing_info, server_port, server_address,
     environment, application_name, metrics, start_time, span, args, kwargs, 

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -133,11 +133,11 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
         metrics['genai_server_tbt'].record(scope._tbt, metrics_attributes)
         metrics['genai_server_ttft'].record(scope._ttft, metrics_attributes)
         metrics['genai_requests'].add(1, metrics_attributes)
-        metrics['genai_completion_tokens'].add(scope._output_tokens, metrics_attributes)
-        metrics['genai_prompt_tokens'].add(scope._input_tokens, metrics_attributes)
+        metrics['genai_completion_tokens'].add(output_tokens, metrics_attributes)
+        metrics['genai_prompt_tokens'].add(input_tokens, metrics_attributes)
         metrics['genai_cost'].record(cost, metrics_attributes)
         metrics['genai_client_usage_tokens'].record(
-            scope._input_tokens + scope._output_tokens, metrics_attributes)
+            input_tokens + output_tokens, metrics_attributes)
 
 def process_chat_response(instance, response, request_model, pricing_info, server_port, server_address,
     environment, application_name, metrics, start_time, span, args, kwargs, 

--- a/sdk/python/src/openlit/instrumentation/vllm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/utils.py
@@ -1,0 +1,143 @@
+"""
+Utility functions for vLLM instrumentation.
+"""
+
+import logging
+import time
+from opentelemetry.trace import SpanKind, Status, StatusCode
+from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from openlit.__helpers import (
+    get_chat_model_cost,
+    general_tokens,
+    create_metrics_attributes,
+    set_server_address_and_port
+)
+from openlit.semcov import SemanticConvention
+
+# Initialize logger for logging potential issues and operations
+logger = logging.getLogger(__name__)
+
+def common_chat_logic(scope, pricing_info, environment, application_name, metrics,
+    capture_message_content, disable_metrics, version, is_stream):
+    """
+    Process chat request and generate Telemetry
+    """
+    scope._end_time = time.time()
+    if len(scope._timestamps) > 1:
+        scope._tbt = calculate_tbt(scope._timestamps)
+
+    # Set base span attributes
+    scope._span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SYSTEM,
+                        SemanticConvention.GEN_AI_SYSTEM_VLLM)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OPERATION,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
+    scope._span.set_attribute(SemanticConvention.SERVER_PORT,
+                        scope._server_port)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
+                        scope._request_model)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
+                        scope._request_model)
+    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS,
+                        scope._server_address)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
+                        "text")
+
+    # Set base span attributes (Extras)
+    scope._span.set_attribute(DEPLOYMENT_ENVIRONMENT,
+                         environment)
+    scope._span.set_attribute(SERVICE_NAME,
+                        application_name)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
+                        is_stream)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT,
+                        scope._end_time - scope._start_time)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION,
+                        version)
+
+    input_tokens = 0
+    output_tokens = 0
+    cost = 0
+
+    if capture_message_content:
+        prompt_attributes = {}
+        completion_attributes = {}
+
+        for i, output in enumerate(scope._response):
+            prompt_attributes[f"{SemanticConvention.GEN_AI_CONTENT_PROMPT}.{i}"] = output.prompt
+            completion_attributes[f"{SemanticConvention.GEN_AI_CONTENT_COMPLETION}.{i}"] = output.outputs[0].text
+            input_tokens += general_tokens(output.prompt)
+            output_tokens += general_tokens(output.outputs[0].text)
+
+        # Add a single event for all prompts
+        scope._span.add_event(
+            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
+            attributes=prompt_attributes,
+        )
+
+        # Add a single event for all completions
+        scope._span.add_event(
+            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
+            attributes=completion_attributes,
+        )
+
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
+                        input_tokens)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
+                        output_tokens)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
+                        input_tokens + output_tokens)
+
+    # Calculate cost of the operation
+    cost = get_chat_model_cost(scope._request_model, pricing_info,
+                                input_tokens, output_tokens)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST,
+                        cost)
+
+    scope._span.set_status(Status(StatusCode.OK))
+
+    if disable_metrics is False:
+        attributes = create_metrics_attributes(
+            service_name=application_name,
+            deployment_environment=environment,
+            operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+            system=SemanticConvention.GEN_AI_SYSTEM_VLLM,
+            request_model=scope._request_model,
+            server_address=scope._server_address,
+            server_port=scope._server_port,
+            response_model=scope._request_model,
+        )
+
+        metrics["genai_client_usage_tokens"].record(
+            input_tokens + output_tokens, attributes
+        )
+        metrics["genai_client_operation_duration"].record(
+            scope._end_time - scope._start_time, attributes
+        )
+        metrics["genai_server_ttft"].record(
+            scope._end_time - scope._start_time, attributes
+        )
+        metrics["genai_requests"].add(1, attributes)
+        metrics["genai_completion_tokens"].add(output_tokens, attributes)
+        metrics["genai_prompt_tokens"].add(input_tokens, attributes)
+        metrics["genai_cost"].record(cost, attributes)
+
+def process_chat_response(instance, response, request_model, pricing_info, server_port, server_address,
+    environment, application_name, metrics, start_time, span, args, kwargs, 
+    capture_message_content=False, disable_metrics=False, version="1.0.0"):
+    """
+    Process chat request and generate Telemetry
+    """
+    self = type('GenericScope', (), {})()
+    self._response = response
+    self._start_time = start_time
+    self._span = span
+    self._server_address = server_address
+    self._server_port = server_port
+    self._request_model = request_model
+    self._timestamps = []
+
+    common_chat_logic(self, pricing_info, environment, application_name, metrics,
+        capture_message_content, disable_metrics, version, is_stream=False)
+
+    return response 

--- a/sdk/python/src/openlit/instrumentation/vllm/vllm.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/vllm.py
@@ -32,7 +32,7 @@ def generate(version, environment, application_name,
         request_model = instance.llm_engine.model_config.model or "facebook/opt-125m"
 
         span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
-        print("hellloooooo")
+
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
             response = wrapped(*args, **kwargs)

--- a/sdk/python/src/openlit/instrumentation/vllm/vllm.py
+++ b/sdk/python/src/openlit/instrumentation/vllm/vllm.py
@@ -4,14 +4,13 @@ Module for monitoring vLLM API calls.
 
 import logging
 import time
-from opentelemetry.trace import SpanKind, Status, StatusCode
-from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.trace import SpanKind
 from openlit.__helpers import (
-    get_chat_model_cost,
     handle_exception,
-    general_tokens,
-    create_metrics_attributes,
     set_server_address_and_port
+)
+from openlit.instrumentation.vllm.utils import (
+    process_chat_response
 )
 from openlit.semcov import SemanticConvention
 
@@ -19,155 +18,48 @@ from openlit.semcov import SemanticConvention
 logger = logging.getLogger(__name__)
 
 def generate(version, environment, application_name,
-                     tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+    tracer, pricing_info, capture_message_content, metrics, disable_metrics):
     """
-    Generates a telemetry wrapper for generate to collect metrics.
-
-    Args:
-        version: Version of the monitoring package.
-        environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the vLLM API.
-        tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of vLLM usage.
-        capture_message_content: Flag indicating whether to trace the actual content.
-
-    Returns:
-        A function that wraps the generate method to add telemetry.
+    Generates a telemetry wrapper for GenAI function call
     """
 
     def wrapper(wrapped, instance, args, kwargs):
         """
-        Wraps the 'generate' API call to add telemetry.
-        
-        This collects metrics such as execution time, cost, and token usage, and handles errors
-        gracefully, adding details to the trace for observability.
-
-        Args:
-            wrapped: The original 'generate' method to be wrapped.
-            instance: The instance of the class where the original method is defined.
-            args: Positional arguments for the 'generate' method.
-            kwargs: Keyword arguments for the 'generate' method.
-
-        Returns:
-            The response from the original 'generate' method.
+        Wraps the GenAI function call.
         """
 
-        server_address, server_port = set_server_address_and_port(instance, "api.cohere.com", 443)
+        server_address, server_port = set_server_address_and_port(instance, "http://127.0.0.1", 443)
         request_model = instance.llm_engine.model_config.model or "facebook/opt-125m"
 
         span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
-
-        # pylint: disable=line-too-long
-        with tracer.start_as_current_span(span_name, kind= SpanKind.CLIENT) as span:
+        print("hellloooooo")
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
             response = wrapped(*args, **kwargs)
-            end_time = time.time()
 
             try:
-                # Set base span attribues
-                span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
-                span.set_attribute(SemanticConvention.GEN_AI_SYSTEM,
-                                    SemanticConvention.GEN_AI_SYSTEM_VLLM)
-                span.set_attribute(SemanticConvention.GEN_AI_OPERATION,
-                                    SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
-                span.set_attribute(SemanticConvention.SERVER_PORT,
-                                    server_port)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
-                                    request_model)
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
-                                    request_model)
-                span.set_attribute(SemanticConvention.SERVER_ADDRESS,
-                                    server_address)
-                span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
-                                    "text")
-
-                # Set base span attribues (Extras)
-                span.set_attribute(DEPLOYMENT_ENVIRONMENT,
-                                     environment)
-                span.set_attribute(SERVICE_NAME,
-                                    application_name)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
-                                    False)
-                span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT,
-                                    end_time - start_time)
-                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION,
-                                    version)
-
-                input_tokens = 0
-                output_tokens = 0
-                cost = 0
-
-                if capture_message_content:
-                    prompt_attributes = {}
-                    completion_attributes = {}
-
-                    for i, output in enumerate(response):
-                        prompt_attributes[f"{SemanticConvention.GEN_AI_CONTENT_PROMPT}.{i}"] = output.prompt
-                        completion_attributes[f"{SemanticConvention.GEN_AI_CONTENT_COMPLETION}.{i}"] = output.outputs[0].text
-                        input_tokens += general_tokens(output.prompt)
-                        output_tokens += general_tokens(output.outputs[0].text)
-
-                    # Add a single event for all prompts
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-                        attributes=prompt_attributes,
-                    )
-
-                    # Add a single event for all completions
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-                        attributes=completion_attributes,
-                    )
-
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
-                                    input_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
-                                    output_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
-                                    input_tokens + output_tokens)
-
-                # Calculate cost of the operation
-                cost = get_chat_model_cost(request_model, pricing_info,
-                                            input_tokens, output_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST,
-                                    cost)
-
-                span.set_status(Status(StatusCode.OK))
-
-                if disable_metrics is False:
-                    attributes = create_metrics_attributes(
-                        service_name=application_name,
-                        deployment_environment=environment,
-                        operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-                        system=SemanticConvention.GEN_AI_SYSTEM_VLLM,
-                        request_model=request_model,
-                        server_address=server_address,
-                        server_port=server_port,
-                        response_model=request_model,
-                    )
-
-                    metrics["genai_client_usage_tokens"].record(
-                        input_tokens + output_tokens, attributes
-                    )
-                    metrics["genai_client_operation_duration"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_server_ttft"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_requests"].add(1, attributes)
-                    metrics["genai_completion_tokens"].add(output_tokens, attributes)
-                    metrics["genai_prompt_tokens"].add(input_tokens, attributes)
-                    metrics["genai_cost"].record(cost, attributes)
-
-                # Return original response
-                return response
-
+                response = process_chat_response(
+                    instance=instance,
+                    response=response,
+                    request_model=request_model,
+                    pricing_info=pricing_info,
+                    server_port=server_port,
+                    server_address=server_address,
+                    environment=environment,
+                    application_name=application_name,
+                    metrics=metrics,
+                    start_time=start_time,
+                    span=span,
+                    args=args,
+                    kwargs=kwargs,
+                    capture_message_content=capture_message_content,
+                    disable_metrics=disable_metrics,
+                    version=version,
+                )
             except Exception as e:
                 handle_exception(span, e)
                 logger.error("Error in trace creation: %s", e)
 
-                # Return original response
-                return response
+            return response
 
     return wrapper


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->

related #758 

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Refactor vLLM OpenTelemetry instrumentation to move span and metric logic into shared utility functions, simplify wrapper implementations, and ensure consistent server address attributes.

Enhancements:
- Extract vLLM telemetry logic into a new utils module to centralize span attribute setup and metric processing
- Simplify the generate wrapper by delegating response processing to process_chat_response and common_chat_logic utilities
- Update default vLLM server address to localhost and correct the wrap path for LLM.generate to use vllm.entrypoints.llm
- Add SERVER_ADDRESS attribute to Google AI Studio spans and streamline response return formatting

## Summary by Sourcery

Refactor OpenTelemetry instrumentation for vLLM by extracting shared telemetry logic into utilities, simplifying wrappers, ensuring consistent server address configuration, and update SDK version.

Enhancements:
- Centralize vLLM span and metric logic into a new utils module
- Simplify the LLM.generate wrapper to use process_chat_response utility
- Update vLLM instrumentation to wrap vllm.entrypoints.llm and default to localhost server address
- Add SERVER_ADDRESS attribute to Google AI Studio spans and streamline response returns

Build:
- Bump Python SDK version to 1.34.2