### PR TITLE
[Feat]: Refactor Reka AI OpenTelemetry Monitoring Instrumentation

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.5"
+version = "1.34.6"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/reka/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/reka/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=useless-return, bad-staticmethod-argument, disable=duplicate-code
 """Initializer of Auto Instrumentation of Reka Functions"""
 
 from typing import Collection
@@ -17,15 +16,15 @@ _instruments = ("reka-api >= 3.2.0",)
 
 class RekaInstrumentor(BaseInstrumentor):
     """
-    An instrumentor for Reka's client library.
+    An instrumentor for Reka client library.
     """
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs):
-        application_name = kwargs.get("application_name", "default_application")
-        environment = kwargs.get("environment", "default_environment")
+        application_name = kwargs.get("application_name", "default")
+        environment = kwargs.get("environment", "default")
         tracer = kwargs.get("tracer")
         metrics = kwargs.get("metrics_dict")
         pricing_info = kwargs.get("pricing_info", {})
@@ -33,7 +32,7 @@ class RekaInstrumentor(BaseInstrumentor):
         disable_metrics = kwargs.get("disable_metrics")
         version = importlib.metadata.version("reka-api")
 
-        # sync chat
+        # Chat completions
         wrap_function_wrapper(
             "reka.chat.client",
             "ChatClient.create",
@@ -41,7 +40,7 @@ class RekaInstrumentor(BaseInstrumentor):
                   tracer, pricing_info, capture_message_content, metrics, disable_metrics),
         )
 
-        # async chat
+        # Chat completions
         wrap_function_wrapper(
             "reka.chat.client",
             "AsyncChatClient.create",
@@ -50,5 +49,4 @@ class RekaInstrumentor(BaseInstrumentor):
         )
 
     def _uninstrument(self, **kwargs):
-        # Proper uninstrumentation logic to revert patched methods
         pass

--- a/sdk/python/src/openlit/instrumentation/reka/async_reka.py
+++ b/sdk/python/src/openlit/instrumentation/reka/async_reka.py
@@ -2,53 +2,26 @@
 Module for monitoring Reka API calls.
 """
 
-import logging
 import time
-from opentelemetry.trace import SpanKind, Status, StatusCode
-from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.trace import SpanKind
 from openlit.__helpers import (
-    get_chat_model_cost,
     handle_exception,
-    create_metrics_attributes,
     set_server_address_and_port
+)
+from openlit.instrumentation.reka.utils import (
+    process_chat_response
 )
 from openlit.semcov import SemanticConvention
 
-# Initialize logger for logging potential issues and operations
-logger = logging.getLogger(__name__)
-
 def async_chat(version, environment, application_name,
-                     tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+    tracer, pricing_info, capture_message_content, metrics, disable_metrics):
     """
-    Generates a telemetry wrapper for chat to collect metrics.
-
-    Args:
-        version: Version of the monitoring package.
-        environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the Reka API.
-        tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of Reka usage.
-        capture_message_content: Flag indicating whether to trace the actual content.
-
-    Returns:
-        A function that wraps the chat method to add telemetry.
+    Generates a telemetry wrapper for GenAI function call
     """
 
     async def wrapper(wrapped, instance, args, kwargs):
         """
-        Wraps the 'chat' API call to add telemetry.
-        
-        This collects metrics such as execution time, cost, and token usage, and handles errors
-        gracefully, adding details to the trace for observability.
-
-        Args:
-            wrapped: The original 'chat' method to be wrapped.
-            instance: The instance of the class where the original method is defined.
-            args: Positional arguments for the 'chat' method.
-            kwargs: Keyword arguments for the 'chat' method.
-
-        Returns:
-            The response from the original 'chat' method.
+        Wraps the GenAI function call.
         """
 
         server_address, server_port = set_server_address_and_port(instance, "api.reka.ai", 443)
@@ -56,142 +29,32 @@ def async_chat(version, environment, application_name,
 
         span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
 
-        with tracer.start_as_current_span(span_name, kind= SpanKind.CLIENT) as span:
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
             response = await wrapped(*args, **kwargs)
-            end_time = time.time()
 
             try:
-                # Format 'messages' into a single string
-                message_prompt = kwargs.get("messages", "")
-                formatted_messages = []
-                for message in message_prompt:
-                    role = message["role"]
-                    content = message["content"]
+                response = process_chat_response(
+                    response=response,
+                    request_model=request_model,
+                    pricing_info=pricing_info,
+                    server_port=server_port,
+                    server_address=server_address,
+                    environment=environment,
+                    application_name=application_name,
+                    metrics=metrics,
+                    start_time=start_time,
+                    span=span,
+                    capture_message_content=capture_message_content,
+                    disable_metrics=disable_metrics,
+                    version=version,
+                    **kwargs
+                )
 
-                    if isinstance(content, list):
-                        content_str = ", ".join(
-                            f'{item["type"]}: {item["text"] if "text" in item else item["image_url"]}'
-                            if "type" in item else f'text: {item["text"]}'
-                            for item in content
-                        )
-                        formatted_messages.append(f"{role}: {content_str}")
-                    else:
-                        formatted_messages.append(f"{role}: {content}")
-                prompt = "\n".join(formatted_messages)
-
-                input_tokens = response.usage.input_tokens
-                output_tokens = response.usage.output_tokens
-
-                # Calculate cost of the operation
-                cost = get_chat_model_cost(request_model,
-                                            pricing_info, input_tokens, output_tokens)
-
-                # Set Span attributes (OTel Semconv)
-                span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
-                span.set_attribute(SemanticConvention.GEN_AI_OPERATION,
-                                    SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
-                span.set_attribute(SemanticConvention.GEN_AI_SYSTEM,
-                                    SemanticConvention.GEN_AI_SYSTEM_REKAAI)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
-                                    request_model)
-                span.set_attribute(SemanticConvention.SERVER_PORT,
-                                    server_port)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                    kwargs.get("seed", ""))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
-                                    kwargs.get("max_tokens", -1))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                    kwargs.get("stop", []))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                    kwargs.get("presence_penalty", 0.0))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                    kwargs.get("temperature", 0.4))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_K,
-                                    kwargs.get("top_k", 1.0))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                    kwargs.get("top_p", 1.0))
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
-                                    [response.responses[0].finish_reason])
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
-                                    response.id)
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
-                                    response.model)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
-                                    input_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
-                                    output_tokens)
-                span.set_attribute(SemanticConvention.SERVER_ADDRESS,
-                                    server_address)
-                span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
-                                    'text')
-
-                # Set Span attributes (Extra)
-                span.set_attribute(DEPLOYMENT_ENVIRONMENT,
-                                    environment)
-                span.set_attribute(SERVICE_NAME,
-                                    application_name)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
-                                    False)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
-                                    input_tokens + output_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST,
-                                    cost)
-                span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT,
-                                    end_time - start_time)
-                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION,
-                                    version)
-
-                if capture_message_content:
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-                        attributes={
-                            SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
-                        },
-                    )
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-                        attributes={
-                            SemanticConvention.GEN_AI_CONTENT_COMPLETION: response.responses[0].message.content,
-                        },
-                    )
-
-                span.set_status(Status(StatusCode.OK))
-
-                if disable_metrics is False:
-                    attributes = create_metrics_attributes(
-                        service_name=application_name,
-                        deployment_environment=environment,
-                        operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-                        system=SemanticConvention.GEN_AI_SYSTEM_REKAAI,
-                        request_model=request_model,
-                        server_address=server_address,
-                        server_port=server_port,
-                        response_model=response.model,
-                    )
-
-                    metrics["genai_client_usage_tokens"].record(
-                        input_tokens + output_tokens, attributes
-                    )
-                    metrics["genai_client_operation_duration"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_server_ttft"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_requests"].add(1, attributes)
-                    metrics["genai_completion_tokens"].add(output_tokens, attributes)
-                    metrics["genai_prompt_tokens"].add(input_tokens, attributes)
-                    metrics["genai_cost"].record(cost, attributes)
-
-                # Return original response
                 return response
 
             except Exception as e:
                 handle_exception(span, e)
-                logger.error("Error in trace creation: %s", e)
-
-                # Return original response
                 return response
 
     return wrapper

--- a/sdk/python/src/openlit/instrumentation/reka/reka.py
+++ b/sdk/python/src/openlit/instrumentation/reka/reka.py
@@ -2,53 +2,26 @@
 Module for monitoring Reka API calls.
 """
 
-import logging
 import time
-from opentelemetry.trace import SpanKind, Status, StatusCode
-from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
+from opentelemetry.trace import SpanKind
 from openlit.__helpers import (
-    get_chat_model_cost,
     handle_exception,
-    create_metrics_attributes,
     set_server_address_and_port
 )
+from openlit.instrumentation.reka.utils import (
+    process_chat_response
+)
 from openlit.semcov import SemanticConvention
-
-# Initialize logger for logging potential issues and operations
-logger = logging.getLogger(__name__)
 
 def chat(version, environment, application_name,
                      tracer, pricing_info, capture_message_content, metrics, disable_metrics):
     """
-    Generates a telemetry wrapper for chat to collect metrics.
-
-    Args:
-        version: Version of the monitoring package.
-        environment: Deployment environment (e.g., production, staging).
-        application_name: Name of the application using the Reka API.
-        tracer: OpenTelemetry tracer for creating spans.
-        pricing_info: Information used for calculating the cost of Reka usage.
-        capture_message_content: Flag indicating whether to trace the actual content.
-
-    Returns:
-        A function that wraps the chat method to add telemetry.
+    Generates a telemetry wrapper for GenAI function call
     """
 
     def wrapper(wrapped, instance, args, kwargs):
         """
-        Wraps the 'chat' API call to add telemetry.
-        
-        This collects metrics such as execution time, cost, and token usage, and handles errors
-        gracefully, adding details to the trace for observability.
-
-        Args:
-            wrapped: The original 'chat' method to be wrapped.
-            instance: The instance of the class where the original method is defined.
-            args: Positional arguments for the 'chat' method.
-            kwargs: Keyword arguments for the 'chat' method.
-
-        Returns:
-            The response from the original 'chat' method.
+        Wraps the GenAI function call.
         """
 
         server_address, server_port = set_server_address_and_port(instance, "api.reka.ai", 443)
@@ -56,142 +29,32 @@ def chat(version, environment, application_name,
 
         span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
 
-        with tracer.start_as_current_span(span_name, kind= SpanKind.CLIENT) as span:
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
             response = wrapped(*args, **kwargs)
-            end_time = time.time()
 
             try:
-                # Format 'messages' into a single string
-                message_prompt = kwargs.get("messages", "")
-                formatted_messages = []
-                for message in message_prompt:
-                    role = message["role"]
-                    content = message["content"]
+                response = process_chat_response(
+                    response=response,
+                    request_model=request_model,
+                    pricing_info=pricing_info,
+                    server_port=server_port,
+                    server_address=server_address,
+                    environment=environment,
+                    application_name=application_name,
+                    metrics=metrics,
+                    start_time=start_time,
+                    span=span,
+                    capture_message_content=capture_message_content,
+                    disable_metrics=disable_metrics,
+                    version=version,
+                    **kwargs
+                )
 
-                    if isinstance(content, list):
-                        content_str = ", ".join(
-                            f'{item["type"]}: {item["text"] if "text" in item else item["image_url"]}'
-                            if "type" in item else f'text: {item["text"]}'
-                            for item in content
-                        )
-                        formatted_messages.append(f"{role}: {content_str}")
-                    else:
-                        formatted_messages.append(f"{role}: {content}")
-                prompt = "\n".join(formatted_messages)
-
-                input_tokens = response.usage.input_tokens
-                output_tokens = response.usage.output_tokens
-
-                # Calculate cost of the operation
-                cost = get_chat_model_cost(request_model,
-                                            pricing_info, input_tokens, output_tokens)
-
-                # Set Span attributes (OTel Semconv)
-                span.set_attribute(TELEMETRY_SDK_NAME, "openlit")
-                span.set_attribute(SemanticConvention.GEN_AI_OPERATION,
-                                    SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
-                span.set_attribute(SemanticConvention.GEN_AI_SYSTEM,
-                                    SemanticConvention.GEN_AI_SYSTEM_REKAAI)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL,
-                                    request_model)
-                span.set_attribute(SemanticConvention.SERVER_PORT,
-                                    server_port)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED,
-                                    kwargs.get("seed", ""))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
-                                    kwargs.get("max_tokens", -1))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-                                    kwargs.get("stop", []))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-                                    kwargs.get("presence_penalty", 0.0))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-                                    kwargs.get("temperature", 0.4))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_K,
-                                    kwargs.get("top_k", 1.0))
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P,
-                                    kwargs.get("top_p", 1.0))
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
-                                    [response.responses[0].finish_reason])
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID,
-                                    response.id)
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL,
-                                    response.model)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
-                                    input_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
-                                    output_tokens)
-                span.set_attribute(SemanticConvention.SERVER_ADDRESS,
-                                    server_address)
-                span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
-                                    'text')
-
-                # Set Span attributes (Extra)
-                span.set_attribute(DEPLOYMENT_ENVIRONMENT,
-                                    environment)
-                span.set_attribute(SERVICE_NAME,
-                                    application_name)
-                span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
-                                    False)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS,
-                                    input_tokens + output_tokens)
-                span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST,
-                                    cost)
-                span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT,
-                                    end_time - start_time)
-                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION,
-                                    version)
-
-                if capture_message_content:
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-                        attributes={
-                            SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
-                        },
-                    )
-                    span.add_event(
-                        name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-                        attributes={
-                            SemanticConvention.GEN_AI_CONTENT_COMPLETION: response.responses[0].message.content,
-                        },
-                    )
-
-                span.set_status(Status(StatusCode.OK))
-
-                if disable_metrics is False:
-                    attributes = create_metrics_attributes(
-                        service_name=application_name,
-                        deployment_environment=environment,
-                        operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-                        system=SemanticConvention.GEN_AI_SYSTEM_REKAAI,
-                        request_model=request_model,
-                        server_address=server_address,
-                        server_port=server_port,
-                        response_model=response.model,
-                    )
-
-                    metrics["genai_client_usage_tokens"].record(
-                        input_tokens + output_tokens, attributes
-                    )
-                    metrics["genai_client_operation_duration"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_server_ttft"].record(
-                        end_time - start_time, attributes
-                    )
-                    metrics["genai_requests"].add(1, attributes)
-                    metrics["genai_completion_tokens"].add(output_tokens, attributes)
-                    metrics["genai_prompt_tokens"].add(input_tokens, attributes)
-                    metrics["genai_cost"].record(cost, attributes)
-
-                # Return original response
                 return response
 
             except Exception as e:
                 handle_exception(span, e)
-                logger.error("Error in trace creation: %s", e)
-
-                # Return original response
                 return response
 
     return wrapper

--- a/sdk/python/src/openlit/instrumentation/reka/utils.py
+++ b/sdk/python/src/openlit/instrumentation/reka/utils.py
@@ -1,5 +1,5 @@
 """
-Together AI OpenTelemetry instrumentation utility functions
+Reka OpenTelemetry instrumentation utility functions
 """
 import time
 
@@ -11,7 +11,6 @@ from openlit.__helpers import (
     response_as_dict,
     calculate_tbt,
     get_chat_model_cost,
-    get_image_model_cost,
     create_metrics_attributes,
 )
 from openlit.semcov import SemanticConvention
@@ -37,36 +36,6 @@ def format_content(messages):
             formatted_messages.append(f"{role}: {content}")
 
     return "\n".join(formatted_messages)
-
-def process_chunk(scope, chunk):
-    """
-    Process a chunk of response data and update state.
-    """
-
-    end_time = time.time()
-    # Record the timestamp for the current chunk
-    scope._timestamps.append(end_time)
-
-    if len(scope._timestamps) == 1:
-        # Calculate time to first chunk
-        scope._ttft = calculate_ttft(scope._timestamps, scope._start_time)
-
-    chunked = response_as_dict(chunk)
-    # Collect message IDs and aggregated response from events
-    if (len(chunked.get("choices")) > 0 and ("delta" in chunked.get("choices")[0] and
-        "content" in chunked.get("choices")[0].get("delta"))):
-
-        content = chunked.get("choices")[0].get("delta").get("content")
-        if content:
-            scope._llmresponse += content
-
-    if chunked.get("usage"):
-        scope._response_id = chunked.get("id")
-        scope._response_model = chunked.get("model")
-        scope._input_tokens = chunked.get("usage").get("prompt_tokens")
-        scope._output_tokens = chunked.get("usage").get("completion_tokens")
-        scope._finish_reason = str(chunked.get("finish_reason"))
-        scope._end_time = time.time()
 
 def common_span_attributes(scope, gen_ai_operation, gen_ai_system, server_address, server_port,
     request_model, response_model, environment, application_name, is_stream, tbt, ttft, version):
@@ -126,24 +95,24 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
         scope._tbt = calculate_tbt(scope._timestamps)
 
     prompt = format_content(scope._kwargs.get("messages", ""))
-    request_model = scope._kwargs.get("model", "jamba-1.5-mini")
+    request_model = scope._kwargs.get("model", "reka-core-20240501")
 
     cost = get_chat_model_cost(request_model, pricing_info, scope._input_tokens, scope._output_tokens)
 
     # Common Span Attributes
     common_span_attributes(scope,
-        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,SemanticConvention.GEN_AI_SYSTEM_TOGETHER,
+        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,SemanticConvention.GEN_AI_SYSTEM_REKAAI,
         scope._server_address, scope._server_port, request_model, scope._response_model,
         environment, application_name, is_stream, scope._tbt, scope._ttft, version)
 
     # Span Attributes for Response parameters
     scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [scope._finish_reason])
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_SEED, scope._kwargs.get("seed", ""))
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, scope._kwargs.get("frequency_penalty", 0.0))
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, scope._kwargs.get("max_tokens", -1))
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, scope._kwargs.get("presence_penalty", 0.0))
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, scope._kwargs.get("stop", []))
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, scope._kwargs.get("temperature", 1.0))
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, scope._kwargs.get("temperature", 0.4))
+    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_K, scope._kwargs.get("top_k", 1.0))
     scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_TOP_P, scope._kwargs.get("top_p", 1.0))
     scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID, scope._response_id)
     scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "text" if isinstance(scope._llmresponse, str) else "json")
@@ -156,9 +125,9 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
 
     # Span Attributes for Tools
     if scope._tools:
-        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_NAME, scope._tools.get("function","")).get("name","")
+        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_NAME, scope._tools.get("name",""))
         scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_CALL_ID, str(scope._tools.get("id","")))
-        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_ARGS, str(scope._tools.get("function","").get("arguments","")))
+        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_ARGS, str(scope._tools.get("parameters","")))
 
     # Span Attributes for Content
     if capture_message_content:
@@ -183,18 +152,10 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
 
     # Metrics
     if not disable_metrics:
-        record_common_metrics(metrics, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT, SemanticConvention.GEN_AI_SYSTEM_TOGETHER,
+        record_common_metrics(metrics, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT, SemanticConvention.GEN_AI_SYSTEM_REKAAI,
             scope._server_address, scope._server_port, request_model, scope._response_model, environment,
             application_name, scope._start_time, scope._end_time, scope._input_tokens, scope._output_tokens,
             cost, scope._tbt, scope._ttft)
-
-def process_streaming_chat_response(scope, pricing_info, environment, application_name, metrics,
-    capture_message_content=False, disable_metrics=False, version=""):
-    """
-    Process chat request and generate Telemetry
-    """
-    common_chat_logic(scope, pricing_info, environment, application_name, metrics,
-        capture_message_content, disable_metrics, version, is_stream=True)
 
 def process_chat_response(response, request_model, pricing_info, server_port, server_address,
     environment, application_name, metrics, start_time, span, capture_message_content=False,
@@ -211,110 +172,23 @@ def process_chat_response(response, request_model, pricing_info, server_port, se
     scope._span = span
     scope._llmresponse = " ".join(
         (choice.get("message", {}).get("content") or "")
-        for choice in response_dict.get("choices", [])
+        for choice in response_dict.get("responses", [])
     )
     scope._response_id = response_dict.get("id")
     scope._response_model = response_dict.get("model")
-    scope._input_tokens = response_dict.get("usage").get("prompt_tokens")
-    scope._output_tokens = response_dict.get("usage").get("completion_tokens")
+    scope._input_tokens = response_dict.get("usage").get("input_tokens")
+    scope._output_tokens = response_dict.get("usage").get("output_tokens")
     scope._timestamps = []
     scope._ttft, scope._tbt = scope._end_time - scope._start_time, 0
     scope._server_address, scope._server_port = server_address, server_port
     scope._kwargs = kwargs
-    scope._finish_reason = str(response_dict.get("choices")[0].get("finish_reason"))
-
+    scope._finish_reason = str(response_dict.get("responses")[0].get("finish_reason"))
     if scope._kwargs.get("tools"):
-        scope._tools = response_dict.get("choices")[0].get("message").get("tool_calls")
+        scope._tools = response_dict.get("responses")[0].get("message").get("tool_calls")
     else:
         scope._tools = None
 
     common_chat_logic(scope, pricing_info, environment, application_name, metrics,
         capture_message_content, disable_metrics, version, is_stream=False)
-
-    return response
-
-def common_image_logic(scope, pricing_info, environment, application_name, metrics,
-    capture_message_content, disable_metrics, version):
-    """
-    Process image generation request and generate Telemetry
-    """
-
-    # Find Image format
-    if "response_format" in scope._kwargs and scope._kwargs["response_format"] == "b64_json":
-        image_format = "b64_json"
-    else:
-        image_format = "url"
-
-    image_size = str(scope._kwargs.get("width", "1024")) + "x" + str(scope._kwargs.get("height", "1024"))
-    request_model = scope._kwargs.get("model", "dall-e-2")
-
-    # Calculate cost of the operation
-    cost = get_image_model_cost(request_model, pricing_info, image_size,
-        scope._kwargs.get("quality", "standard"))
-
-    # Common Span Attributes
-    common_span_attributes(scope,
-        SemanticConvention.GEN_AI_OPERATION_TYPE_IMAGE, SemanticConvention.GEN_AI_SYSTEM_TOGETHER,
-        scope._server_address, scope._server_port, request_model, scope._response_model,
-        environment, application_name, False, scope._tbt, scope._ttft, version)
-
-    # Image-specific span attributes
-    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID, scope._response_id)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "image")
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IMAGE_SIZE, image_size)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, len(scope._response_data) * cost)
-
-    # Content attributes
-    if capture_message_content:
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: scope._kwargs.get("prompt", ""),
-            },
-        )
-
-        for images_count, item in enumerate(scope._response_data):
-            attribute_name = f"{SemanticConvention.GEN_AI_RESPONSE_IMAGE}.{images_count}"
-            scope._span.add_event(
-                name=attribute_name,
-                attributes={
-                    SemanticConvention.GEN_AI_CONTENT_COMPLETION: getattr(item, image_format),
-                },
-            )
-
-    scope._span.set_status(Status(StatusCode.OK))
-
-    # Metrics
-    if not disable_metrics:
-        record_common_metrics(
-            metrics, SemanticConvention.GEN_AI_OPERATION_TYPE_IMAGE,
-            SemanticConvention.GEN_AI_SYSTEM_TOGETHER, scope._server_address, scope._server_port,
-            request_model, scope._response_model, environment, application_name,
-            scope._start_time, scope._end_time, 0, 0, len(scope._response_data) * cost
-        )
-
-def process_image_response(response, request_model, pricing_info, server_address, server_port,
-    environment, application_name, metrics, start_time, end_time, span, capture_message_content,
-    disable_metrics, version, **kwargs):
-    """
-    Process image generation request and generate Telemetry
-    """
-
-    scope = type("GenericScope", (), {})()
-
-    scope._start_time = start_time
-    scope._end_time = end_time
-    scope._span = span
-    scope._response_id = response.id
-    scope._response_model = response.model
-    scope._response_data = response.data
-    scope._server_address = server_address
-    scope._server_port = server_port
-    scope._kwargs = kwargs
-    scope._tbt = 0
-    scope._ttft = end_time - start_time
-
-    common_image_logic(scope, pricing_info, environment, application_name, metrics,
-        capture_message_content, disable_metrics, version)
 
     return response

--- a/sdk/python/src/openlit/instrumentation/reka/utils.py
+++ b/sdk/python/src/openlit/instrumentation/reka/utils.py
@@ -7,7 +7,6 @@ from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOY
 from opentelemetry.trace import Status, StatusCode
 
 from openlit.__helpers import (
-    calculate_ttft,
     response_as_dict,
     calculate_tbt,
     get_chat_model_cost,

--- a/sdk/python/src/openlit/instrumentation/reka/utils.py
+++ b/sdk/python/src/openlit/instrumentation/reka/utils.py
@@ -80,9 +80,9 @@ def record_common_metrics(metrics, gen_ai_operation, gen_ai_system, server_addre
     metrics["genai_completion_tokens"].add(output_tokens, attributes)
     metrics["genai_client_usage_tokens"].record(input_tokens + output_tokens, attributes)
     metrics["genai_cost"].record(cost, attributes)
-    if tbt:
+    if tbt is not None:
         metrics["genai_server_tbt"].record(tbt, attributes)
-    if ttft:
+    if ttft is not None:
         metrics["genai_server_ttft"].record(ttft, attributes)
 
 def common_chat_logic(scope, pricing_info, environment, application_name, metrics,

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOY
 from opentelemetry.trace import Status, StatusCode
 
 from openlit.__helpers import (
+    calculate_ttft,
     response_as_dict,
     calculate_tbt,
     get_chat_model_cost,

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -111,9 +111,9 @@ def record_common_metrics(metrics, gen_ai_operation, gen_ai_system, server_addre
     metrics["genai_completion_tokens"].add(output_tokens, attributes)
     metrics["genai_client_usage_tokens"].record(input_tokens + output_tokens, attributes)
     metrics["genai_cost"].record(cost, attributes)
-    if tbt:
+    if tbt is not None:
         metrics["genai_server_tbt"].record(tbt, attributes)
-    if ttft:
+    if ttft is not None:
         metrics["genai_server_ttft"].record(ttft, attributes)
 
 def common_chat_logic(scope, pricing_info, environment, application_name, metrics,

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -7,7 +7,6 @@ from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOY
 from opentelemetry.trace import Status, StatusCode
 
 from openlit.__helpers import (
-    calculate_ttft,
     response_as_dict,
     calculate_tbt,
     get_chat_model_cost,


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Extract common chat telemetry logic into a dedicated utils module and simplify Reka sync and async instrumentation by delegating processing to shared helpers.

Enhancements:
- Introduce openlit/instrumentation/reka/utils.py with reusable functions to format content, set span attributes, and record metrics
- Refactor both sync and async Reka wrappers to call process_chat_response instead of duplicating telemetry logic
- Remove inline cost calculation, span attribute setting, and metric recording from individual wrappers
- Simplify imports by eliminating direct dependencies on get_chat_model_cost, create_metrics_attributes, and logging in wrappers
- Update default application_name and environment values in RekaInstrumentor to "default" and standardize wrapper comments to reflect chat completions