### PR TITLE
fix: Async Generator Syntax Error Preventing Initialization

### DIFF
--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -780,7 +780,7 @@ def async_workflow_run_wrap(
                 async for event in result:
                     yield event
             else:
-                return await result
+                yield await result
             return
 
         workflow_name = getattr(instance, "name", "unknown_workflow")

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -780,7 +780,8 @@ def async_workflow_run_wrap(
                 async for event in result:
                     yield event
             else:
-                yield await result
+                # Test
+                return await result
             return
 
         workflow_name = getattr(instance, "name", "unknown_workflow")

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -780,8 +780,7 @@ def async_workflow_run_wrap(
                 async for event in result:
                     yield event
             else:
-                # Test
-                return await result
+                yield await result
             return
 
         workflow_name = getattr(instance, "name", "unknown_workflow")


### PR DESCRIPTION
**Issue number**: #997 

### Change description:

This PR fixes a critical initialization bug in the v1.36.8 release. The `async_workflow_run_wrap` function is an async generator, but was using `return await result` on line 783, which violates Python's async generator syntax rules (PEP 525). This was changed to `yield await result` to fix the error `'return' with value in async generator` that prevented OpenLIT from initializing. This one-word fix restores full functionality.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Bug Fixes:
- Correct async generator behavior in async_agno instrumentation by yielding awaited results instead of returning them, preventing initialization errors.