### PR TITLE
[Fix] async MCP span naming by populating method metadata

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.5"
+version = "1.35.6"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Overview:
- Mirror the synchronous MCP wrapper’s method-metadata setup in all async wrappers by adding `_populate_context_method_metadata` (mcp_server/openlit/instrumentation/mcp/async_mcp.py:15).
- Invoke the helper in each async wrapper (`async_mcp_wrap`, `async_mcp_tool_call_wrap`, `async_mcp_resource_wrap`, `async_mcp_transport_wrap`) so `ctx.method_name` resolves to `call_tool`, `read_resource`, etc.
- Fixes async span naming so traces now show `mcp tools/call` with the server spans correctly nested beneath the tool call.

### Visuals (If applicable):
<img width="674" height="562" alt="image" src="https://github.com/user-attachments/assets/40460608-7d5a-4ec7-bc0a-dcdf2cbe5a05" />

<img width="637" height="425" alt="image" src="https://github.com/user-attachments/assets/e1f6de2b-c023-4fe1-b615-9cceb83773c7" />


### Checklist:
- [x] PR name follows conventional commit format: `[Feat]: ...` or `[Fix]: ...`
- [x] Added visuals for changes (If applicable)
- [x] Checked OpenLIT [contribution guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)

## Summary by Sourcery

Populate method metadata in async MCP wrappers to fix span naming issues by adding and invoking a context-populating helper

Bug Fixes:
- Fix async MCP span naming so operation names (e.g., `mcp tools/call`) display correctly with proper server span nesting

Enhancements:
- Introduce `_populate_context_method_metadata` helper to set function name and endpoint method on the instrumentation context
- Invoke the helper in all async MCP wrappers for consistent metadata setup