### PR TITLE
[Fix] fix order of arguments

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.1"
+version = "1.35.2"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -449,9 +449,9 @@ def record_completion_metrics(
     application_name,
     start_time,
     end_time,
-    cost,
     input_tokens,
     output_tokens,
+    cost,
     tbt,
     ttft,
 ):


### PR DESCRIPTION
### Overview:
fix for https://github.com/openlit/openlit/issues/876

## Summary by Sourcery

Bug Fixes:
- Fix the argument order in record_completion_metrics by moving cost after output_tokens