### PR TITLE
[Feat]: Set detailed_tracing argument as `True`

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.34.40"
+version = "1.34.41"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -78,7 +78,7 @@ class OpenlitConfig:
         cls.disable_batch = False
         cls.capture_message_content = True
         cls.disable_metrics = False
-        cls.detailed_tracing = False
+        cls.detailed_tracing = True
 
     @classmethod
     def update_config(
@@ -187,7 +187,7 @@ def init(
     disable_metrics=False,
     pricing_json=None,
     collect_gpu_stats=False,
-    detailed_tracing=False,
+    detailed_tracing=True,
 ):
     """
     Initializes the openLIT configuration and setups tracing.


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Enable detailed tracing by default in the Python SDK configuration, bump the package version, and remove an obsolete analysis file.

New Features:
- Set detailed_tracing default to True in reset_to_defaults
- Change init signature to default detailed_tracing to True

Chores:
- Bump SDK version from 1.34.40 to 1.34.41
- Remove competitive_analysis/firecrawl file