### PR TITLE
fix: database doesn't exist fix for open telemetry collector through opamp server

### DIFF
--- a/assets/clickhouse-init.sh
+++ b/assets/clickhouse-init.sh
@@ -6,7 +6,7 @@ echo "==================== ClickHouse Initialization ===================="
 
 clickhouse-client --query "CREATE DATABASE IF NOT EXISTS ${CLICKHOUSE_DATABASE}"
 
-echo "✅ Database $DATABASE_NAME created successfully"
+echo "✅ Database $CLICKHOUSE_DATABASE created successfully"
 echo ""
 echo "Creating OTEL tables required by OpenTelemetry Collector..."
 

--- a/assets/clickhouse-init.sh
+++ b/assets/clickhouse-init.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+set -e
+
+# Get database name from environment or use default
+DATABASE_NAME="${CLICKHOUSE_DATABASE:-openlit}"
+
+echo "==================== ClickHouse Initialization ===================="
+echo "Creating database: $DATABASE_NAME"
+
+# Create the database if it doesn't exist
+clickhouse-client --query "CREATE DATABASE IF NOT EXISTS $DATABASE_NAME"
+
+echo "✅ Database $DATABASE_NAME created successfully"
+echo ""
+echo "Creating OTEL tables required by OpenTelemetry Collector..."
+
+# Create OTEL tables in the database
+# These tables must exist before the OTEL collector starts writing data
+
+# OTEL Traces Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_traces (
+	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TraceId String CODEC(ZSTD(1)),
+	SpanId String CODEC(ZSTD(1)),
+	ParentSpanId String CODEC(ZSTD(1)),
+	TraceState String CODEC(ZSTD(1)),
+	SpanName LowCardinality(String) CODEC(ZSTD(1)),
+	SpanKind LowCardinality(String) CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	SpanAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	Duration Int64 CODEC(ZSTD(1)),
+	StatusCode LowCardinality(String) CODEC(ZSTD(1)),
+	StatusMessage String CODEC(ZSTD(1)),
+	\`Events.Timestamp\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+	\`Events.Name\` Array(LowCardinality(String)) CODEC(ZSTD(1)),
+	\`Events.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	\`Links.TraceId\` Array(String) CODEC(ZSTD(1)),
+	\`Links.SpanId\` Array(String) CODEC(ZSTD(1)),
+	\`Links.TraceState\` Array(String) CODEC(ZSTD(1)),
+	\`Links.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_duration Duration TYPE minmax GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SpanName, toUnixTimestamp(Timestamp), TraceId)
+TTL toDateTime(Timestamp) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Logs Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_logs (
+	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TraceId String CODEC(ZSTD(1)),
+	SpanId String CODEC(ZSTD(1)),
+	TraceFlags UInt32 CODEC(ZSTD(1)),
+	SeverityText LowCardinality(String) CODEC(ZSTD(1)),
+	SeverityNumber Int32 CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	Body String CODEC(ZSTD(1)),
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	LogAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(Timestamp)
+ORDER BY (ServiceName, SeverityText, toUnixTimestamp(Timestamp), TraceId)
+TTL toDateTime(Timestamp) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Metrics Gauge Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	MetricName String CODEC(ZSTD(1)),
+	MetricDescription String CODEC(ZSTD(1)),
+	MetricUnit String CODEC(ZSTD(1)),
+	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	Value Float64 CODEC(ZSTD(1)),
+	Flags UInt32 CODEC(ZSTD(1)),
+	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Metrics Sum Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_sum (
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	MetricName String CODEC(ZSTD(1)),
+	MetricDescription String CODEC(ZSTD(1)),
+	MetricUnit String CODEC(ZSTD(1)),
+	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	Value Float64 CODEC(ZSTD(1)),
+	Flags UInt32 CODEC(ZSTD(1)),
+	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+	AggregationTemporality Int32 CODEC(ZSTD(1)),
+	IsMonotonic Bool CODEC(Delta(1), ZSTD(1)),
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Metrics Histogram Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_histogram (
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	MetricName String CODEC(ZSTD(1)),
+	MetricDescription String CODEC(ZSTD(1)),
+	MetricUnit String CODEC(ZSTD(1)),
+	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	Count UInt64 CODEC(Delta(8), ZSTD(1)),
+	Sum Float64 CODEC(ZSTD(1)),
+	BucketCounts Array(UInt64) CODEC(ZSTD(1)),
+	ExplicitBounds Array(Float64) CODEC(ZSTD(1)),
+	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+	Flags UInt32 CODEC(ZSTD(1)),
+	Min Float64 CODEC(ZSTD(1)),
+	Max Float64 CODEC(ZSTD(1)),
+	AggregationTemporality Int32 CODEC(ZSTD(1)),
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Metrics Summary Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_summary (
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	MetricName String CODEC(ZSTD(1)),
+	MetricDescription String CODEC(ZSTD(1)),
+	MetricUnit String CODEC(ZSTD(1)),
+	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	Count UInt64 CODEC(Delta(8), ZSTD(1)),
+	Sum Float64 CODEC(ZSTD(1)),
+	\`ValueAtQuantiles.Quantile\` Array(Float64) CODEC(ZSTD(1)),
+	\`ValueAtQuantiles.Value\` Array(Float64) CODEC(ZSTD(1)),
+	Flags UInt32 CODEC(ZSTD(1)),
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Metrics Exponential Histogram Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_exponential_histogram (
+	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ResourceSchemaUrl String CODEC(ZSTD(1)),
+	ScopeName String CODEC(ZSTD(1)),
+	ScopeVersion String CODEC(ZSTD(1)),
+	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
+	ScopeSchemaUrl String CODEC(ZSTD(1)),
+	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
+	MetricName String CODEC(ZSTD(1)),
+	MetricDescription String CODEC(ZSTD(1)),
+	MetricUnit String CODEC(ZSTD(1)),
+	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+	Count UInt64 CODEC(Delta(8), ZSTD(1)),
+	Sum Float64 CODEC(ZSTD(1)),
+	Scale Int32 CODEC(ZSTD(1)),
+	ZeroCount UInt64 CODEC(ZSTD(1)),
+	PositiveOffset Int32 CODEC(ZSTD(1)),
+	PositiveBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+	NegativeOffset Int32 CODEC(ZSTD(1)),
+	NegativeBucketCounts Array(UInt64) CODEC(ZSTD(1)),
+	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+	Flags UInt32 CODEC(ZSTD(1)),
+	Min Float64 CODEC(ZSTD(1)),
+	Max Float64 CODEC(ZSTD(1)),
+	AggregationTemporality Int32 CODEC(ZSTD(1)),
+	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(TimeUnix)
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
+TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# OTEL Traces TraceID Timestamp Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE TABLE IF NOT EXISTS otel_traces_trace_id_ts (
+	TraceId String CODEC(ZSTD(1)),
+	Start DateTime CODEC(Delta(4), ZSTD(1)),
+	End DateTime CODEC(Delta(4), ZSTD(1)),
+	INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = MergeTree
+PARTITION BY toDate(Start)
+ORDER BY (TraceId, Start)
+TTL toDateTime(Start) + INTERVAL 730 HOUR
+SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
+"
+
+# Materialized View for Trace Timestamp Table
+clickhouse-client --database="$DATABASE_NAME" --query "
+CREATE MATERIALIZED VIEW IF NOT EXISTS otel_traces_trace_id_ts_mv
+TO otel_traces_trace_id_ts
+AS SELECT
+	TraceId,
+	toDateTime(min(Timestamp)) AS Start,
+	toDateTime(max(Timestamp)) AS End
+FROM otel_traces
+WHERE TraceId != ''
+GROUP BY TraceId
+"
+
+echo "✅ All 9 OTEL tables created successfully"
+echo "===================================================================="

--- a/assets/clickhouse-init.sh
+++ b/assets/clickhouse-init.sh
@@ -1,315 +1,322 @@
 #!/bin/bash
 set -e
 
-# Get database name from environment or use default
-DATABASE_NAME="${CLICKHOUSE_DATABASE:-openlit}"
-
 echo "==================== ClickHouse Initialization ===================="
-echo "Creating database: $DATABASE_NAME"
 
-# Create the database if it doesn't exist
-clickhouse-client --query "CREATE DATABASE IF NOT EXISTS $DATABASE_NAME"
+
+clickhouse-client --query "CREATE DATABASE IF NOT EXISTS ${CLICKHOUSE_DATABASE}"
 
 echo "✅ Database $DATABASE_NAME created successfully"
 echo ""
 echo "Creating OTEL tables required by OpenTelemetry Collector..."
 
-# Create OTEL tables in the database
-# These tables must exist before the OTEL collector starts writing data
-
-# OTEL Traces Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_traces (
-	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TraceId String CODEC(ZSTD(1)),
-	SpanId String CODEC(ZSTD(1)),
-	ParentSpanId String CODEC(ZSTD(1)),
-	TraceState String CODEC(ZSTD(1)),
-	SpanName LowCardinality(String) CODEC(ZSTD(1)),
-	SpanKind LowCardinality(String) CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	SpanAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	Duration Int64 CODEC(ZSTD(1)),
-	StatusCode LowCardinality(String) CODEC(ZSTD(1)),
-	StatusMessage String CODEC(ZSTD(1)),
-	\`Events.Timestamp\` Array(DateTime64(9)) CODEC(ZSTD(1)),
-	\`Events.Name\` Array(LowCardinality(String)) CODEC(ZSTD(1)),
-	\`Events.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	\`Links.TraceId\` Array(String) CODEC(ZSTD(1)),
-	\`Links.SpanId\` Array(String) CODEC(ZSTD(1)),
-	\`Links.TraceState\` Array(String) CODEC(ZSTD(1)),
-	\`Links.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_duration Duration TYPE minmax GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_traces
+(
+    \`Timestamp\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TraceId\` String CODEC(ZSTD(1)),
+    \`SpanId\` String CODEC(ZSTD(1)),
+    \`ParentSpanId\` String CODEC(ZSTD(1)),
+    \`TraceState\` String CODEC(ZSTD(1)),
+    \`SpanName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`SpanKind\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`SpanAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`Duration\` UInt64 CODEC(ZSTD(1)),
+    \`StatusCode\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`StatusMessage\` String CODEC(ZSTD(1)),
+    \`Events.Timestamp\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    \`Events.Name\` Array(LowCardinality(String)) CODEC(ZSTD(1)),
+    \`Events.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    \`Links.TraceId\` Array(String) CODEC(ZSTD(1)),
+    \`Links.SpanId\` Array(String) CODEC(ZSTD(1)),
+    \`Links.TraceState\` Array(String) CODEC(ZSTD(1)),
+    \`Links.Attributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_key mapKeys(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_span_attr_value mapValues(SpanAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_duration Duration TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(Timestamp)
-ORDER BY (ServiceName, SpanName, toUnixTimestamp(Timestamp), TraceId)
-TTL toDateTime(Timestamp) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, SpanName, toDateTime(Timestamp))
+TTL toDateTime(Timestamp) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Logs Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_logs (
-	Timestamp DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TraceId String CODEC(ZSTD(1)),
-	SpanId String CODEC(ZSTD(1)),
-	TraceFlags UInt32 CODEC(ZSTD(1)),
-	SeverityText LowCardinality(String) CODEC(ZSTD(1)),
-	SeverityNumber Int32 CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	Body String CODEC(ZSTD(1)),
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	LogAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1
-) ENGINE = MergeTree
-PARTITION BY toDate(Timestamp)
-ORDER BY (ServiceName, SeverityText, toUnixTimestamp(Timestamp), TraceId)
-TTL toDateTime(Timestamp) + INTERVAL 730 HOUR
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_logs
+(
+    \`Timestamp\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimestampTime\` DateTime DEFAULT toDateTime(Timestamp),
+    \`TraceId\` String CODEC(ZSTD(1)),
+    \`SpanId\` String CODEC(ZSTD(1)),
+    \`TraceFlags\` UInt8,
+    \`SeverityText\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`SeverityNumber\` UInt8,
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`Body\` String CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`LogAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.001) GRANULARITY 1,
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_log_attr_key mapKeys(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_log_attr_value mapValues(LogAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_body Body TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 8
+)
+ENGINE = MergeTree
+PARTITION BY toDate(TimestampTime)
+PRIMARY KEY (ServiceName, TimestampTime)
+ORDER BY (ServiceName, TimestampTime, Timestamp)
+TTL TimestampTime + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Metrics Gauge Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_metrics_gauge (
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	MetricName String CODEC(ZSTD(1)),
-	MetricDescription String CODEC(ZSTD(1)),
-	MetricUnit String CODEC(ZSTD(1)),
-	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	Value Float64 CODEC(ZSTD(1)),
-	Flags UInt32 CODEC(ZSTD(1)),
-	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
-	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
-	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
-	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_gauge
+(
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeDroppedAttrCount\` UInt32 CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`MetricName\` String CODEC(ZSTD(1)),
+    \`MetricDescription\` String CODEC(ZSTD(1)),
+    \`MetricUnit\` String CODEC(ZSTD(1)),
+    \`Attributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`StartTimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`Value\` Float64 CODEC(ZSTD(1)),
+    \`Flags\` UInt32 CODEC(ZSTD(1)),
+    \`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    \`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    \`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+    \`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+    \`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
-TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Metrics Sum Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_metrics_sum (
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	MetricName String CODEC(ZSTD(1)),
-	MetricDescription String CODEC(ZSTD(1)),
-	MetricUnit String CODEC(ZSTD(1)),
-	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	Value Float64 CODEC(ZSTD(1)),
-	Flags UInt32 CODEC(ZSTD(1)),
-	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
-	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
-	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
-	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
-	AggregationTemporality Int32 CODEC(ZSTD(1)),
-	IsMonotonic Bool CODEC(Delta(1), ZSTD(1)),
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_sum
+(
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeDroppedAttrCount\` UInt32 CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`MetricName\` String CODEC(ZSTD(1)),
+    \`MetricDescription\` String CODEC(ZSTD(1)),
+    \`MetricUnit\` String CODEC(ZSTD(1)),
+    \`Attributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`StartTimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`Value\` Float64 CODEC(ZSTD(1)),
+    \`Flags\` UInt32 CODEC(ZSTD(1)),
+    \`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    \`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    \`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+    \`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+    \`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+    \`AggregationTemporality\` Int32 CODEC(ZSTD(1)),
+    \`IsMonotonic\` Bool CODEC(Delta(1), ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
-TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Metrics Histogram Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_metrics_histogram (
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	MetricName String CODEC(ZSTD(1)),
-	MetricDescription String CODEC(ZSTD(1)),
-	MetricUnit String CODEC(ZSTD(1)),
-	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	Count UInt64 CODEC(Delta(8), ZSTD(1)),
-	Sum Float64 CODEC(ZSTD(1)),
-	BucketCounts Array(UInt64) CODEC(ZSTD(1)),
-	ExplicitBounds Array(Float64) CODEC(ZSTD(1)),
-	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
-	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
-	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
-	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
-	Flags UInt32 CODEC(ZSTD(1)),
-	Min Float64 CODEC(ZSTD(1)),
-	Max Float64 CODEC(ZSTD(1)),
-	AggregationTemporality Int32 CODEC(ZSTD(1)),
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_histogram
+(
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeDroppedAttrCount\` UInt32 CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`MetricName\` String CODEC(ZSTD(1)),
+    \`MetricDescription\` String CODEC(ZSTD(1)),
+    \`MetricUnit\` String CODEC(ZSTD(1)),
+    \`Attributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`StartTimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`Count\` UInt64 CODEC(Delta(8), ZSTD(1)),
+    \`Sum\` Float64 CODEC(ZSTD(1)),
+    \`BucketCounts\` Array(UInt64) CODEC(ZSTD(1)),
+    \`ExplicitBounds\` Array(Float64) CODEC(ZSTD(1)),
+    \`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    \`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    \`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+    \`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+    \`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+    \`Flags\` UInt32 CODEC(ZSTD(1)),
+    \`Min\` Float64 CODEC(ZSTD(1)),
+    \`Max\` Float64 CODEC(ZSTD(1)),
+    \`AggregationTemporality\` Int32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
-TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Metrics Summary Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_metrics_summary (
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	MetricName String CODEC(ZSTD(1)),
-	MetricDescription String CODEC(ZSTD(1)),
-	MetricUnit String CODEC(ZSTD(1)),
-	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	Count UInt64 CODEC(Delta(8), ZSTD(1)),
-	Sum Float64 CODEC(ZSTD(1)),
-	\`ValueAtQuantiles.Quantile\` Array(Float64) CODEC(ZSTD(1)),
-	\`ValueAtQuantiles.Value\` Array(Float64) CODEC(ZSTD(1)),
-	Flags UInt32 CODEC(ZSTD(1)),
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_summary
+(
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeDroppedAttrCount\` UInt32 CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`MetricName\` String CODEC(ZSTD(1)),
+    \`MetricDescription\` String CODEC(ZSTD(1)),
+    \`MetricUnit\` String CODEC(ZSTD(1)),
+    \`Attributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`StartTimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`Count\` UInt64 CODEC(Delta(8), ZSTD(1)),
+    \`Sum\` Float64 CODEC(ZSTD(1)),
+    \`ValueAtQuantiles.Quantile\` Array(Float64) CODEC(ZSTD(1)),
+    \`ValueAtQuantiles.Value\` Array(Float64) CODEC(ZSTD(1)),
+    \`Flags\` UInt32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
-TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Metrics Exponential Histogram Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_metrics_exponential_histogram (
-	ResourceAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ResourceSchemaUrl String CODEC(ZSTD(1)),
-	ScopeName String CODEC(ZSTD(1)),
-	ScopeVersion String CODEC(ZSTD(1)),
-	ScopeAttributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	ScopeDroppedAttrCount UInt32 CODEC(ZSTD(1)),
-	ScopeSchemaUrl String CODEC(ZSTD(1)),
-	ServiceName LowCardinality(String) CODEC(ZSTD(1)),
-	MetricName String CODEC(ZSTD(1)),
-	MetricDescription String CODEC(ZSTD(1)),
-	MetricUnit String CODEC(ZSTD(1)),
-	Attributes Map(LowCardinality(String), String) CODEC(ZSTD(1)),
-	StartTimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	TimeUnix DateTime64(9) CODEC(Delta(8), ZSTD(1)),
-	Count UInt64 CODEC(Delta(8), ZSTD(1)),
-	Sum Float64 CODEC(ZSTD(1)),
-	Scale Int32 CODEC(ZSTD(1)),
-	ZeroCount UInt64 CODEC(ZSTD(1)),
-	PositiveOffset Int32 CODEC(ZSTD(1)),
-	PositiveBucketCounts Array(UInt64) CODEC(ZSTD(1)),
-	NegativeOffset Int32 CODEC(ZSTD(1)),
-	NegativeBucketCounts Array(UInt64) CODEC(ZSTD(1)),
-	\`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
-	\`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
-	\`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
-	\`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
-	\`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
-	Flags UInt32 CODEC(ZSTD(1)),
-	Min Float64 CODEC(ZSTD(1)),
-	Max Float64 CODEC(ZSTD(1)),
-	AggregationTemporality Int32 CODEC(ZSTD(1)),
-	INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
-	INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_metrics_exponential_histogram
+(
+    \`ResourceAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ResourceSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ScopeName\` String CODEC(ZSTD(1)),
+    \`ScopeVersion\` String CODEC(ZSTD(1)),
+    \`ScopeAttributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`ScopeDroppedAttrCount\` UInt32 CODEC(ZSTD(1)),
+    \`ScopeSchemaUrl\` String CODEC(ZSTD(1)),
+    \`ServiceName\` LowCardinality(String) CODEC(ZSTD(1)),
+    \`MetricName\` String CODEC(ZSTD(1)),
+    \`MetricDescription\` String CODEC(ZSTD(1)),
+    \`MetricUnit\` String CODEC(ZSTD(1)),
+    \`Attributes\` Map(LowCardinality(String), String) CODEC(ZSTD(1)),
+    \`StartTimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`TimeUnix\` DateTime64(9) CODEC(Delta(8), ZSTD(1)),
+    \`Count\` UInt64 CODEC(Delta(8), ZSTD(1)),
+    \`Sum\` Float64 CODEC(ZSTD(1)),
+    \`Scale\` Int32 CODEC(ZSTD(1)),
+    \`ZeroCount\` UInt64 CODEC(ZSTD(1)),
+    \`PositiveOffset\` Int32 CODEC(ZSTD(1)),
+    \`PositiveBucketCounts\` Array(UInt64) CODEC(ZSTD(1)),
+    \`NegativeOffset\` Int32 CODEC(ZSTD(1)),
+    \`NegativeBucketCounts\` Array(UInt64) CODEC(ZSTD(1)),
+    \`Exemplars.FilteredAttributes\` Array(Map(LowCardinality(String), String)) CODEC(ZSTD(1)),
+    \`Exemplars.TimeUnix\` Array(DateTime64(9)) CODEC(ZSTD(1)),
+    \`Exemplars.Value\` Array(Float64) CODEC(ZSTD(1)),
+    \`Exemplars.SpanId\` Array(String) CODEC(ZSTD(1)),
+    \`Exemplars.TraceId\` Array(String) CODEC(ZSTD(1)),
+    \`Flags\` UInt32 CODEC(ZSTD(1)),
+    \`Min\` Float64 CODEC(ZSTD(1)),
+    \`Max\` Float64 CODEC(ZSTD(1)),
+    \`AggregationTemporality\` Int32 CODEC(ZSTD(1)),
+    INDEX idx_res_attr_key mapKeys(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_res_attr_value mapValues(ResourceAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_key mapKeys(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_scope_attr_value mapValues(ScopeAttributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_key mapKeys(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1,
+    INDEX idx_attr_value mapValues(Attributes) TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(TimeUnix)
-ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp(TimeUnix))
-TTL toDateTime(TimeUnix) + INTERVAL 730 HOUR
+ORDER BY (ServiceName, MetricName, Attributes, toUnixTimestamp64Nano(TimeUnix))
+TTL toDateTime(TimeUnix) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# OTEL Traces TraceID Timestamp Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE TABLE IF NOT EXISTS otel_traces_trace_id_ts (
-	TraceId String CODEC(ZSTD(1)),
-	Start DateTime CODEC(Delta(4), ZSTD(1)),
-	End DateTime CODEC(Delta(4), ZSTD(1)),
-	INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
-) ENGINE = MergeTree
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE TABLE IF NOT EXISTS otel_traces_trace_id_ts
+(
+    \`TraceId\` String CODEC(ZSTD(1)),
+    \`Start\` DateTime CODEC(Delta(4), ZSTD(1)),
+    \`End\` DateTime CODEC(Delta(4), ZSTD(1)),
+    INDEX idx_trace_id TraceId TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = MergeTree
 PARTITION BY toDate(Start)
 ORDER BY (TraceId, Start)
-TTL toDateTime(Start) + INTERVAL 730 HOUR
+TTL toDateTime(Start) + toIntervalHour(730)
 SETTINGS index_granularity = 8192, ttl_only_drop_parts = 1
 "
 
-# Materialized View for Trace Timestamp Table
-clickhouse-client --database="$DATABASE_NAME" --query "
-CREATE MATERIALIZED VIEW IF NOT EXISTS otel_traces_trace_id_ts_mv
-TO otel_traces_trace_id_ts
+clickhouse-client --database="${CLICKHOUSE_DATABASE}" --query "
+CREATE MATERIALIZED VIEW IF NOT EXISTS otel_traces_trace_id_ts_mv TO otel_traces_trace_id_ts
+(
+    \`TraceId\` String,
+    \`Start\` DateTime64(9),
+    \`End\` DateTime64(9)
+)
 AS SELECT
-	TraceId,
-	toDateTime(min(Timestamp)) AS Start,
-	toDateTime(max(Timestamp)) AS End
+    TraceId,
+    min(Timestamp) AS Start,
+    max(Timestamp) AS End
 FROM otel_traces
 WHERE TraceId != ''
 GROUP BY TraceId

--- a/assets/otel-collector-config.yaml
+++ b/assets/otel-collector-config.yaml
@@ -24,7 +24,8 @@ exporters:
     ttl: 730h
     logs_table_name: otel_logs
     traces_table_name: otel_traces
-    metrics_table_name: otel_metrics
+    # Metrics use separate tables by type: otel_metrics_gauge, otel_metrics_sum,
+    # otel_metrics_histogram, otel_metrics_summary, otel_metrics_exponential_histogram
     timeout: 5s
     retry_on_failure:
       enabled: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,20 @@ services:
     environment:
       CLICKHOUSE_PASSWORD: ${OPENLIT_DB_PASSWORD:-OPENLIT}
       CLICKHOUSE_USER: ${OPENLIT_DB_USER:-default}
+      CLICKHOUSE_DATABASE: ${OPENLIT_DB_NAME:-openlit}
+      CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS: true
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ./assets/clickhouse-config.xml:/etc/clickhouse-server/config.d/custom-config.xml:ro
+      - ./assets/clickhouse-init.sh:/docker-entrypoint-initdb.d/init.sh:ro
     ports:
       - "9000:9000"
       - "8123:8123"
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     restart: always
 
   openlit:
@@ -50,7 +58,8 @@ services:
       - "4317:4317"  # OTLP gRPC receiver
       - "4318:4318"  # OTLP HTTP receiver
     depends_on:
-      - clickhouse
+      clickhouse:
+        condition: service_healthy
     volumes:
       - openlit-data:/app/client/data
       - ./assets/otel-collector-config.yaml:/etc/otel/otel-collector-config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9000:9000"
       - "8123:8123"
     healthcheck:
-      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      test: ["CMD", "clickhouse-client", "--user", "$${CLICKHOUSE_USER}", "--password", "$${CLICKHOUSE_PASSWORD}", "--query", "SELECT 1"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,10 +15,11 @@ services:
       - "9000:9000"
       - "8123:8123"
     healthcheck:
-      test: ["CMD", "clickhouse-client", "--user", "$${CLICKHOUSE_USER}", "--password", "$${CLICKHOUSE_PASSWORD}", "--query", "SELECT 1"]
+      test: ["CMD-SHELL", "clickhouse-client --user=$${CLICKHOUSE_USER} --password=$${CLICKHOUSE_PASSWORD} --query='SELECT 1' || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 10
+      start_period: 30s
     restart: always
 
   openlit:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -107,10 +107,12 @@ COPY --from=builder /app/client/public ./public
 COPY --from=builder /app/client/.next/static ./.next/static
 COPY --from=builder /app/client/prisma ./prisma
 COPY --from=builder /app/client/scripts ./scripts
-# Copying prisma client, prisma and prisma cli (.bin) from builder stage
-COPY --from=builder /app/client/node_modules/@prisma ./node_modules/@prisma
+# Copying prisma and prisma cli (.bin) from builder stage (but NOT @prisma client - we'll regenerate it)
 COPY --from=builder /app/client/node_modules/.bin ./node_modules/.bin
 COPY --from=builder /app/client/node_modules/prisma ./node_modules/prisma
+
+# Regenerate Prisma client for Debian (to get correct binaries instead of Alpine/musl ones)
+RUN npx prisma generate
 
 # Copy the built opamp-server binary from go-builder stage
 COPY --from=go-builder /app/opamp-server/opamp-server /app/opamp/opamp-server

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -107,12 +107,10 @@ COPY --from=builder /app/client/public ./public
 COPY --from=builder /app/client/.next/static ./.next/static
 COPY --from=builder /app/client/prisma ./prisma
 COPY --from=builder /app/client/scripts ./scripts
-# Copying prisma and prisma cli (.bin) from builder stage (but NOT @prisma client - we'll regenerate it)
+# Copying prisma client, prisma and prisma cli (.bin) from builder stage
+COPY --from=builder /app/client/node_modules/@prisma ./node_modules/@prisma
 COPY --from=builder /app/client/node_modules/.bin ./node_modules/.bin
 COPY --from=builder /app/client/node_modules/prisma ./node_modules/prisma
-
-# Regenerate Prisma client for Debian (to get correct binaries instead of Alpine/musl ones)
-RUN npx prisma generate
 
 # Copy the built opamp-server binary from go-builder stage
 COPY --from=go-builder /app/opamp-server/opamp-server /app/opamp/opamp-server

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.15.1",
+      "version": "1.15.2",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.21.1",
         "@clickhouse/client": "^1.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/client/prisma/schema.prisma
+++ b/src/client/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x", "linux-musl-arm64-openssl-3.0.x"]
+  binaryTargets = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
 }
 
 datasource db {

--- a/src/dev-docker-compose.yml
+++ b/src/dev-docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9000:9000"
       - "8123:8123"
     healthcheck:
-      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      test: ["CMD", "clickhouse-client", "--user", "$${CLICKHOUSE_USER}", "--password", "$${CLICKHOUSE_PASSWORD}", "--query", "SELECT 1"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/src/dev-docker-compose.yml
+++ b/src/dev-docker-compose.yml
@@ -15,10 +15,11 @@ services:
       - "9000:9000"
       - "8123:8123"
     healthcheck:
-      test: ["CMD", "clickhouse-client", "--user", "$${CLICKHOUSE_USER}", "--password", "$${CLICKHOUSE_PASSWORD}", "--query", "SELECT 1"]
+      test: ["CMD-SHELL", "clickhouse-client --user=$${CLICKHOUSE_USER} --password=$${CLICKHOUSE_PASSWORD} --query='SELECT 1' || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 10
+      start_period: 30s
     restart: always
 
   openlit:

--- a/src/dev-docker-compose.yml
+++ b/src/dev-docker-compose.yml
@@ -5,12 +5,20 @@ services:
     environment:
       CLICKHOUSE_PASSWORD: ${OPENLIT_DB_PASSWORD:-OPENLIT}
       CLICKHOUSE_USER: ${OPENLIT_DB_USER:-default}
+      CLICKHOUSE_DATABASE: ${OPENLIT_DB_NAME:-openlit}
+      CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS: true
     volumes:
       - clickhouse-data:/var/lib/clickhouse
       - ../assets/clickhouse-config.xml:/etc/clickhouse-server/config.d/custom-config.xml:ro
+      - ../assets/clickhouse-init.sh:/docker-entrypoint-initdb.d/init.sh:ro
     ports:
       - "9000:9000"
       - "8123:8123"
+    healthcheck:
+      test: ["CMD", "clickhouse-client", "--query", "SELECT 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
     restart: always
 
   openlit:
@@ -53,7 +61,8 @@ services:
       - "4317:4317"  # OTLP gRPC receiver
       - "4318:4318"  # OTLP HTTP receiver
     depends_on:
-      - clickhouse
+      clickhouse:
+        condition: service_healthy
     volumes:
       - openlit-data:/app/client/data
       - ../assets/otel-collector-config.yaml:/etc/otel/otel-collector-config.yaml


### PR DESCRIPTION
**Issue number**:
Fixes: #953

### Change description:
This PR creates a script for creating database and table for otel collector version that doesn't automatically create these. Also run this script always as, it detects and creates table and database only when those doesn't exist.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [X] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [X] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Ensure ClickHouse is automatically initialized with the required OpenTelemetry schema and that dependent services wait for a healthy database before starting.

Bug Fixes:
- Prevent OpenTelemetry Collector failures by creating the ClickHouse database and all required OTEL tables at container startup, even when they do not already exist.

Enhancements:
- Add a ClickHouse init script and wiring in docker-compose to always run schema setup, including separate metric tables per type.
- Configure ClickHouse health checks and make application/collector services depend on a healthy ClickHouse instance.
- Document the updated ClickHouse metrics table layout in the OTEL collector configuration comments.
- Bump the client package version from 1.15.1 to 1.15.2 to reflect these changes.

Build:
- Mount ClickHouse initialization script and configuration via docker-compose for both production and development setups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures ClickHouse is ready with the OTEL schema and that dependent services start only after the DB is healthy.
> 
> - Add `assets/clickhouse-init.sh` to create the database and all required OTEL tables (separate metrics tables per type) plus a materialized view
> - Update `docker-compose.yml` and `src/dev-docker-compose.yml` to mount the init script, set `CLICKHOUSE_DATABASE`, enable `CLICKHOUSE_ALWAYS_RUN_INITDB_SCRIPTS`, add ClickHouse healthcheck, and gate `openlit` on `service_healthy`
> - Adjust `assets/otel-collector-config.yaml` to reflect per-type metrics tables (comments) and keep logs/traces table names
> - Bump client version to `1.15.2` in `src/client/package.json` and lockfile
> - Change Prisma `binaryTargets` to OpenSSL 1.1 variants in `src/client/prisma/schema.prisma`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8415fea506c70686c92d6b62289cfbf1161967. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->