### PR TITLE
fix(agno): deprecate old Agno yield_run_response parameter for new yi…

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.36.3"
+version = "1.36.4"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -239,17 +239,19 @@ def async_agent_run_stream_wrap(
             try:
                 # agno 2.x: when `yield_run_response=True`, the final `RunOutput` is yielded
                 # rather than stored on `instance.run_response`
+                # agno 2.3+: `yield_run_response` has been deprecated for `yield_run_output` 
                 try:
                     from agno.run.agent import RunOutput  # noqa: WPS433 # pylint: disable=import-error
                 except Exception:  # noqa: WPS429
                     RunOutput = None  # type: ignore # pylint: disable=invalid-name
-                yield_run_response = kwargs.get("yield_run_response", None)
+                # `yield_run_response` is backwards compatibility for agno < 2.3
+                yield_run_output = kwargs.get("yield_run_output", None) or kwargs.get("yield_run_response", None)
                 new_kwargs = dict(kwargs)
-                new_kwargs["yield_run_response"] = True
+                new_kwargs["yield_run_output"] = True
                 async for response in wrapped(*args, **new_kwargs):
                     if RunOutput and isinstance(response, RunOutput):
                         final_response = response
-                        if yield_run_response:
+                        if yield_run_output:
                             yield response
                     else:
                         yield response

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -239,7 +239,7 @@ def async_agent_run_stream_wrap(
             try:
                 # agno 2.x: when `yield_run_response=True`, the final `RunOutput` is yielded
                 # rather than stored on `instance.run_response`
-                # agno 2.3+: `yield_run_response` has been deprecated for `yield_run_output` 
+                # agno 2.3+: `yield_run_response` has been deprecated for `yield_run_output`
                 try:
                     from agno.run.agent import RunOutput  # noqa: WPS433 # pylint: disable=import-error
                 except Exception:  # noqa: WPS429


### PR DESCRIPTION
…eld_run_output

Starting from Agno 2.3.0 yield_run_response which controls the fact that the RunOutput event would be yielded into the async generator has been deprecated for yield_run_output. Newers Agno versions don't pass yield_run_response anymore which would cause Workflows and Agent calls to fail when Agno was to be instrumented with OpenLit

This fix makes openlit use the newer yield_run_output and preserve backward compatibility with yield_run_response

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: #947 947

### Change description:

Starting from Agno 2.3.0 yield_run_response which controls the fact that the RunOutput event would be yielded into the async generator has been deprecated for yield_run_output.

Newers Agno versions don't pass yield_run_response anymore which would cause Workflows and Agent calls to fail when Agno was to be instrumented with OpenLit

This fix makes openlit use the newer yield_run_output and preserve backward compatibility with yield_run_response

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [ x ] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [ x ] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ x ] I have performed a self-review of this change
* [ x ] Changes have been tested
* [] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Bug Fixes:
- Prevent failures in instrumented Agno workflows and agent calls when newer Agno versions no longer pass the deprecated yield_run_response parameter.