### PR TITLE
[feat]: add chat completion parse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 logs/
 
 .vscode/
+.idea/

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.2"
+version = "1.34.3"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/openai/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/openai/__init__.py
@@ -5,9 +5,10 @@ import importlib.metadata
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from wrapt import wrap_function_wrapper
 
-from openlit.instrumentation.openai.openai import chat_completions, embedding, responses
+from openlit.instrumentation.openai.openai import chat_completions, embedding, responses, chat_completions_parse
 from openlit.instrumentation.openai.openai import image_generate, image_variatons, audio_create
-from openlit.instrumentation.openai.async_openai import async_chat_completions, async_embedding
+from openlit.instrumentation.openai.async_openai import (async_chat_completions, async_embedding,
+                                                         async_chat_completions_parse)
 from openlit.instrumentation.openai.async_openai import async_image_generate, async_image_variatons
 from openlit.instrumentation.openai.async_openai import async_audio_create, async_responses
 
@@ -125,6 +126,20 @@ class OpenAIInstrumentor(BaseInstrumentor):
             async_audio_create(version, environment, application_name,
                                tracer, pricing_info, capture_message_content,
                                metrics, disable_metrics),
+        )
+
+        wrap_function_wrapper(
+            "openai.resources.beta.chat.completions",
+            "Completions.parse",
+            chat_completions_parse(version, environment, application_name, tracer, pricing_info,
+                                   capture_message_content, metrics, disable_metrics),
+        )
+
+        wrap_function_wrapper(
+            "openai.resources.beta.chat.completions",
+            "AsyncCompletions.parse",
+            async_chat_completions_parse(version, environment, application_name, tracer, pricing_info,
+                                         capture_message_content, metrics, disable_metrics),
         )
 
     @staticmethod

--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -982,7 +982,6 @@ def async_chat_completions_parse(version, environment, application_name, tracer,
                 span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, input_tokens + output_tokens)
                 span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
                 span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT, end_time - start_time)
-                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
                 if capture_message_content:
                     span.add_event(

--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -882,6 +882,168 @@ def async_chat_completions(version, environment, application_name,
 
     return wrapper
 
+def async_chat_completions_parse(version, environment, application_name, tracer, pricing_info, capture_message_content,
+                                 metrics, disable_metrics):
+    """
+    Generates a telemetry wrapper for chat completions parse to collect metrics.
+
+    Args:
+        version: Version of the monitoring package.
+        environment: Deployment environment (e.g., production, staging).
+        application_name: Name of the application using the OpenAI API.
+        tracer: OpenTelemetry tracer for creating spans.
+        pricing_info: Information used for calculating the cost of OpenAI usage.
+        capture_message_content: Flag indicating whether to trace the actual content.
+
+    Returns:
+        A function that wraps the chat completions parse method to add telemetry.
+    """
+
+    async def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the 'chat.completions.parse' API call to add telemetry.
+
+        This collects metrics such as execution time, cost, and token usage, and handles errors
+        gracefully, adding details to the trace for observability.
+
+        Args:
+            wrapped: The original 'chat.completions' method to be wrapped.
+            instance: The instance of the class where the original method is defined.
+            args: Positional arguments for the 'chat.completions' method.
+            kwargs: Keyword arguments for the 'chat.completions' method.
+
+        Returns:
+            The response from the original 'chat.completions.parse' method.
+        """
+        server_address, server_port = set_server_address_and_port(instance, "api.openai.com", 443)
+        request_model = kwargs.get("model", "gpt-4o")
+        span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
+            try:
+                # Execute the original 'parse' method
+                response = await wrapped(*args, **kwargs)
+                end_time = time.time()
+
+                response_dict = response_as_dict(response)
+
+                # Format 'messages' from kwargs to calculate input tokens
+                message_prompt = kwargs.get("messages", "")
+                formatted_messages = []
+                for message in message_prompt:
+                    role = message.get("role")
+                    content = message.get("content")
+                    if content:
+                        formatted_messages.append(f"{role}: {content}")
+                prompt = "\n".join(formatted_messages)
+
+                input_tokens = response_dict.get('usage').get('prompt_tokens')
+                output_tokens = response_dict.get('usage').get('completion_tokens')
+
+                # Calculate cost
+                cost = get_chat_model_cost(request_model,
+                                           pricing_info, input_tokens,
+                                           output_tokens)
+
+                # Set base span attribues (OTel Semconv)
+                span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
+                span.set_attribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
+                span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_OPENAI)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED, str(kwargs.get("seed", "")))
+                span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+                                   str(kwargs.get("frequency_penalty", 0.0)))
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, str(kwargs.get("max_tokens", -1)))
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
+                                   str(kwargs.get("presence_penalty", 0.0)))
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, str(kwargs.get("stop", [])))
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, str(kwargs.get("temperature", 1.0)))
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P, str(kwargs.get("top_p", 1.0)))
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID, response_dict.get("id"))
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, response_dict.get('model'))
+                span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
+                span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, output_tokens)
+                span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SERVICE_TIER,
+                                   str(kwargs.get("service_tier", "auto")))
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER,
+                                   response_dict.get('service_tier', 'auto'))
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT,
+                                   str(response_dict.get('system_fingerprint', '')))
+
+                # Set base span attribues (Extras)
+                span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
+                span.set_attribute(SERVICE_NAME, application_name)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_USER, kwargs.get("user", ""))
+                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, False)
+                span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, input_tokens + output_tokens)
+                span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
+                span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT, end_time - start_time)
+                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+
+                if capture_message_content:
+                    span.add_event(
+                        name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
+                        attributes={SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt},
+                    )
+
+                for i in range(kwargs.get('n', 1)):
+                    span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
+                                       [response_dict.get('choices')[i].get('finish_reason')])
+                    if capture_message_content:
+                        span.add_event(
+                            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
+                            attributes={
+                                # pylint: disable=line-too-long
+                                SemanticConvention.GEN_AI_CONTENT_COMPLETION: str(
+                                    response_dict.get('choices')[i].get('message').get('content')),
+                            },
+                        )
+                    if kwargs.get('tools'):
+                        span.set_attribute(SemanticConvention.GEN_AI_TOOL_CALLS,
+                                           str(response_dict.get('choices')[i].get('message').get('tool_calls')))
+
+                    if isinstance(response_dict.get('choices')[i].get('message').get('content'), str):
+                        span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
+                                           "text")
+                    elif response_dict.get('choices')[i].get('message').get('content') is not None:
+                        span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
+                                           "json")
+
+                span.set_status(Status(StatusCode.OK))
+
+                if not disable_metrics:
+                    attributes = create_metrics_attributes(
+                        service_name=application_name,
+                        deployment_environment=environment,
+                        operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                        system=SemanticConvention.GEN_AI_SYSTEM_OPENAI,
+                        request_model=request_model,
+                        server_address=server_address,
+                        server_port=server_port,
+                        response_model=response_dict.get('model'),
+                    )
+                    metrics["genai_client_usage_tokens"].record(input_tokens + output_tokens, attributes)
+                    metrics["genai_client_operation_duration"].record(end_time - start_time, attributes)
+                    metrics["genai_server_ttft"].record( end_time - start_time, attributes)
+                    metrics["genai_requests"].add(1, attributes)
+                    metrics["genai_completion_tokens"].add(output_tokens, attributes)
+                    metrics["genai_prompt_tokens"].add(input_tokens, attributes)
+                    metrics["genai_cost"].record(cost, attributes)
+
+                return response
+
+            except Exception as e:
+                handle_exception(span, e)
+                logger.error("Error in 'parse' trace creation: %s", e)
+                # Re-raise the exception to not interfere with the application flow
+                raise
+
+    return wrapper
+
 def async_embedding(version, environment, application_name,
               tracer, pricing_info, capture_message_content, metrics, disable_metrics):
     """

--- a/sdk/python/src/openlit/instrumentation/openai/openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/openai.py
@@ -982,7 +982,6 @@ def chat_completions_parse(version, environment, application_name, tracer, prici
                 span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, input_tokens + output_tokens)
                 span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
                 span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT, end_time - start_time)
-                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
                 if capture_message_content:
                     span.add_event(

--- a/sdk/python/tests/test_openai.py
+++ b/sdk/python/tests/test_openai.py
@@ -15,7 +15,6 @@ prior to running these tests.
 
 import pytest
 from openai import OpenAI, AsyncOpenAI
-import openlit
 from pydantic import BaseModel
 import openlit
 

--- a/sdk/python/tests/test_openai.py
+++ b/sdk/python/tests/test_openai.py
@@ -16,6 +16,7 @@ prior to running these tests.
 import pytest
 from openai import OpenAI, AsyncOpenAI
 import openlit
+from pydantic import BaseModel
 
 # Initialize synchronous OpenAI client
 sync_client = OpenAI()
@@ -38,6 +39,30 @@ def test_sync_openai_chat_completions():
         model="gpt-3.5-turbo",
         max_tokens=1,
         messages=[{"role": "user", "content": "What is LLM Observability?"}]
+    )
+    assert chat_completions_resp.object == 'chat.completion'
+
+def test_sync_openai_chat_completions_parse():
+    """
+    Tests synchronous chat completions with the 'gpt-3.5-turbo' model.
+
+    Raises:
+        AssertionError: If the chat completion response object is not as expected.
+    """
+
+    class User(BaseModel):
+        """A model to represent a user's details."""
+        name: str
+        age: int
+
+
+    chat_completions_resp = sync_client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "Extract the user's name and age from the following text."},
+            {"role": "user", "content": "The user's name is John Doe and he is 30 years old."},
+        ],
+        response_format=User,  # Pass the Pydantic model as the response format
     )
     assert chat_completions_resp.object == 'chat.completion'
 
@@ -136,6 +161,30 @@ async def test_async_openai_chat_completions():
         model="gpt-3.5-turbo",
         max_tokens=1,
         messages=[{"role": "user", "content": "What is LLM Observability?"}]
+    )
+    assert chat_completions_resp.object == 'chat.completion'
+
+@pytest.mark.asyncio
+async def test_async_openai_chat_completions_parse():
+    """
+    Tests asynchronous chat completions parse with the 'gpt-3.5-turbo' model.
+
+    Raises:
+        AssertionError: If the chat completion parse response object is not as expected.
+    """
+
+    class User(BaseModel):
+        """A model to represent a user's details."""
+        name: str
+        age: int
+
+    chat_completions_resp = await async_client.beta.chat.completions.parse(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "Extract the user's name and age from the following text."},
+            {"role": "user", "content": "The user's name is John Doe and he is 30 years old."},
+        ],
+        response_format=User,  # Pass the Pydantic model as the response format
     )
     assert chat_completions_resp.object == 'chat.completion'
 

--- a/sdk/python/tests/test_openai.py
+++ b/sdk/python/tests/test_openai.py
@@ -17,6 +17,7 @@ import pytest
 from openai import OpenAI, AsyncOpenAI
 import openlit
 from pydantic import BaseModel
+import openlit
 
 # Initialize synchronous OpenAI client
 sync_client = OpenAI()


### PR DESCRIPTION
### Overview:
There is currently no support for parsing method offered in chat completion beta by OpenAI in openlit. This PR aims to add that functionality. Link to issue: https://github.com/openlit/openlit/issues/760


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Add support for parsing OpenAI Chat Completion responses by introducing new "parse" methods in both synchronous and asynchronous clients, instrumenting them with telemetry, and covering them with tests.

New Features:
- Support beta.chat.completions.parse in both sync and async OpenAI clients with Pydantic response_format handling.

Enhancements:
- Introduce OpenTelemetry wrappers for chat.completions.parse to capture metrics such as token usage, cost, execution time, and trace events.
- Register the new parse instrumentation in the OpenAI module initialization.

Tests:
- Add unit tests for synchronous and asynchronous chat.completions.parse to validate the response object.