### PR TITLE
feat: add support langchain `astream`

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.36.0"
+version = "1.36.1"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: resolves #933 

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add support for LangChain `astream` streaming by tracking individual tokens via on_llm_new_token, assembling full streamed responses in on_llm_end, and capturing usage metrics. Enhance error handling by cleaning up streaming buffers and classifying both LLM and chain errors with detailed attributes. Bump Python SDK version to 1.36.1.

New Features:
- Introduce on_llm_new_token callback to accumulate tokens during streaming operations.
- Assemble and record complete streamed responses and token usage in on_llm_end.
- Add on_chain_error callback to capture and annotate chain errors.

Enhancements:
- Clean up streaming token buffers on LLM and chain errors.
- Enhance error classification and attach framework error attributes to spans.

Build:
- Bump Python SDK version from 1.36.0 to 1.36.1.