### PR TITLE
build: Update to python 3.10 to support langchain >1.0.0

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -45,7 +45,8 @@ opentelemetry-instrumentation-system-metrics = {version = ">=0.52b0,<1.0.0", opt
 openai = "^1.1.1"
 anthropic = ">=0.42.0,<1.0.0"
 openai-agents = ">=0.0.3"
-langchain = "^0.3.15"
+langchain = "^1.2.0"
+langchain-core = "^1.2.1"
 
 [tool.poetry.scripts]
 openlit-instrument = "openlit.cli.main:run"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9.0"
+python = "^3.10.0"
 requests = "^2.26.0"
 schedule = "^1.2.2"
 pydantic = "^2.0.0"


### PR DESCRIPTION
**Issue number**: https://github.com/openlit/openlit/issues/949

### Change description:
- Python 3.9.0 → 3.10.0 upgrade
- LangChain 0.3.15 → 1.2.0 upgrade
- LangChain Core 1.2.1 addition (Necessary with new langchain)

### Checklist
If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Update Python and LangChain versions in the Python SDK build configuration.

Build:
- Bump Python runtime requirement from 3.9 to 3.10 in the SDK pyproject configuration.
- Upgrade LangChain dependency to 1.2.0 and add a langchain-core 1.2.1 dependency in the SDK pyproject.

## Summary by Sourcery

Update Python SDK runtime and LangChain dependencies to align with newer ecosystem requirements.

Build:
- Raise Python runtime requirement for the SDK from 3.9 to 3.10 in pyproject configuration.
- Upgrade LangChain dependency to 1.2.0 and add a langchain-core 1.2.1 dependency in pyproject configuration.