### PR TITLE
fix: Opamp Supervisor not able to run or execute in the linux environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-      start_period: 30s
+      start_period: 100s
     restart: always
 
   openlit:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -79,6 +79,14 @@ RUN curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor \
 # Final runtime image - Use slim-bullseye (Debian) for compatibility
 FROM python:3.11-slim-bullseye
 
+# Accept build arguments to pass version and architecture info
+ARG OPAMP_SUPERVISOR_VERSION=v0.142.0
+ARG TARGETARCH=amd64
+
+# Set as environment variables for use by scripts
+ENV OPAMP_SUPERVISOR_VERSION=${OPAMP_SUPERVISOR_VERSION}
+ENV TARGETARCH=${TARGETARCH}
+
 # Install Node.js from NodeSource repository
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -54,34 +54,41 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o opamp-server .
 # OpenTelemetry Collector Contrib download
 FROM alpine AS otel-downloader
 
-# Accept build arguments
-ARG OTEL_VERSION=v0.132.4
-ARG OPAMP_SUPERVISOR_VERSION=v0.132.4
-ARG TARGETARCH=arm64
+# Accept build arguments (TARGETARCH is automatically provided by Docker buildx)
+# Default to amd64 if not specified (most common architecture)
+ARG OTEL_VERSION=v0.142.0
+ARG OPAMP_SUPERVISOR_VERSION=v0.142.0
+ARG TARGETARCH=amd64
+ARG TARGETPLATFORM
 
-# Install curl for downloading binaries
-RUN apk add --no-cache curl
+# Install curl and file utilities for downloading binaries and verification
+RUN apk add --no-cache curl file
 
 # Set working directory
 WORKDIR /tmp
 
-# Download OpenTelemetry Collector Contrib
-RUN curl -LO "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/${OTEL_VERSION}/otelcol-contrib_${OTEL_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
+# Download OpenTelemetry Collector Contrib and OpAMP Supervisor
+RUN echo "Downloading binaries for architecture: ${TARGETARCH}" && \
+    curl -LO "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/${OTEL_VERSION}/otelcol-contrib_${OTEL_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
     tar -xzf "otelcol-contrib_${OTEL_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
-    chmod +x otelcol-contrib
-
-# Download OpAMP Supervisor
-RUN curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor \
+    chmod +x otelcol-contrib && \
+    echo "otelcol-contrib binary info:" && file otelcol-contrib && \
+    curl --proto '=https' --tlsv1.2 -fL -o opampsupervisor \
     "https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fopampsupervisor%2F${OPAMP_SUPERVISOR_VERSION}/opampsupervisor_${OPAMP_SUPERVISOR_VERSION#v}_linux_${TARGETARCH}" && \
-    chmod +x opampsupervisor
+    chmod +x opampsupervisor && \
+    echo "opampsupervisor binary info:" && file opampsupervisor
 
 
 # Final runtime image - Use slim-bullseye (Debian) for compatibility
 FROM python:3.11-slim-bullseye
 
 # Accept build arguments to pass version and architecture info
+# TARGETARCH is automatically provided by Docker buildx based on --platform
+# Default to amd64 if not specified (must match otel-downloader stage)
 ARG OPAMP_SUPERVISOR_VERSION=v0.142.0
 ARG TARGETARCH=amd64
+ARG TARGETPLATFORM
+
 
 # Set as environment variables for use by scripts
 ENV OPAMP_SUPERVISOR_VERSION=${OPAMP_SUPERVISOR_VERSION}
@@ -129,6 +136,14 @@ COPY --from=go-builder /app/opamp-server/setup-supervisor.sh /app/opamp/setup-su
 # Place otelcol-contrib at the path expected by supervisor configuration file
 COPY --from=otel-downloader /tmp/otelcol-contrib /app/opamp/otelcontribcol
 COPY --from=otel-downloader /tmp/opampsupervisor /app/opamp/opampsupervisor
+
+# Verify binary architectures match runtime
+RUN apt-get update && apt-get install -y --no-install-recommends file && \
+    echo "Verifying binary architectures..." && \
+    echo "Runtime architecture: $(uname -m)" && \
+    echo "otelcontribcol:" && file /app/opamp/otelcontribcol && \
+    echo "opampsupervisor:" && file /app/opamp/opampsupervisor && \
+    rm -rf /var/lib/apt/lists/*
 
 # Execute entrypoint script to generate NextAuth.js secret and run commands
 RUN chmod +x ./scripts/entrypoint.sh /app/opamp/otelcontribcol /app/opamp/opampsupervisor /app/opamp/opamp-server /app/opamp/setup-supervisor.sh

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.15.2",
+      "version": "1.15.3",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.21.1",
         "@clickhouse/client": "^1.1.0",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/dev-docker-compose.yml
+++ b/src/dev-docker-compose.yml
@@ -19,7 +19,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
-      start_period: 30s
+      start_period: 100s
     restart: always
 
   openlit:


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

Fix : #965
Fix: #957
Fix: #951

### Change description:
This PR fixes the opamp supervisor version of setting the opamp supervisor server using the target architecture.

Thanks @AIRobotNic for the direction of fixing this bug. Reference PR : https://github.com/openlit/openlit/pull/966

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Update OpAMP supervisor setup and container build to correctly handle architecture-specific binaries and versions across environments.

Bug Fixes:
- Ensure OpAMP supervisor download and execution use the correct target architecture and version on Linux and other platforms.

Enhancements:
- Allow configuring OpAMP supervisor version and target architecture via script flags and environment variables, with automatic architecture detection.
- Increase docker-compose healthcheck start period to give services more time to become healthy on startup.
- Bump client package version to reflect the updated OpAMP supervisor behavior.

Build:
- Update Dockerfile to use newer OpenTelemetry Collector and OpAMP supervisor versions and to download architecture-specific binaries based on Docker build arguments, validating their architectures at build time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fixes OpAMP supervisor execution across architectures** by making arch/version configurable and aligning downloaded binaries with the runtime.
> 
> - Updates `Dockerfile` to OTEL/OpAMP v0.142.0, default `TARGETARCH=amd64`, propagates env (`OPAMP_SUPERVISOR_VERSION`, `TARGETARCH`), and verifies binary architectures at runtime
> - Enhances `setup-supervisor.sh` with `--version`/`--arch` flags, auto-arch detection, and arch-aware deployment instructions/commands
> - Increases ClickHouse healthcheck `start_period` to `100s` in `docker-compose.yml` and `src/dev-docker-compose.yml`
> - Bumps client version to `1.15.3`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0707fe27afaf20d14713c2a9f4b504423052a771. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->