### PR TITLE
[Fix]: Remove extra parameter

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.35.6"
+version = "1.35.7"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -818,7 +818,6 @@ def async_workflow_run_wrap(
                     capture_message_content,
                     disable_metrics,
                     version,
-                    SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
                 )
 
                 span.set_status(Status(StatusCode.OK))


### PR DESCRIPTION
As this raises:

> Error in async workflow run trace creation: process_workflow_request()
takes 13 positional arguments but 14 were given

And process_workflow_request already handles the SemanticConvention

## Summary by Sourcery

Bug Fixes:
- Remove SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK from process_workflow_request call to match its signature and prevent the positional arguments mismatch error