### PR TITLE
[Fix]: Incorrect start time in spans when streaming and encoding key in LiteLLM

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.3"
+version = "1.35.4"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
@@ -85,22 +85,23 @@ def acompletion(
                 return chunk
             except StopAsyncIteration:
                 try:
-                    with tracer.start_as_current_span(
-                        self._span_name, kind=SpanKind.CLIENT
-                    ) as self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                        )
+                    # Use the existing span that was started when the stream began
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                    )
+                    # End the span after processing
+                    self._span.end()
 
                 except Exception as e:
                     handle_exception(self._span, e)
+                    self._span.end()
 
                 raise
 

--- a/sdk/python/src/openlit/instrumentation/litellm/litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/litellm.py
@@ -85,22 +85,23 @@ def completion(
                 return chunk
             except StopIteration:
                 try:
-                    with tracer.start_as_current_span(
-                        self._span_name, kind=SpanKind.CLIENT
-                    ) as self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                        )
+                    # Use the existing span that was started when the stream began
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                    )
+                    # End the span after processing
+                    self._span.end()
 
                 except Exception as e:
                     handle_exception(self._span, e)
+                    self._span.end()
 
                 raise
 

--- a/sdk/python/src/openlit/instrumentation/litellm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/utils.py
@@ -100,7 +100,10 @@ def process_chunk(scope, chunk):
         scope._output_tokens = chunked.get("usage").get("completion_tokens", 0)
         scope._response_id = chunked.get("id")
         scope._response_model = chunked.get("model")
-        scope._finish_reason = chunked.get("choices", [{}])[0].get("finish_reason")
+        finish_reason = chunked.get("choices", [{}])[0].get("finish_reason")
+        # Only update finish_reason if it's not None (preserve previous valid value)
+        if finish_reason is not None:
+            scope._finish_reason = finish_reason
         scope._response_service_tier = str(chunked.get("system_fingerprint", ""))
         scope._end_time = time.time()
 
@@ -189,7 +192,7 @@ def common_chat_logic(
     # Span Attributes for Response parameters
     scope._span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_ID, scope._response_id)
     scope._span.set_attribute(
-        SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [scope._finish_reason]
+        SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [scope._finish_reason or ""]
     )
     scope._span.set_attribute(
         SemanticConvention.GEN_AI_RESPONSE_SERVICE_TIER, scope._response_service_tier


### PR DESCRIPTION
### Overview:
<!-- What does this PR do? Link issues here -->

resolves #879 and #878 

### Visuals (If applicable):
<!-- Attach screenshots/screen recordings here to show the changes -->


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Fix span timing and finish reason handling in LiteLLM instrumentation and bump SDK version to 1.35.4

Bug Fixes:
- Reuse the original client span for streaming responses instead of starting a new span at the end in both sync and async flows
- Ensure the span is properly ended after processing or upon exception
- Preserve a previously set finish_reason when processing streaming chunks and default to an empty string in span attributes

Build:
- Bump python SDK version to 1.35.4