### PR TITLE
Fix: prompt details repetition

### DIFF
--- a/src/client/src/app/(playground)/prompt-hub/[id]/page.tsx
+++ b/src/client/src/app/(playground)/prompt-hub/[id]/page.tsx
@@ -233,38 +233,6 @@ export default function PromptHub() {
 						</div>
 					</div>
 				) : null}
-				{metaPropertiesMap.length > 0 ? (
-					<div className="flex flex-col gap-2">
-						<h3 className="text-sm text-stone-500 dark:text-stone-400">
-							Meta Properties
-						</h3>
-						<div className="rounded-sm border border-stone-200 dark:border-stone-700">
-							<Table>
-								<TableHeader className="bg-stone-100 dark:bg-stone-800">
-									<TableRow>
-										<TableHead className="h-8 text-stone-400">Key</TableHead>
-										<TableHead className="h-8 text-stone-400">Value</TableHead>
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{metaPropertiesMap.map(([itemKey, value]: string[]) => (
-										<TableRow
-											key={itemKey}
-											className="bg-stone-50 dark:bg-stone-900 data-[state=selected]:bg-stone-50 dark:data-[state=selected]:bg-stone-900 text-stone-600 dark:text-stone-300"
-										>
-											<TableCell className="p-0 px-4 align-middle font-medium h-10">
-												{itemKey}
-											</TableCell>
-											<TableCell className="p-0 px-4 align-middle h-10">
-												{value}
-											</TableCell>
-										</TableRow>
-									))}
-								</TableBody>
-							</Table>
-						</div>
-					</div>
-				) : null}
 				</CardContent>
 			</Card>
 			<Card className="border border-stone-200 dark:border-stone-800">


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
The repetition of the prompt hub meta details on the prompt hub detail page is removed

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Bug Fixes:
- Eliminate redundant meta properties block in prompt hub detail view