### PR TITLE
[Fix]: Attributes in OpenTelemetry Instrumentations

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.1"
+version = "1.35.2"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -209,6 +209,29 @@ def create_metrics_attributes(
     }
 
 
+def create_db_metrics_attributes(
+    service_name: str,
+    deployment_environment: str,
+    db_system: str,
+    db_operation: str,
+    server_address: str,
+    server_port: int,
+) -> Dict[Any, Any]:
+    """
+    Returns OTel metrics attributes for database operations
+    """
+
+    return {
+        TELEMETRY_SDK_NAME: "openlit",
+        SERVICE_NAME: service_name,
+        DEPLOYMENT_ENVIRONMENT: deployment_environment,
+        SemanticConvention.DB_SYSTEM_NAME: db_system,
+        SemanticConvention.DB_OPERATION_NAME: db_operation,
+        SemanticConvention.SERVER_ADDRESS: server_address,
+        SemanticConvention.SERVER_PORT: server_port,
+    }
+
+
 def set_server_address_and_port(
     client_instance: Any, default_server_address: str, default_server_port: int
 ) -> Tuple[str, int]:
@@ -802,20 +825,19 @@ def record_db_metrics(
     application_name,
     start_time,
     end_time,
+    db_operation,
 ):
     """
     Record database-specific metrics for the operation.
     """
 
-    attributes = create_metrics_attributes(
-        operation=SemanticConvention.GEN_AI_OPERATION_TYPE_VECTORDB,
-        system=db_system,
-        request_model=db_system,
-        server_address=server_address,
-        server_port=server_port,
-        response_model=db_system,
+    attributes = create_db_metrics_attributes(
         service_name=application_name,
         deployment_environment=environment,
+        db_system=db_system,
+        db_operation=db_operation,
+        server_address=server_address,
+        server_port=server_port,
     )
     metrics["db_requests"].add(1, attributes)
     metrics["db_client_operation_duration"].record(end_time - start_time, attributes)

--- a/sdk/python/src/openlit/instrumentation/astra/utils.py
+++ b/sdk/python/src/openlit/instrumentation/astra/utils.py
@@ -303,6 +303,7 @@ def common_astra_logic(
             application_name,
             scope._start_time,
             scope._end_time,
+            scope._db_operation,
         )
 
 

--- a/sdk/python/src/openlit/instrumentation/chroma/utils.py
+++ b/sdk/python/src/openlit/instrumentation/chroma/utils.py
@@ -337,6 +337,7 @@ def common_vectordb_logic(
             application_name,
             scope._start_time,
             scope._end_time,
+            scope._db_operation,
         )
 
 

--- a/sdk/python/src/openlit/instrumentation/milvus/utils.py
+++ b/sdk/python/src/openlit/instrumentation/milvus/utils.py
@@ -306,6 +306,7 @@ def common_milvus_logic(
             application_name,
             scope._start_time,
             scope._end_time,
+            scope._db_operation,
         )
 
 

--- a/sdk/python/src/openlit/instrumentation/pinecone/utils.py
+++ b/sdk/python/src/openlit/instrumentation/pinecone/utils.py
@@ -283,6 +283,7 @@ def common_vectordb_logic(
             application_name,
             scope._start_time,
             scope._end_time,
+            scope._db_operation,
         )
 
 

--- a/sdk/python/src/openlit/instrumentation/qdrant/utils.py
+++ b/sdk/python/src/openlit/instrumentation/qdrant/utils.py
@@ -413,6 +413,7 @@ def common_qdrant_logic(
             application_name,
             scope._start_time,
             scope._end_time,
+            scope._db_operation,
         )
 
 

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -353,7 +353,7 @@ class SemanticConvention:
     DB_OPERATION_UPSERT = "UPSERT"
     DB_OPERATION_GET = "GET"
     DB_OPERATION_ADD = "ADD"
-    DB_OPERATION_PEEK = "peePEEKk"
+    DB_OPERATION_PEEK = "PEEK"
     DB_ID_COUNT = "db.ids_count"
     DB_VECTOR_COUNT = "db.vector.count"
     DB_METADATA = "db.metadata"


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Add support for detailed database operation metrics by centralizing attribute creation and propagating the operation type through database instrumentation, fix a typo in the semantic conventions, and bump the SDK version

New Features:
- Introduce create_db_metrics_attributes function to construct OTel metrics attributes for database operations

Bug Fixes:
- Fix typo in SemanticConvention.DB_OPERATION_PEEK constant

Enhancements:
- Update record_db_metrics and instrumentation utils for Astra, Chroma, Milvus, Pinecone, and Qdrant to pass the db_operation parameter to metrics recording

Build:
- Bump Python SDK version from 1.35.1 to 1.35.2