### PR TITLE
[Fix]: Semantic convention attributes in OpenAI and Agno

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.5"
+version = "1.35.6"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -818,7 +818,7 @@ def async_workflow_run_wrap(
                     capture_message_content,
                     disable_metrics,
                     version,
-                    SemanticConvention.GEN_AI_OPERATION_TYPE_WORKFLOW,
+                    SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
                 )
 
                 span.set_status(Status(StatusCode.OK))

--- a/sdk/python/src/openlit/instrumentation/agno/utils.py
+++ b/sdk/python/src/openlit/instrumentation/agno/utils.py
@@ -683,7 +683,7 @@ def process_workflow_request(
     # Use common span attributes for workflow operations
     common_span_attributes(
         scope,
-        SemanticConvention.GEN_AI_OPERATION_TYPE_WORKFLOW,
+        SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
         SemanticConvention.GEN_AI_SYSTEM_AGNO,
         "localhost",  # server_address
         80,  # server_port

--- a/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
+++ b/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
@@ -258,10 +258,10 @@ class OpenLITTracingProcessor(TracingProcessor):
         """Get operation type based on span characteristics."""
         type_mapping = {
             "agent": SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
-            "generation": SemanticConvention.GEN_AI_OPERATION_CHAT,
-            "function": SemanticConvention.GEN_AI_OPERATION_CHAT,
-            "tool": SemanticConvention.GEN_AI_OPERATION_CHAT,
-            "handoff": SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+            "generation": SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+            "function": SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+            "tool": SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+            "handoff": SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
         }
 
         # Check span type first
@@ -274,7 +274,7 @@ class OpenLITTracingProcessor(TracingProcessor):
             if key in span_name.lower():
                 return operation
 
-        return SemanticConvention.GEN_AI_OPERATION_CHAT
+        return SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT
 
     def _process_span_attributes(self, span, span_data, span_type: str):
         """Process and set span attributes based on span type."""

--- a/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
+++ b/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
@@ -101,7 +101,7 @@ class OpenLITTracingProcessor(TracingProcessor):
                 kind=SpanKind.CLIENT,
                 attributes={
                     SemanticConvention.GEN_AI_SYSTEM: "openai_agents",
-                    SemanticConvention.GEN_AI_OPERATION: SemanticConvention.GEN_AI_OPERATION_TYPE_WORKFLOW,
+                    SemanticConvention.GEN_AI_OPERATION: SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
                     "trace.id": trace_id,
                     "trace.name": name,
                 },


### PR DESCRIPTION
### Overview:
Fixes issue with SemanticConvention attributes not having been updated once it was removed.

```
Error in async workflow run trace creation: type object 'SemanticConvention' has no attribute 'GEN_AI_OPERATION_TYPE_WORKFLOW'
```

## Summary by Sourcery

Fix semantic convention attribute references by replacing missing or deprecated workflow constants with the correct framework constants and aligning chat operation type mappings to prevent attribute errors in OpenAI and AGNO instrumentation.

Bug Fixes:
- Replace incorrect GEN_AI_OPERATION_TYPE_WORKFLOW constant with GEN_AI_OPERATION_TYPE_FRAMEWORK in OpenAI Agents and AGNO modules
- Correct mapping and default return of generation, function, tool, and handoff spans to use the GEN_AI_OPERATION_TYPE_CHAT constant