### PR TITLE
fix: handle None tool arguments in OpenAI streaming responses

### DIFF
--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -123,17 +123,21 @@ def process_chat_chunk(scope, chunk):
                     scope._tools[idx] = {
                         "id": tool["id"],
                         "function": {
-                            "name": func.get("name", ""),
-                            "arguments": func.get("arguments", ""),
+                            # Use `or ""` to handle explicit None values from some providers
+                            "name": func.get("name") or "",
+                            "arguments": func.get("arguments") or "",
                         },
                         "type": tool.get("type", "function"),
                     }
                 elif (
                     scope._tools[idx] and "function" in tool
                 ):  # Append args (id is None)
-                    scope._tools[idx]["function"]["arguments"] += tool["function"].get(
-                        "arguments", ""
-                    )
+                    # Handle None arguments - some providers return None instead of ""
+                    new_args = tool["function"].get("arguments") or ""
+                    if scope._tools[idx]["function"]["arguments"] is None:
+                        scope._tools[idx]["function"]["arguments"] = new_args
+                    else:
+                        scope._tools[idx]["function"]["arguments"] += new_args
 
     # Extract metadata
     scope._response_id = chunked.get("id") or scope._response_id


### PR DESCRIPTION
**Issue number**: #989

### Change description:

Some OpenAI-compatible providers (e.g., `moonshotai/kimi-k2.5` via OpenRouter) return `None` for `function.arguments` instead of an empty string during streaming tool calls. This causes a `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'` when attempting to concatenate arguments.

**Changes:**
- Use `or ""` instead of default parameter to handle explicit `None` values when initializing tool arguments
- Add `None` check before string concatenation in argument accumulation

**Before:**
```python
"arguments": func.get("arguments", ""),  # Returns None if value is explicitly None
```

**After:**
```python
"arguments": func.get("arguments") or "",  # Returns "" for both missing and None values
```

### Checklist

* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ ] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Bug Fixes:
- Prevent TypeError when accumulating streaming tool call arguments by safely handling None values for function name and arguments.