### PR TITLE
[Feat]: add support for agno 2.x

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.1"
+version = "1.35.2"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.2"
+version = "1.35.3"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -237,7 +237,9 @@ def async_agent_run_stream_wrap(
     Wrap Agno Agent._arun_stream async generator method.
     """
 
+
     async def wrapper(wrapped, instance, args, kwargs):
+
         # CRITICAL: Suppression check to prevent recursive instrumentation
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             async for response in wrapped(*args, **kwargs):
@@ -254,13 +256,27 @@ def async_agent_run_stream_wrap(
 
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
-
             try:
-                async for response in wrapped(*args, **kwargs):
-                    yield response
-
-                # Get the final response after iteration completes
-                final_response = getattr(instance, "run_response", None)
+                # agno 2.x: when `yield_run_response=True`, the final `RunOutput` is yielded
+                # rather than stored on `instance.run_response`
+                try:
+                    from agno.run.agent import RunOutput  # noqa: WPS433 # pylint: disable=import-error
+                except Exception:  # noqa: WPS429
+                    RunOutput = None  # type: ignore # pylint: disable=invalid-name
+                yield_run_response = kwargs.get("yield_run_response", None)
+                final_response = None
+                new_kwargs = dict(kwargs)
+                new_kwargs['yield_run_response'] = True
+                async for response in wrapped(*args, **new_kwargs):
+                    if RunOutput and isinstance(response, RunOutput):
+                        final_response = response
+                        if yield_run_response:
+                            yield response
+                    else:
+                        yield response
+                if not RunOutput:
+                    # Get the final response after iteration completes
+                    final_response = getattr(instance, "run_response", None)
             except Exception as e:
                 handle_exception(span, e)
                 logger.error("Error in async agent._arun_stream: %s", e)
@@ -870,6 +886,86 @@ def async_team_run_wrap(
                 logger.error("Error in async team run trace creation: %s", e)
 
             return result
+
+    return wrapper
+
+
+def async_team_run_stream_wrap(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """
+    Wrap Team async stream run; request final RunOutput via yield_run_response=True.
+    """
+
+    async def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            async for item in wrapped(*args, **kwargs):
+                yield item
+            return
+
+        team_name = getattr(instance, "name", "unknown_team")
+        span_name = f"team {team_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
+            final_response = None
+
+
+            try:
+                # agno 2.x: when `yield_run_response=True`, the final `TeamRunOutput` is yielded
+                # rather than stored on `instance.run_response`
+                try:
+                    from agno.run.team import TeamRunOutput  # noqa: WPS433 # pylint: disable=import-error
+                except Exception:  # noqa: WPS429
+                    TeamRunOutput = None  # type: ignore # pylint: disable=invalid-name
+
+                yield_run_response = kwargs.get("yield_run_response", None)
+                final_response = None
+                new_kwargs = dict(kwargs)
+                new_kwargs['yield_run_response'] = True
+                async for response in wrapped(*args, **new_kwargs):
+                    if TeamRunOutput and isinstance(response, TeamRunOutput):
+                        final_response = response
+                        if yield_run_response:
+                            yield response
+                    else:
+                        yield response
+                if not TeamRunOutput:
+                    # Get the final response after iteration completes
+                    final_response = getattr(instance, "run_response", None)
+            except Exception as e:
+                handle_exception(span, e)
+                logger.error("Error in team stream run: %s", e)
+                raise
+
+            try:
+                process_team_request(
+                    span,
+                    instance,
+                    args,
+                    kwargs,
+                    final_response,
+                    start_time,
+                    pricing_info,
+                    environment,
+                    application_name,
+                    metrics,
+                    capture_message_content,
+                    disable_metrics,
+                    version,
+                )
+                span.set_status(Status(StatusCode.OK))
+            except Exception as e:
+                handle_exception(span, e)
+                logger.error("Error creating team stream trace: %s", e)
 
     return wrapper
 

--- a/sdk/python/src/openlit/instrumentation/agno/utils.py
+++ b/sdk/python/src/openlit/instrumentation/agno/utils.py
@@ -2,6 +2,7 @@
 Utility functions for Agno instrumentation following OpenLIT patterns.
 """
 
+import importlib
 import logging
 import time
 from openlit.__helpers import (
@@ -149,6 +150,17 @@ def process_agent_request(
                 SemanticConvention.GEN_AI_CONTENT_PROMPT, str(args[0])[:1000]
             )
 
+    # agno 2.x versions agent.run use input instead of args[0]
+    if kwargs and kwargs.get('input', None) and capture_message_content:
+        span.set_attribute(
+            SemanticConvention.GEN_AI_CONTENT_PROMPT, str(kwargs['input'])[:1000]
+        )
+    # agno 2.x versions team.run use input_message instead of args[0]
+    if kwargs and kwargs.get('input_message', None) and capture_message_content:
+        span.set_attribute(
+            SemanticConvention.GEN_AI_CONTENT_PROMPT, str(kwargs['input_message'])[:1000]
+        )
+
     # User and session information
     if "user_id" in kwargs and kwargs["user_id"]:
         span.set_attribute(SemanticConvention.GEN_AI_REQUEST_USER, kwargs["user_id"])
@@ -157,6 +169,10 @@ def process_agent_request(
 
     if "session_id" in kwargs and kwargs["session_id"]:
         span.set_attribute(SemanticConvention.GEN_AI_SESSION_ID, kwargs["session_id"])
+
+    # agno 2.x versions use session instead of session_id
+    if "session" in kwargs and kwargs["session"] and hasattr(kwargs["session"], "session_id"):
+        span.set_attribute(SemanticConvention.GEN_AI_SESSION_ID, kwargs["session"].session_id)
 
     # Stream and reasoning attributes
     if "stream" in kwargs:
@@ -758,6 +774,15 @@ def process_team_request(
             SemanticConvention.GEN_AI_TEAM_AGENT_COUNT, len(instance.agents)
         )
 
+    if hasattr(instance, "members") and instance.members:
+        agent_names = [getattr(agent, "name", "unknown") for agent in instance.members]
+        span.set_attribute(
+            SemanticConvention.GEN_AI_TEAM_AGENTS, agent_names[:10]
+        )  # Limit to 10
+        span.set_attribute(
+            SemanticConvention.GEN_AI_TEAM_AGENT_COUNT, len(instance.members)
+        )
+
     # Set execution metrics
     span.set_attribute(
         SemanticConvention.GEN_AI_TEAM_EXECUTION_DURATION, execution_time
@@ -765,3 +790,78 @@ def process_team_request(
     span.set_attribute(
         SemanticConvention.GEN_AI_TEAM_OPERATION_SUCCESS, response is not None
     )
+
+
+def resolve_agno_memory_target():
+    """
+    Resolve the appropriate Agno memory target class.
+
+    Attempts to find and import the correct memory class from Agno framework.
+    Tries multiple candidate modules in order of preference.
+
+    Returns:
+        tuple: (module_name, class_name) if successful, (None, None) if no valid target found
+
+    Example:
+        >>> module, class_name = resolve_agno_memory_target()
+        >>> if module:
+        ...     print(f"Found memory class: {class_name} in {module}")
+    """
+    return resolve_target("agno.memory", (
+        ("agno.memory.v2.memory", "Memory"),
+        ("agno.memory.manager", "MemoryManager"),))
+
+
+def resolve_agno_knowledge_target():
+    """
+    Resolve the appropriate Agno knowledge target class.
+    
+    Attempts to find and import the correct knowledge class from Agno framework.
+    Tries multiple candidate modules in order of preference.
+    
+    Returns:
+        tuple: (module_name, class_name) if successful, (None, None) if no valid target found
+        
+    Example:
+        >>> module, class_name = resolve_agno_knowledge_target()
+        >>> if module:
+        ...     print(f"Found knowledge class: {class_name} in {module}")
+    """
+    return resolve_target("agno.knowledge", (
+        ("agno.knowledge.agent", "AgentKnowledge"),
+        ("agno.knowledge.knowledge", "Knowledge"),))
+
+def resolve_target(target_name, candidates):
+    """
+    Resolve a target class by trying multiple candidate modules.
+    
+    This function attempts to import and find a specific class from a list of candidate
+    modules. It tries each candidate in order until it finds a valid module and class.
+    
+    Args:
+        target_name (str): Name of the target being resolved (used for logging)
+        candidates (tuple): Tuple of (module_name, class_name) pairs to try
+        
+    Returns:
+        tuple: (module_name, class_name) if successful, (None, None) if no valid target found
+        
+    Example:
+        >>> candidates = (
+        ...     ("agno.memory.v2.memory", "Memory"),
+        ...     ("agno.memory.manager", "MemoryManager")
+        ... )
+        >>> module, class_name = resolve_target("agno.memory", candidates)
+        >>> if module:
+        ...     print(f"Found: {class_name} in {module}")
+    """
+    for module_name, class_name in candidates:
+        try:
+            module = importlib.import_module(module_name)
+            if hasattr(module, class_name):
+                return module_name, class_name
+        except ModuleNotFoundError:
+            continue
+        except Exception as e:
+            logger.info(f"Skip {target_name} candidate %s due to: %s", module_name, e)
+            continue
+    return None, None

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -84,6 +84,7 @@ class SemanticConvention:
     GEN_AI_OPERATION_TYPE_VECTORDB = "vectordb"
     GEN_AI_OPERATION_TYPE_FRAMEWORK = "workflow"
     GEN_AI_OPERATION_TYPE_AGENT = "invoke_agent"
+    GEN_AI_OPERATION_TYPE_TEAM = "team"
     GEN_AI_OPERATION_TYPE_CREATE_AGENT = "create_agent"
     GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK = "execute_task"
     GEN_AI_OPERATION_TYPE_GRAPH_EXECUTION = "graph_execution"


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->


### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Add compatibility for agno 2.x by introducing dynamic instrumentation targets, enhanced streaming wrappers, and updated semantic conventions for team operations.

New Features:
- Add async_team_run_stream_wrap for instrumenting streaming team runs

Enhancements:
- Introduce resolve_target utilities to dynamically locate agno memory and knowledge classes across versions
- Refactor memory and knowledge instrumentation to use version‐aware wrappers and prevent duplicate spans
- Capture final RunOutput/TeamRunOutput in streamed generators and honor yield_run_response flags
- Extend process_agent_request and process_team_request to handle input kwargs and include team member metadata