### PR TITLE
fix(langgraph): prevent wrapping of ToolNode objects

### DIFF
--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -515,7 +515,13 @@ def wrap_add_node(
 
         # Wrap the action function
         node_name = str(node_key) if not isinstance(node_key, str) else node_key
-        wrapped_action = create_wrapped_node(action, node_name)
+
+        # FIX: Check if action is a function/routine. 
+        # If it is a class instance (like ToolNode), do NOT wrap it.
+        if inspect.isroutine(action):
+            wrapped_action = create_wrapped_node(action, node_name)
+        else:
+            wrapped_action = action
 
         # Call original add_node with wrapped action
         if args and len(args) > 1:

--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -516,7 +516,7 @@ def wrap_add_node(
         # Wrap the action function
         node_name = str(node_key) if not isinstance(node_key, str) else node_key
 
-        # FIX: Check if action is a function/routine. 
+        # FIX: Check if action is a function/routine.
         # If it is a class instance (like ToolNode), do NOT wrap it.
         if inspect.isroutine(action):
             wrapped_action = create_wrapped_node(action, node_name)


### PR DESCRIPTION
**Issue number**: #986

### Change description:
This PR fixes a crash in LangGraph instrumentation. Previously, `wrap_add_node` was incorrectly wrapping class instances (like `ToolNode`) into a function wrapper. This caused LangGraph's internal `inspect` calls to fail with a `TypeError`.

I added a check using `inspect.isroutine()` to ensure we only wrap functions/routines, allowing `ToolNode` objects to pass through unwrapped.

### Checklist

* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

## Summary by Sourcery

Bug Fixes:
- Avoid crashing LangGraph instrumentation by only wrapping node actions that are routines/functions and leaving class instance actions unwrapped.