### PR TITLE
[Docs]: Fix link in README for Kubernetes Helm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ flowchart TB;
    docker compose up -d
    ```
 
-> For instructions on installing in Kubernetes using Helm, refer to the [Kubernetes Helm installation guide](https://docs.openlit.io/latest/installation#kubernetes).
+> For instructions on installing in Kubernetes using Helm, refer to the [Kubernetes Helm installation guide](https://docs.openlit.io/latest/openlit/installation#kubernetes).
 
 ### Step 2: Install OpenLIT SDK
 


### PR DESCRIPTION
### Overview:
Fix link in README for Kubernetes Helm installation

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Documentation:
- Update README link for Kubernetes Helm installation to use the correct '/openlit/installation#kubernetes' URL