### PR TITLE
[Feat]: Refactor AWS Bedrock OpenTelemetry Monitoring Instrumentation

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.19"
+version = "1.34.20"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/bedrock/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/__init__.py
@@ -1,4 +1,3 @@
-# pylint: disable=useless-return, bad-staticmethod-argument, disable=duplicate-code
 """Initializer of Auto Instrumentation of AWS Bedrock Functions"""
 
 from typing import Collection
@@ -6,37 +5,43 @@ import importlib.metadata
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from wrapt import wrap_function_wrapper
 
-from openlit.instrumentation.bedrock.bedrock import converse
+from openlit.instrumentation.bedrock.bedrock import converse, converse_stream
 
 _instruments = ("boto3 >= 1.34.138",)
 
 class BedrockInstrumentor(BaseInstrumentor):
     """
-    An instrumentor for AWS Bedrock's client library.
+    An instrumentor for AWS Bedrock client library.
     """
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs):
-        application_name = kwargs.get("application_name", "default_application")
-        environment = kwargs.get("environment", "default_environment")
+        version = importlib.metadata.version("boto3")
+        environment = kwargs.get("environment", "default")
+        application_name = kwargs.get("application_name", "default")
         tracer = kwargs.get("tracer")
-        event_provider = kwargs.get('event_provider')
-        metrics = kwargs.get("metrics_dict")
         pricing_info = kwargs.get("pricing_info", {})
         capture_message_content = kwargs.get("capture_message_content", False)
+        metrics = kwargs.get("metrics_dict")
         disable_metrics = kwargs.get("disable_metrics")
-        version = importlib.metadata.version("boto3")
 
-        #sync
+        # sync
         wrap_function_wrapper(
-            "botocore.client",  
-            "ClientCreator.create_client",  
-            converse(version, environment, application_name,
-                     tracer, event_provider, pricing_info, capture_message_content, metrics, disable_metrics),
+            "botocore.client",
+            "ClientCreator.create_client",
+            converse(version, environment, application_name, tracer, pricing_info,
+                capture_message_content, metrics, disable_metrics),
+        )
+
+        # streaming
+        wrap_function_wrapper(
+            "botocore.client",
+            "ClientCreator.create_client",
+            converse_stream(version, environment, application_name, tracer, pricing_info,
+                capture_message_content, metrics, disable_metrics),
         )
 
     def _uninstrument(self, **kwargs):
-        # Proper uninstrumentation logic to revert patched methods
         pass

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -2,64 +2,65 @@
 Module for monitoring Amazon Bedrock API calls.
 """
 
-import logging
 import time
 from opentelemetry.trace import SpanKind
 from openlit.__helpers import (
+    handle_exception,
     set_server_address_and_port
 )
 from openlit.instrumentation.bedrock.utils import (
+    process_chunk,
     process_chat_response,
+    process_streaming_chat_response,
 )
 from openlit.semcov import SemanticConvention
 
-# Initialize logger for logging potential issues and operations
-logger = logging.getLogger(__name__)
-
-def converse(version, environment, application_name, tracer, event_provider,
-         pricing_info, capture_message_content, metrics, disable_metrics):
+def converse(version, environment, application_name, tracer, pricing_info, capture_message_content, metrics, disable_metrics):
     """
-    Generates a telemetry wrapper for GenAI function call
+    Generates a telemetry wrapper for AWS Bedrock converse calls.
     """
 
     def wrapper(wrapped, instance, args, kwargs):
         """
-        Wraps the GenAI function call.
+        Wraps the ClientCreator.create_client call.
         """
 
         def converse_wrapper(original_method, *method_args, **method_kwargs):
-
             """
-            Wraps the GenAI function call.
+            Wraps the individual converse method call.
             """
 
-            server_address, server_port = set_server_address_and_port(instance, 'aws.amazon.com', 443)
-            request_model = method_kwargs.get('modelId', 'amazon.titan-text-express-v1')
+            server_address, server_port = set_server_address_and_port(instance, "aws.amazon.com", 443)
+            request_model = method_kwargs.get("modelId", "amazon.titan-text-express-v1")
 
-            span_name = f'{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}'
+            span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
 
             with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
                 start_time = time.time()
                 response = original_method(*method_args, **method_kwargs)
-                llm_config = method_kwargs.get('inferenceConfig', {})
-                response = process_chat_response(
-                    response=response,
-                    request_model=request_model,
-                    pricing_info=pricing_info,
-                    server_port=server_port,
-                    server_address=server_address,
-                    environment=environment,
-                    application_name=application_name,
-                    metrics=metrics,
-                    event_provider=event_provider,
-                    start_time=start_time,
-                    span=span,
-                    capture_message_content=capture_message_content,
-                    disable_metrics=disable_metrics,
-                    version=version,
-                    llm_config=llm_config,
-                    **method_kwargs
-                )
+                llm_config = method_kwargs.get("inferenceConfig", {})
+                
+                try:
+                    response = process_chat_response(
+                        response=response,
+                        request_model=request_model,
+                        pricing_info=pricing_info,
+                        server_port=server_port,
+                        server_address=server_address,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        start_time=start_time,
+                        span=span,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        llm_config=llm_config,
+                        **method_kwargs
+                    )
+
+                except Exception as e:
+                    handle_exception(span, e)
 
                 return response
 
@@ -67,10 +68,143 @@ def converse(version, environment, application_name, tracer, event_provider,
         client = wrapped(*args, **kwargs)
 
         # Replace the original method with the instrumented one
-        if kwargs.get('service_name') == 'bedrock-runtime':
+        if kwargs.get("service_name") == "bedrock-runtime":
             original_invoke_model = client.converse
-            client.converse = lambda *args, **kwargs: converse_wrapper(original_invoke_model,
-                                                                            *args, **kwargs)
+            client.converse = lambda *args, **kwargs: converse_wrapper(original_invoke_model, *args, **kwargs)
+
+        return client
+
+    return wrapper
+
+def converse_stream(version, environment, application_name, tracer, pricing_info, capture_message_content, metrics, disable_metrics):
+    """
+    Generates a telemetry wrapper for AWS Bedrock converse_stream calls.
+    """
+
+    class TracedSyncStream:
+        """
+        Wrapper for streaming responses to collect telemetry.
+        """
+
+        def __init__(
+                self,
+                wrapped_response,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                **args,
+            ):
+            self.__wrapped_response = wrapped_response
+            # Extract the actual stream iterator from the response
+            if isinstance(wrapped_response, dict) and "stream" in wrapped_response:
+                self.__wrapped_stream = iter(wrapped_response["stream"])
+            else:
+                self.__wrapped_stream = iter(wrapped_response)
+                
+            self._span = span
+            self._span_name = span_name
+            self._llmresponse = ""
+            self._response_id = ""
+            self._response_model = ""
+            self._finish_reason = ""
+            self._tools = None
+            self._input_tokens = 0
+            self._output_tokens = 0
+
+            self._args = args
+            self._kwargs = kwargs
+            self._start_time = time.time()
+            self._end_time = None
+            self._timestamps = []
+            self._ttft = 0
+            self._tbt = 0
+            self._server_address = server_address
+            self._server_port = server_port
+
+        def __enter__(self):
+            if hasattr(self.__wrapped_stream, "__enter__"):
+                self.__wrapped_stream.__enter__()
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            if hasattr(self.__wrapped_stream, "__exit__"):
+                self.__wrapped_stream.__exit__(exc_type, exc_value, traceback)
+
+        def __iter__(self):
+            return self
+
+        def __getattr__(self, name):
+            """Delegate attribute access to the wrapped response."""
+            return getattr(self.__wrapped_response, name)
+
+        def get(self, key, default=None):
+            """Delegate get method to the wrapped response if its a dict."""
+            if isinstance(self.__wrapped_response, dict):
+                return self.__wrapped_response.get(key, default)
+            return getattr(self.__wrapped_response, key, default)
+
+        def __getitem__(self, key):
+            """Delegate item access to the wrapped response if its a dict."""
+            if isinstance(self.__wrapped_response, dict):
+                return self.__wrapped_response[key]
+            return getattr(self.__wrapped_response, key)
+
+        def __next__(self):
+            try:
+                chunk = next(self.__wrapped_stream)
+                process_chunk(self, chunk)
+                return chunk
+            except StopIteration:
+                try:
+                    llm_config = self._kwargs.get("inferenceConfig", {})
+                    with tracer.start_as_current_span(self._span_name, kind=SpanKind.CLIENT) as self._span:
+                        process_streaming_chat_response(
+                            self,
+                            pricing_info=pricing_info,
+                            environment=environment,
+                            application_name=application_name,
+                            metrics=metrics,
+                            capture_message_content=capture_message_content,
+                            disable_metrics=disable_metrics,
+                            version=version,
+                            llm_config=llm_config
+                        )
+
+                except Exception as e:
+                    handle_exception(self._span, e)
+
+                raise
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the ClientCreator.create_client call.
+        """
+
+        def converse_stream_wrapper(original_method, *method_args, **method_kwargs):
+            """
+            Wraps the individual converse_stream method call.
+            """
+
+            server_address, server_port = set_server_address_and_port(instance, "aws.amazon.com", 443)
+            request_model = method_kwargs.get("modelId", "amazon.titan-text-express-v1")
+
+            span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
+
+            # Get the streaming response
+            stream_response = original_method(*method_args, **method_kwargs)
+            span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
+            
+            return TracedSyncStream(stream_response, span, span_name, method_kwargs, server_address, server_port)
+
+        # Get the original client instance from the wrapper
+        client = wrapped(*args, **kwargs)
+
+        # Replace the original method with the instrumented one
+        if kwargs.get("service_name") == "bedrock-runtime":
+            original_stream_model = client.converse_stream
+            client.converse_stream = lambda *args, **kwargs: converse_stream_wrapper(original_stream_model, *args, **kwargs)
 
         return client
 

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -39,7 +39,7 @@ def converse(version, environment, application_name, tracer, pricing_info, captu
                 start_time = time.time()
                 response = original_method(*method_args, **method_kwargs)
                 llm_config = method_kwargs.get("inferenceConfig", {})
-                
+
                 try:
                     response = process_chat_response(
                         response=response,
@@ -102,7 +102,7 @@ def converse_stream(version, environment, application_name, tracer, pricing_info
                 self.__wrapped_stream = iter(wrapped_response["stream"])
             else:
                 self.__wrapped_stream = iter(wrapped_response)
-                
+
             self._span = span
             self._span_name = span_name
             self._llmresponse = ""
@@ -195,7 +195,7 @@ def converse_stream(version, environment, application_name, tracer, pricing_info
             # Get the streaming response
             stream_response = original_method(*method_args, **method_kwargs)
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
-            
+
             return TracedSyncStream(stream_response, span, span_name, method_kwargs, server_address, server_port)
 
         # Get the original client instance from the wrapper

--- a/sdk/python/src/openlit/instrumentation/bedrock/utils.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/utils.py
@@ -3,20 +3,54 @@ AWS Bedrock OpenTelemetry instrumentation utility functions
 """
 import time
 
-from opentelemetry.sdk.resources import SERVICE_NAME, TELEMETRY_SDK_NAME, DEPLOYMENT_ENVIRONMENT
 from opentelemetry.trace import Status, StatusCode
 
 from openlit.__helpers import (
     calculate_ttft,
     response_as_dict,
     calculate_tbt,
-    extract_and_format_input,
     get_chat_model_cost,
-    create_metrics_attributes,
-    otel_event,
-    concatenate_all_contents
+    record_completion_metrics,
+    common_span_attributes,
+    handle_exception
 )
 from openlit.semcov import SemanticConvention
+
+def format_content(messages):
+    """
+    Format the messages into a string for span events.
+    """
+    
+    if not messages:
+        return ""
+    
+    formatted_messages = []
+    for message in messages:
+        if isinstance(message, dict):
+            role = message.get("role", "user")
+            content = message.get("content", "")
+        else:
+            # Handle Bedrock object format
+            role = getattr(message, "role", "user")
+            content = getattr(message, "content", "")
+        
+        if isinstance(content, list):
+            # Handle structured content (e.g., text + images)
+            text_parts = []
+            for part in content:
+                if isinstance(part, dict):
+                    # Bedrock format: {"text": "content"} or generic format: {"type": "text", "text": "content"}
+                    if "text" in part:
+                        text_parts.append(part.get("text", ""))
+                    elif part.get("type") == "text":
+                        text_parts.append(part.get("text", ""))
+            content = " ".join(text_parts)
+        elif not isinstance(content, str):
+            content = str(content)
+            
+        formatted_messages.append(f"{role}: {content}")
+    
+    return "\n".join(formatted_messages)
 
 def process_chunk(self, chunk):
     """
@@ -33,33 +67,33 @@ def process_chunk(self, chunk):
 
     chunked = response_as_dict(chunk)
 
-    # Collect message IDs and input token from events
-    if chunked.get('type') == 'message_start':
-        self._response_id = chunked.get('message').get('id')
-        self._input_tokens = chunked.get('message').get('usage').get('input_tokens')
-        self._response_model = chunked.get('message').get('model')
-        self._response_role = chunked.get('message').get('role')
+    # Handle Bedrock messageStart event
+    if "messageStart" in chunked:
+        message_start = chunked.get("messageStart", {})
+        self._response_role = message_start.get("role", "assistant")
 
-    # Collect message IDs and aggregated response from events
-    if chunked.get('type') == 'content_block_delta':
-        if chunked.get('delta').get('text'):
-            self._llmresponse += chunked.get('delta').get('text')
-        elif chunked.get('delta').get('partial_json'):
-            self._tool_arguments += chunked.get('delta').get('partial_json')
+    # Handle Bedrock contentBlockDelta event
+    if "contentBlockDelta" in chunked:
+        content_delta = chunked.get("contentBlockDelta", {})
+        delta = content_delta.get("delta", {})
+        if "text" in delta:
+            self._llmresponse += delta.get("text", "")
 
-    if chunked.get('type') == 'content_block_start':
-        if chunked.get('content_block').get('id'):
-            self._tool_id = chunked.get('content_block').get('id')
-        if chunked.get('content_block').get('name'):
-            self._tool_name = chunked.get('content_block').get('name')
+    # Handle Bedrock messageStop event
+    if "messageStop" in chunked:
+        message_stop = chunked.get("messageStop", {})
+        self._finish_reason = message_stop.get("stopReason", "")
 
-    # Collect output tokens and stop reason from events
-    if chunked.get('type') == 'message_delta':
-        self._output_tokens = chunked.get('usage').get('output_tokens')
-        self._finish_reason = chunked.get('delta').get('stop_reason')
+    # Handle Bedrock metadata event (final event with usage info)
+    if "metadata" in chunked:
+        metadata = chunked.get("metadata", {})
+        usage = metadata.get("usage", {})
+        self._input_tokens = usage.get("inputTokens", 0)
+        self._output_tokens = usage.get("outputTokens", 0)
+        self._end_time = end_time
 
 def common_chat_logic(scope, pricing_info, environment, application_name, metrics,
-                        event_provider, capture_message_content, disable_metrics, version, llm_config, is_stream):
+                        capture_message_content, disable_metrics, version, llm_config, is_stream):
     """
     Process chat request and generate Telemetry
     """
@@ -68,62 +102,55 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
     if len(scope._timestamps) > 1:
         scope._tbt = calculate_tbt(scope._timestamps)
 
-    formatted_messages = extract_and_format_input(scope._kwargs.get('messages', ''))
-    print(formatted_messages)
-    request_model = scope._kwargs.get('model', 'claude-3-opus-20240229')
+    formatted_messages = format_content(scope._kwargs.get("messages", []))
+    request_model = scope._kwargs.get("modelId", "amazon.titan-text-express-v1")
 
     cost = get_chat_model_cost(request_model, pricing_info, scope._input_tokens, scope._output_tokens)
 
-    # Set Span attributes (OTel Semconv)
-    scope._span.set_attribute(TELEMETRY_SDK_NAME, 'openlit')
-    scope._span.set_attribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SYSTEM, SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, request_model)
-    scope._span.set_attribute(SemanticConvention.SERVER_PORT, scope._server_port)
+    # Common Span Attributes
+    common_span_attributes(scope,
+        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT, SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK,
+        scope._server_address, scope._server_port, request_model, scope._response_model,
+        environment, application_name, is_stream, scope._tbt, scope._ttft, version)
 
-    # List of attributes and their config keys
-    attributes = [
-        (SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, 'frequencyPenalty'),
-        (SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, 'maxTokens'),
-        (SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, 'presencePenalty'),
-        (SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, 'stopSequences'),
-        (SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, 'temperature'),
-        (SemanticConvention.GEN_AI_REQUEST_TOP_P, 'topP'),
-        (SemanticConvention.GEN_AI_REQUEST_TOP_K, 'topK'),
+    # Bedrock-specific attributes from llm_config
+    bedrock_attributes = [
+        (SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, "frequencyPenalty"),
+        (SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, "maxTokens"),
+        (SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, "presencePenalty"),
+        (SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, "stopSequences"),
+        (SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, "temperature"),
+        (SemanticConvention.GEN_AI_REQUEST_TOP_P, "topP"),
+        (SemanticConvention.GEN_AI_REQUEST_TOP_K, "topK"),
     ]
 
-    # Set each attribute if the corresponding value exists and is not None
-    for attribute, key in attributes:
+    # Set each bedrock-specific attribute if the corresponding value exists and is not None
+    for attribute, key in bedrock_attributes:
         value = llm_config.get(key)
         if value is not None:
             scope._span.set_attribute(attribute, value)
 
-    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [scope._finish_reason])
+    # Span Attributes for Response parameters
     scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID, scope._response_id)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, scope._response_model)
+    scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [scope._finish_reason])
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "text" if isinstance(scope._llmresponse, str) else "json")
+
+    # Span Attributes for Cost and Tokens
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, scope._input_tokens)
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, scope._output_tokens)
-    scope._span.set_attribute(SemanticConvention.SERVER_ADDRESS, scope._server_address)
-
-    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE,
-                              'text' if isinstance(scope._llmresponse, str) else 'json')
-
-    scope._span.set_attribute(DEPLOYMENT_ENVIRONMENT, environment)
-    scope._span.set_attribute(SERVICE_NAME, application_name)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, is_stream)
     scope._span.set_attribute(SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE, scope._input_tokens + scope._output_tokens)
     scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TBT, scope._tbt)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SERVER_TTFT, scope._ttft)
-    scope._span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
-    # To be removed one the change to log events (from span events) is complete
-    prompt = concatenate_all_contents(formatted_messages)
+    # Span Attributes for Content
     if capture_message_content:
+        scope._span.set_attribute(SemanticConvention.GEN_AI_CONTENT_PROMPT, formatted_messages)
+        scope._span.set_attribute(SemanticConvention.GEN_AI_CONTENT_COMPLETION, scope._llmresponse)
+
+        # To be removed once the change to span_attributes (from span events) is complete
         scope._span.add_event(
             name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
             attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
+                SemanticConvention.GEN_AI_CONTENT_PROMPT: formatted_messages,
             },
         )
         scope._span.add_event(
@@ -133,120 +160,64 @@ def common_chat_logic(scope, pricing_info, environment, application_name, metric
             },
         )
 
-    choice_event_body = {
-        'finish_reason': scope._finish_reason,
-        'index': 0,
-        'message': {
-            **({'content': scope._llmresponse} if capture_message_content else {}),
-            'role': scope._response_role
-        }
-    }
-
-    # Emit events
-    for role in ['user', 'system', 'assistant', 'tool']:
-        if formatted_messages.get(role, {}).get('content', ''):
-            event = otel_event(
-                name=getattr(SemanticConvention, f'GEN_AI_{role.upper()}_MESSAGE'),
-                attributes={
-                    SemanticConvention.GEN_AI_SYSTEM: SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK
-                },
-                body = {
-                    # pylint: disable=line-too-long
-                    **({'content': formatted_messages.get(role, {}).get('content', '')} if capture_message_content else {}),
-                    'role': formatted_messages.get(role, {}).get('role', []),
-                    **({
-                        'tool_calls': {
-                            'function': {
-                                # pylint: disable=line-too-long
-                                'name': (scope._tool_calls[0].get('function', {}).get('name', '') if scope._tool_calls else ''),
-                                'arguments': (scope._tool_calls[0].get('function', {}).get('arguments', '') if scope._tool_calls else '')
-                            },
-                            'id': (scope._tool_calls[0].get('id', '') if scope._tool_calls else ''),
-                            'type': 'function'
-                        }
-                    } if role == 'assistant' else {}),
-                    **({
-                        'id': (scope._tool_calls[0].get('id', '') if scope._tool_calls else '')
-                    } if role == 'tool' else {})
-                }
-            )
-            event_provider.emit(event)
-
-    choice_event = otel_event(
-        name=SemanticConvention.GEN_AI_CHOICE,
-        attributes={
-            SemanticConvention.GEN_AI_SYSTEM: SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK
-        },
-        body=choice_event_body
-    )
-    event_provider.emit(choice_event)
-
     scope._span.set_status(Status(StatusCode.OK))
 
+    # Record metrics
     if not disable_metrics:
-        metrics_attributes = create_metrics_attributes(
-            service_name=application_name,
-            deployment_environment=environment,
-            operation=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-            system=SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK,
-            request_model=request_model,
-            server_address=scope._server_address,
-            server_port=scope._server_port,
-            response_model=scope._response_model,
-        )
+        record_completion_metrics(metrics, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT, SemanticConvention.GEN_AI_SYSTEM_AWS_BEDROCK,
+            scope._server_address, scope._server_port, request_model, scope._response_model, environment,
+            application_name, scope._start_time, scope._end_time, scope._input_tokens, scope._output_tokens,
+            cost, scope._tbt, scope._ttft)
 
-        metrics['genai_client_usage_tokens'].record(scope._input_tokens + scope._output_tokens, metrics_attributes)
-        metrics['genai_client_operation_duration'].record(scope._end_time - scope._start_time, metrics_attributes)
-        metrics['genai_server_tbt'].record(scope._tbt, metrics_attributes)
-        metrics['genai_server_ttft'].record(scope._ttft, metrics_attributes)
-        metrics['genai_requests'].add(1, metrics_attributes)
-        metrics['genai_completion_tokens'].add(scope._output_tokens, metrics_attributes)
-        metrics['genai_prompt_tokens'].add(scope._input_tokens, metrics_attributes)
-        metrics['genai_cost'].record(cost, metrics_attributes)
-
-def process_streaming_chat_response(self, pricing_info, environment, application_name, metrics,
-    event_provider, capture_message_content=False, disable_metrics=False, version='', llm_config=''):
-
+def process_streaming_chat_response(scope, pricing_info, environment, application_name, metrics,
+                                    capture_message_content=False, disable_metrics=False, version="", llm_config=None):
     """
-    Process chat request and generate Telemetry
+    Process streaming chat response and generate telemetry.
     """
-    if self._tool_id != '':
-        self._tool_calls = {
-            'id': self._tool_id,
-            'name': self._tool_name,
-            'input': self._tool_arguments
-        }
+    
+    try:
+        if llm_config is None:
+            llm_config = {}
 
-    common_chat_logic(self, pricing_info, environment, application_name, metrics,
-                        event_provider, capture_message_content, disable_metrics, version, llm_config, is_stream=True)
+        common_chat_logic(scope, pricing_info, environment, application_name, metrics,
+                            capture_message_content, disable_metrics, version, llm_config, is_stream=True)
+    except Exception as e:
+        handle_exception(scope._span, e)
+        raise
 
 def process_chat_response(response, request_model, pricing_info, server_port, server_address, environment,
-    application_name, metrics, event_provider, start_time,  span, capture_message_content=False,
-    disable_metrics=False, version='1.0.0', llm_config='', **kwargs):
-
+                          application_name, metrics, start_time, span, capture_message_content=False,
+                          disable_metrics=False, version="1.0.0", llm_config=None, **kwargs):
     """
-    Process chat request and generate Telemetry
+    Process non-streaming chat response and generate telemetry.
     """
+    
+    try:
+        if llm_config is None:
+            llm_config = {}
 
-    self = type('GenericScope', (), {})()
-    response_dict = response_as_dict(response)
+        scope = type("GenericScope", (), {})()
+        response_dict = response_as_dict(response)
 
-    # pylint: disable = no-member
-    self._start_time = start_time
-    self._end_time = time.time()
-    self._span = span
-    self._llmresponse = response_dict.get('output').get('message').get('content')[0].get('text')
-    self._response_role = 'assistant'
-    self._input_tokens = response_dict.get('usage').get('inputTokens')
-    self._output_tokens = response_dict.get('usage').get('outputTokens')
-    self._response_model = request_model
-    self._finish_reason = response_dict.get('stopReason', '')
-    self._response_id = response_dict.get('ResponseMetadata').get('RequestId')
-    self._timestamps = []
-    self._ttft, self._tbt = self._end_time - self._start_time, 0
-    self._server_address, self._server_port = server_address, server_port
-    self._kwargs = kwargs
-    common_chat_logic(self, pricing_info, environment, application_name, metrics,
-                        event_provider, capture_message_content, disable_metrics, version, llm_config, is_stream=False)
+        scope._start_time = start_time
+        scope._end_time = time.time()
+        scope._span = span
+        scope._llmresponse = response_dict.get("output", {}).get("message", {}).get("content", [{}])[0].get("text", "")
+        scope._response_role = response_dict.get("output", {}).get("message", {}).get("role", "assistant")
+        scope._input_tokens = response_dict.get("usage", {}).get("inputTokens", 0)
+        scope._output_tokens = response_dict.get("usage", {}).get("outputTokens", 0)
+        scope._response_model = request_model
+        scope._finish_reason = response_dict.get("stopReason", "")
+        scope._response_id = response_dict.get("RequestId", "")
+        scope._timestamps = []
+        scope._ttft, scope._tbt = scope._end_time - scope._start_time, 0
+        scope._server_address, scope._server_port = server_address, server_port
+        scope._kwargs = kwargs
 
-    return response
+        common_chat_logic(scope, pricing_info, environment, application_name, metrics,
+                            capture_message_content, disable_metrics, version, llm_config, is_stream=False)
+
+        return response
+    except Exception as e:
+        handle_exception(span, e)
+        raise

--- a/sdk/python/src/openlit/instrumentation/bedrock/utils.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/utils.py
@@ -20,10 +20,10 @@ def format_content(messages):
     """
     Format the messages into a string for span events.
     """
-    
+
     if not messages:
         return ""
-    
+
     formatted_messages = []
     for message in messages:
         if isinstance(message, dict):
@@ -33,7 +33,7 @@ def format_content(messages):
             # Handle Bedrock object format
             role = getattr(message, "role", "user")
             content = getattr(message, "content", "")
-        
+
         if isinstance(content, list):
             # Handle structured content (e.g., text + images)
             text_parts = []
@@ -47,9 +47,9 @@ def format_content(messages):
             content = " ".join(text_parts)
         elif not isinstance(content, str):
             content = str(content)
-            
+
         formatted_messages.append(f"{role}: {content}")
-    
+
     return "\n".join(formatted_messages)
 
 def process_chunk(self, chunk):
@@ -174,7 +174,7 @@ def process_streaming_chat_response(scope, pricing_info, environment, applicatio
     """
     Process streaming chat response and generate telemetry.
     """
-    
+
     try:
         if llm_config is None:
             llm_config = {}
@@ -191,7 +191,7 @@ def process_chat_response(response, request_model, pricing_info, server_port, se
     """
     Process non-streaming chat response and generate telemetry.
     """
-    
+
     try:
         if llm_config is None:
             llm_config = {}

--- a/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
@@ -68,9 +68,9 @@ def acompletion(version, environment, application_name, tracer, pricing_info,
         def __aiter__(self):
             return self
 
-        def __getattr__(self, name):
+        async def __getattr__(self, name):
             """Delegate attribute access to the wrapped object."""
-            return getattr(self.__wrapped__, name)
+            return getattr(await self.__wrapped__, name)
 
         async def __anext__(self):
             try:


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Refactor AWS Bedrock instrumentation to support streaming responses, unify telemetry logic, and improve error handling and content formatting

New Features:
- Add TracedSyncStream and converse_stream wrapper to enable telemetry for Bedrock streaming calls
- Introduce format_content helper to normalize and format Bedrock message content for spans

Enhancements:
- Consolidate span attribute setting and metrics recording via common_span_attributes and record_completion_metrics
- Simplify event emission by replacing manual otel_event loops with span.add_event for prompts and completions
- Update process_chunk to parse Bedrock-specific streaming events (messageStart, contentBlockDelta, messageStop, metadata)

Chores:
- Bump SDK version to 1.34.20
- Fix async __getattr__ implementation in litellm for proper delegation