### PR TITLE
[Fix] Remove extra parameter passed to `process_team_request` in Agno instrumentation

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.4"
+version = "1.35.5"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -876,7 +876,6 @@ def async_team_run_wrap(
                     capture_message_content,
                     disable_metrics,
                     version,
-                    SemanticConvention.GEN_AI_OPERATION_TYPE_TEAM,
                 )
 
                 span.set_status(Status(StatusCode.OK))


### PR DESCRIPTION
### Overview:
Remove the unnecessary parameter passed to the `process_team_request` util function in the Agno async team run wrapper. This causes an error for when submitting runs asynchronously to Agno Teams.
The call now follows the same format as the other scenarios, i.e. async stream runs and sync runs.

Fixes: #888 

### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ....`
- [ ] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
