### PR TITLE
[Fix]: token treated as a context manager when using Async Agno

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.38"
+version = "1.34.39"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -61,10 +61,13 @@ def async_agent_run_wrap(
         ) as span:
             start_time = time.time()
             # CRITICAL: Set the span context as current for nested calls
-            with context_api.attach(
+            token = context_api.attach(
                 context_api.set_value("current_span", span, current_context)
-            ):
+            )
+            try:
                 response = await wrapped(*args, **kwargs)
+            finally:
+                context_api.detach(token)
 
             try:
                 # Process request using utils function with ALL attributes from semcov
@@ -195,11 +198,13 @@ def async_model_run_function_call_wrap(
         ) as span:
             start_time = time.time()
             # CRITICAL: Set the span context as current for nested calls
-            with context_api.attach(
+            token = context_api.attach(
                 context_api.set_value("current_span", span, current_context)
-            ):
+            )
+            try:
                 result = await wrapped(*args, **kwargs)
-
+            finally:
+                context_api.detach(token)
             try:
                 # Process request using utils function with ALL attributes from semcov
                 process_tool_request(
@@ -266,10 +271,13 @@ def async_function_entrypoint_wrap(
         ) as span:
             start_time = time.time()
             # CRITICAL: Set the span context as current for nested calls
-            with context_api.attach(
+            token = context_api.attach(
                 context_api.set_value("current_span", span, current_context)
-            ):
+            )
+            try:
                 result = await wrapped(*args, **kwargs)
+            finally:
+                context_api.detach(token)
 
             try:
                 # Process request using utils function with ALL attributes from semcov
@@ -857,10 +865,13 @@ def async_function_execute_wrap(
             # Execute async tool with timing
             start_time = time.time()
             # CRITICAL: Set the span context as current for nested calls
-            with context_api.attach(
+            token = context_api.attach(
                 context_api.set_value("current_span", span, current_context)
-            ):
+            )
+            try:
                 result = await wrapped(*args, **kwargs)
+            finally:
+                context_api.detach(token)
 
             try:
                 # Process request using utils function with ALL attributes from semcov


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->
Fix #838 

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Bug Fixes:
- Replace with-context_api.attach usage with token assignment and add try/finally blocks to call context_api.detach(token) in multiple async_agno wrapper functions