### PR TITLE
Fix: Wrong TARGETARCH

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -70,7 +70,7 @@ RUN curl -LO "https://github.com/open-telemetry/opentelemetry-collector-releases
     tar -xzf "otelcol-contrib_${OTEL_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
     chmod +x otelcol-contrib
 
-# Download OpAMP Supervisor 
+# Download OpAMP Supervisor
 RUN curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor \
     "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fopampsupervisor%2F${OPAMP_SUPERVISOR_VERSION}/opampsupervisor_${OPAMP_SUPERVISOR_VERSION#v}_linux_${TARGETARCH}" && \
     chmod +x opampsupervisor

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -57,7 +57,7 @@ FROM alpine AS otel-downloader
 # Accept build arguments
 ARG OTEL_VERSION=v0.142.0
 ARG OPAMP_SUPERVISOR_VERSION=v0.142.0
-ARG TARGETARCH=arm64
+ARG TARGETARCH=amd64
 
 # Install curl for downloading binaries
 RUN apk add --no-cache curl

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -55,8 +55,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o opamp-server .
 FROM alpine AS otel-downloader
 
 # Accept build arguments
-ARG OTEL_VERSION=v0.132.4
-ARG OPAMP_SUPERVISOR_VERSION=v0.132.4
+ARG OTEL_VERSION=v0.142.0
+ARG OPAMP_SUPERVISOR_VERSION=v0.142.0
 ARG TARGETARCH=arm64
 
 # Install curl for downloading binaries
@@ -70,7 +70,7 @@ RUN curl -LO "https://github.com/open-telemetry/opentelemetry-collector-releases
     tar -xzf "otelcol-contrib_${OTEL_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
     chmod +x otelcol-contrib
 
-# Download OpAMP Supervisor
+# Download OpAMP Supervisor 
 RUN curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor \
     "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fopampsupervisor%2F${OPAMP_SUPERVISOR_VERSION}/opampsupervisor_${OPAMP_SUPERVISOR_VERSION#v}_linux_${TARGETARCH}" && \
     chmod +x opampsupervisor

--- a/src/opamp-server/setup-supervisor.sh
+++ b/src/opamp-server/setup-supervisor.sh
@@ -213,7 +213,8 @@ cat > "${INSTRUCTIONS_FILE}" << EOF
 
 \`\`\`bash
 # Download the latest OpAMP supervisor binary
-curl -LO https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest/download/opampsupervisor_linux_amd64
+curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor_linux_amd64 \
+    "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fopampsupervisor%2Fv0.142.0/opampsupervisor_0.142.0_linux_amd64"
 
 # Make it executable
 chmod +x opampsupervisor_linux_amd64


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.

> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:
https://github.com/openlit/openlit/issues/965

### Change description:
Fixed: Wrong TARGETARCH

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Align OpAMP supervisor artifacts with the correct architecture and pinned version for Docker builds and manual installation instructions.

Build:
- Update Docker build arguments to use OpenTelemetry Collector and OpAMP supervisor version v0.142.0 and default TARGETARCH to amd64.

Documentation:
- Refresh supervisor setup instructions to download a pinned OpAMP supervisor v0.142.0 Linux amd64 binary over a stricter HTTPS configuration.