### PR TITLE
feat: Use Otel Events in Anthropic, Google, Azure and AWS instrumentations

### DIFF
--- a/contributors/OTEL_ATTRIBUTE_MAPPING.md
+++ b/contributors/OTEL_ATTRIBUTE_MAPPING.md
@@ -17,76 +17,169 @@ Quick reference for mapping provider-specific parameters to OpenTelemetry Gen-AI
 
 | OTel Attribute | Constant | Type | Description | Example |
 |----------------|----------|------|-------------|---------|
-| `gen_ai.operation` | `GEN_AI_OPERATION` | string | Type of operation | `"chat"`, `"completion"`, `"embedding"` |
-| `gen_ai.request.model` | `GEN_AI_REQUEST_MODEL` | string | Model requested | `"gpt-4"`, `"claude-3-opus"` |
-| `gen_ai.response.model` | `GEN_AI_RESPONSE_MODEL` | string | Model that responded | `"gpt-4-0613"` |
+| `gen_ai.operation.name` | `GEN_AI_OPERATION_NAME` | string | **REQUIRED** - Name of the operation being performed | `"chat"`, `"completion"`, `"embedding"` |
 
 ---
 
-## Content Attributes (Chat/Completions)
+## Conditionally Required Attributes (Inference)
 
-| OTel Attribute | Constant | Type | Description | Format |
-|----------------|----------|------|-------------|--------|
-| `gen_ai.input.messages` | `GEN_AI_INPUT_MESSAGES` | array | Structured input messages | See [Input Message Schema](#input-message-schema) |
-| `gen_ai.output.messages` | `GEN_AI_OUTPUT_MESSAGES` | array | Structured output messages | See [Output Message Schema](#output-message-schema) |
-| `gen_ai.system_instructions` | `GEN_AI_SYSTEM_INSTRUCTIONS` | string | System prompt (alternative to messages) | `"You are a helpful assistant"` |
-| `gen_ai.tool.definitions` | `GEN_AI_TOOL_DEFINITIONS` | array | Available tool/function definitions | See [Tool Definition Schema](#tool-definition-schema) |
+These attributes MUST be included when the specified condition is met:
 
----
-
-## Request Parameters (Optional)
-
-| OTel Attribute | Constant | Type | Provider Parameter | Default |
-|----------------|----------|------|-------------------|---------|
-| `gen_ai.request.temperature` | `GEN_AI_REQUEST_TEMPERATURE` | double | `temperature` | Provider-specific |
-| `gen_ai.request.max_tokens` | `GEN_AI_REQUEST_MAX_TOKENS` | int | `max_tokens`, `max_completion_tokens` | Provider-specific |
-| `gen_ai.request.top_p` | `GEN_AI_REQUEST_TOP_P` | double | `top_p` | 1.0 |
-| `gen_ai.request.top_k` | `GEN_AI_REQUEST_TOP_K` | int | `top_k` | Provider-specific |
-| `gen_ai.request.frequency_penalty` | `GEN_AI_REQUEST_FREQUENCY_PENALTY` | double | `frequency_penalty` | 0.0 |
-| `gen_ai.request.presence_penalty` | `GEN_AI_REQUEST_PRESENCE_PENALTY` | double | `presence_penalty` | 0.0 |
-| `gen_ai.request.stop_sequences` | `GEN_AI_REQUEST_STOP_SEQUENCES` | array[string] | `stop` | `[]` |
-| `gen_ai.request.seed` | `GEN_AI_REQUEST_SEED` | int | `seed` | None |
+| OTel Attribute | Constant | Type | Condition | Description | Example |
+|----------------|----------|------|-----------|-------------|---------|
+| `error.type` | `ERROR_TYPE` | string | If operation ended in error | Error class/type describing the error | `"timeout"`, `"rate_limit"` |
+| `gen_ai.conversation.id` | `GEN_AI_CONVERSATION_ID` | string | When readily available | Identifies the conversation/session | `"session-abc123"` |
+| `gen_ai.output.type` | `GEN_AI_OUTPUT_TYPE` | string | When applicable | Requested content type | `"text"`, `"json_object"` |
+| `gen_ai.request.choice.count` | `GEN_AI_REQUEST_CHOICE_COUNT` | int | If available and ≠ 1 | Number of choices requested | `3` |
+| `gen_ai.request.model` | `GEN_AI_REQUEST_MODEL` | string | If available | Model name being called | `"gpt-4"`, `"claude-3-opus"` |
+| `gen_ai.request.seed` | `GEN_AI_REQUEST_SEED` | int | If seed was provided | Seed for deterministic generation | `42` |
+| `server.port` | `SERVER_PORT` | int | If server.address is set | Server port number | `443` |
 
 ---
 
-## Response Metadata (Recommended)
+## Recommended Attributes (Inference)
+
+These attributes SHOULD be included when available:
+
+### Request Parameters
 
 | OTel Attribute | Constant | Type | Description | Example |
 |----------------|----------|------|-------------|---------|
+| `gen_ai.request.frequency_penalty` | `GEN_AI_REQUEST_FREQUENCY_PENALTY` | double | Frequency penalty setting | `0.5` |
+| `gen_ai.request.max_tokens` | `GEN_AI_REQUEST_MAX_TOKENS` | int | Maximum tokens to generate | `1024` |
+| `gen_ai.request.presence_penalty` | `GEN_AI_REQUEST_PRESENCE_PENALTY` | double | Presence penalty setting | `0.3` |
+| `gen_ai.request.stop_sequences` | `GEN_AI_REQUEST_STOP_SEQUENCES` | string[] | Sequences where model stops | `["END", "\n\n"]` |
+| `gen_ai.request.temperature` | `GEN_AI_REQUEST_TEMPERATURE` | double | Temperature setting | `0.7` |
+| `gen_ai.request.top_p` | `GEN_AI_REQUEST_TOP_P` | double | Top-p (nucleus) sampling | `0.9` |
+
+### Response Metadata
+
+| OTel Attribute | Constant | Type | Description | Example |
+|----------------|----------|------|-------------|---------|
+| `gen_ai.response.finish_reasons` | `GEN_AI_RESPONSE_FINISH_REASONS` | string[] | Reasons model stopped | `["stop"]`, `["max_tokens"]` |
 | `gen_ai.response.id` | `GEN_AI_RESPONSE_ID` | string | Unique response identifier | `"chatcmpl-123"` |
-| `gen_ai.response.finish_reasons` | `GEN_AI_RESPONSE_FINISH_REASONS` | array[string] | Why generation stopped | `["stop"]`, `["max_tokens"]` |
-| `gen_ai.response.choice_count` | `GEN_AI_RESPONSE_CHOICE_COUNT` | int | Number of choices returned | `1` |
-| `gen_ai.response.output_type` | `GEN_AI_RESPONSE_OUTPUT_TYPE` | string | Output format type | `"text"`, `"json_object"` |
+| `gen_ai.response.model` | `GEN_AI_RESPONSE_MODEL` | string | Model that generated response | `"gpt-4-0613"` |
 
----
+### Usage Metrics
 
-## Usage Metrics (Recommended)
+| OTel Attribute | Constant | Type | Description | Example |
+|----------------|----------|------|-------------|---------|
+| `gen_ai.usage.cache_creation.input_tokens` | `GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS` | int | Input tokens written to cache | `512` |
+| `gen_ai.usage.cache_read.input_tokens` | `GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS` | int | Input tokens served from cache | `256` |
+| `gen_ai.usage.input_tokens` | `GEN_AI_USAGE_INPUT_TOKENS` | int | Total tokens in prompt | `128` |
+| `gen_ai.usage.output_tokens` | `GEN_AI_USAGE_OUTPUT_TOKENS` | int | Tokens in response | `64` |
 
-| OTel Attribute | Constant | Type | Description |
-|----------------|----------|------|-------------|
-| `gen_ai.usage.input_tokens` | `GEN_AI_USAGE_INPUT_TOKENS` | int | Tokens in input/prompt |
-| `gen_ai.usage.output_tokens` | `GEN_AI_USAGE_OUTPUT_TOKENS` | int | Tokens in output/completion |
-
----
-
-## Server Attributes (Recommended)
+### Server Information
 
 | OTel Attribute | Type | Description | Example |
 |----------------|------|-------------|---------|
-| `server.address` | string | API server hostname/IP | `"api.openai.com"`, `"api.anthropic.com"` |
-| `server.port` | int | API server port | `443` |
+| `server.address` | string | GenAI server hostname/IP | `"api.openai.com"`, `"api.anthropic.com"` |
 
 ---
 
-## Evaluation Attributes
+## Opt-In Attributes (Content - Chat/Completions)
 
-| OTel Attribute | Constant | Type | Required | Description | Example |
-|----------------|----------|------|----------|-------------|---------|
-| `gen_ai.evaluation.name` | `GEN_AI_EVALUATION_NAME` | string | Yes | Type of evaluation | `"hallucination"`, `"bias_detection"` |
-| `gen_ai.evaluation.score.value` | `GEN_AI_EVALUATION_SCORE_VALUE` | double | Conditional | Numerical score (0.0-1.0) | `0.85` |
-| `gen_ai.evaluation.score.label` | `GEN_AI_EVALUATION_SCORE_LABEL` | string | Conditional | Human-readable label | `"yes"`, `"no"`, `"pass"`, `"fail"` |
-| `gen_ai.evaluation.explanation` | `GEN_AI_EVALUATION_EXPLANATION` | string | Recommended | Brief explanation | `"The output contains factual inaccuracies"` |
-| `gen_ai.response.id` | `GEN_AI_RESPONSE_ID` | string | Recommended | Response being evaluated | `"chatcmpl-123"` |
+These attributes contain sensitive content and MUST only be included when explicitly enabled via `capture_message_content=True`:
+
+| OTel Attribute | Constant | Type | Description | Format |
+|----------------|----------|------|-------------|--------|
+| `gen_ai.input.messages` | `GEN_AI_INPUT_MESSAGES` | array | Chat history provided to model as input | See [Input Message Schema](#input-message-schema) |
+| `gen_ai.output.messages` | `GEN_AI_OUTPUT_MESSAGES` | array | Messages returned by model (responses) | See [Output Message Schema](#output-message-schema) |
+| `gen_ai.system_instructions` | `GEN_AI_SYSTEM_INSTRUCTIONS` | string or array | System message/instructions separate from chat | `"You are a helpful assistant"` |
+| `gen_ai.tool.definitions` | `GEN_AI_TOOL_DEFINITIONS` | array | List of tool/function definitions available | See [Tool Definition Schema](#tool-definition-schema) |
+
+**Important:** These attributes contain user data and MUST only be set when `capture_message_content=True`.
+
+---
+
+## Evaluation Event Attributes
+
+### Event: `gen_ai.evaluation.result`
+
+#### Required Attributes
+
+| OTel Attribute | Constant | Type | Description | Example |
+|----------------|----------|------|-------------|---------|
+| `gen_ai.evaluation.name` | `GEN_AI_EVALUATION_NAME` | string | **REQUIRED** - Evaluation metric name used | `"hallucination"`, `"bias_detection"`, `"toxicity"` |
+
+#### Conditionally Required Attributes
+
+| OTel Attribute | Constant | Type | Condition | Description | Example |
+|----------------|----------|------|-----------|-------------|---------|
+| `error.type` | `ERROR_TYPE` | string | If operation ended in error | Error type for failed evaluation | `"api_error"` |
+| `gen_ai.evaluation.score.label` | `GEN_AI_EVALUATION_SCORE_LABEL` | string | At least one of label/value required | Human-readable evaluation label | `"yes"`, `"no"`, `"pass"`, `"fail"` |
+| `gen_ai.evaluation.score.value` | `GEN_AI_EVALUATION_SCORE_VALUE` | double | At least one of label/value required | Numeric evaluation score | `0.85` |
+
+**Note:** Either `score.label` or `score.value` (or both) MUST be present for the evaluation to be meaningful.
+
+#### Recommended Attributes
+
+| OTel Attribute | Constant | Type | Description | Example |
+|----------------|----------|------|-------------|---------|
+| `gen_ai.evaluation.explanation` | `GEN_AI_EVALUATION_EXPLANATION` | string | Free-form explanation for assigned score | `"The output contains factual inaccuracies"` |
+| `gen_ai.response.id` | `GEN_AI_RESPONSE_ID` | string | Links evaluation to specific GenAI response | `"chatcmpl-123"` |
+
+---
+
+## Attribute Requirement Levels
+
+Understanding when to include attributes is critical for OTel compliance:
+
+### Required
+- **MUST** be included in every event
+- Missing required attributes makes the event non-compliant
+- Example: `gen_ai.operation.name`
+
+### Conditionally Required
+- **MUST** be included when the specified condition is met
+- The condition describes when the attribute becomes mandatory
+- Examples:
+  - `error.type` - Required IF the operation ended in error
+  - `server.port` - Required IF `server.address` is set
+  - `gen_ai.request.seed` - Required IF a seed was provided in the request
+
+### Recommended
+- **SHOULD** be included when the information is available
+- Improves observability but not strictly required
+- Examples: `gen_ai.response.id`, `gen_ai.usage.input_tokens`
+
+### Opt-In
+- **MUST NOT** be included by default (contains sensitive data)
+- Only include when user explicitly enables via configuration flag
+- Examples: `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.tool.definitions`
+- Check: `if capture_message_content and event_provider:`
+
+### Implementation Guidelines
+
+```python
+# Required - always include
+attributes = {
+    "gen_ai.operation.name": "chat",  # REQUIRED
+}
+
+# Conditionally Required - check condition first
+if error_occurred:
+    attributes["error.type"] = error_type  # REQUIRED when condition met
+
+if server_address:
+    attributes["server.address"] = server_address
+    attributes["server.port"] = server_port  # REQUIRED when server.address set
+
+if seed is not None:
+    attributes["gen_ai.request.seed"] = seed  # REQUIRED when provided
+
+# Recommended - include when available
+if response_id:
+    attributes["gen_ai.response.id"] = response_id  # RECOMMENDED
+
+if input_tokens is not None:
+    attributes["gen_ai.usage.input_tokens"] = input_tokens  # RECOMMENDED
+
+# Opt-In - only when explicitly enabled
+if capture_message_content and event_provider:
+    attributes["gen_ai.input.messages"] = input_messages  # OPT-IN
+    attributes["gen_ai.output.messages"] = output_messages  # OPT-IN
+```
 
 ---
 
@@ -337,106 +430,169 @@ tool_definitions = [
 
 ### OpenAI / Azure OpenAI
 
-| OpenAI Parameter | OTel Attribute | Notes |
-|------------------|----------------|-------|
-| `messages` | `gen_ai.input.messages` | Transform to structured format |
-| `model` | `gen_ai.request.model` | Direct mapping |
-| `temperature` | `gen_ai.request.temperature` | Direct mapping |
-| `max_tokens` | `gen_ai.request.max_tokens` | Direct mapping |
-| `top_p` | `gen_ai.request.top_p` | Direct mapping |
-| `frequency_penalty` | `gen_ai.request.frequency_penalty` | Direct mapping |
-| `presence_penalty` | `gen_ai.request.presence_penalty` | Direct mapping |
-| `stop` | `gen_ai.request.stop_sequences` | Direct mapping |
-| `seed` | `gen_ai.request.seed` | Direct mapping |
-| `tools` | `gen_ai.tool.definitions` | Direct mapping |
-| `response_format.type` | `gen_ai.response.output_type` | Direct mapping |
+Request mapping:
+| OpenAI Parameter | OTel Attribute | Required Level | Notes |
+|------------------|----------------|----------------|-------|
+| `messages` | `gen_ai.input.messages` | Opt-In | Transform to structured format |
+| `model` | `gen_ai.request.model` | Conditionally Required | Direct mapping |
+| `temperature` | `gen_ai.request.temperature` | Recommended | Direct mapping |
+| `max_tokens` / `max_completion_tokens` | `gen_ai.request.max_tokens` | Recommended | Direct mapping |
+| `top_p` | `gen_ai.request.top_p` | Recommended | Direct mapping |
+| `frequency_penalty` | `gen_ai.request.frequency_penalty` | Recommended | Direct mapping |
+| `presence_penalty` | `gen_ai.request.presence_penalty` | Recommended | Direct mapping |
+| `stop` | `gen_ai.request.stop_sequences` | Recommended | Direct mapping |
+| `seed` | `gen_ai.request.seed` | Conditionally Required | Include if provided |
+| `n` | `gen_ai.request.choice.count` | Conditionally Required | Include if ≠ 1 |
+| `tools` / `functions` | `gen_ai.tool.definitions` | Opt-In | Direct mapping |
+| `response_format.type` | `gen_ai.output.type` | Conditionally Required | When applicable |
 
 Response mapping:
-| OpenAI Field | OTel Attribute |
-|--------------|----------------|
-| `id` | `gen_ai.response.id` |
-| `model` | `gen_ai.response.model` |
-| `choices[0].message.content` | Part of `gen_ai.output.messages` |
-| `choices[0].message.tool_calls` | Part of `gen_ai.output.messages` |
-| `choices[0].finish_reason` | Part of `gen_ai.output.messages[0].finish_reason` |
-| `usage.prompt_tokens` | `gen_ai.usage.input_tokens` |
-| `usage.completion_tokens` | `gen_ai.usage.output_tokens` |
+| OpenAI Field | OTel Attribute | Required Level | Notes |
+|--------------|----------------|----------------|-------|
+| `id` | `gen_ai.response.id` | Recommended | Direct mapping |
+| `model` | `gen_ai.response.model` | Recommended | Direct mapping |
+| `choices[0].message.content` | Part of `gen_ai.output.messages` | Opt-In | Text content |
+| `choices[0].message.tool_calls` | Part of `gen_ai.output.messages` | Opt-In | Tool calls |
+| `choices[0].finish_reason` | Part of `gen_ai.output.messages[0].finish_reason` | Recommended | Map: length→max_tokens |
+| `usage.prompt_tokens` | `gen_ai.usage.input_tokens` | Recommended | Direct mapping |
+| `usage.completion_tokens` | `gen_ai.usage.output_tokens` | Recommended | Direct mapping |
+| `usage.prompt_tokens_details.cached_tokens` | `gen_ai.usage.cache_read.input_tokens` | Recommended | Cached input tokens |
+| `system_fingerprint` | Custom attribute | Optional | OpenAI-specific backend configuration identifier |
 
 ### Anthropic
 
-| Anthropic Parameter | OTel Attribute | Notes |
-|---------------------|----------------|-------|
-| `messages` | `gen_ai.input.messages` | Transform to structured format |
-| `system` | `gen_ai.system_instructions` | Single string (not in messages array) |
-| `model` | `gen_ai.request.model` | Direct mapping |
-| `temperature` | `gen_ai.request.temperature` | Direct mapping |
-| `max_tokens` | `gen_ai.request.max_tokens` | Direct mapping |
-| `top_p` | `gen_ai.request.top_p` | Direct mapping |
-| `top_k` | `gen_ai.request.top_k` | Direct mapping |
-| `stop_sequences` | `gen_ai.request.stop_sequences` | Direct mapping |
-| `tools` | `gen_ai.tool.definitions` | Transform if needed |
+Request mapping:
+| Anthropic Parameter | OTel Attribute | Required Level | Notes |
+|---------------------|----------------|----------------|-------|
+| `messages` | `gen_ai.input.messages` | Opt-In | Transform to structured format |
+| `system` | `gen_ai.system_instructions` | Opt-In | Single string (not in messages array) |
+| `model` | `gen_ai.request.model` | Conditionally Required | Direct mapping |
+| `temperature` | `gen_ai.request.temperature` | Recommended | Direct mapping |
+| `max_tokens` | `gen_ai.request.max_tokens` | Recommended | Direct mapping |
+| `top_p` | `gen_ai.request.top_p` | Recommended | Direct mapping |
+| `top_k` | `gen_ai.request.top_k` | Recommended | Direct mapping (Anthropic-specific) |
+| `stop_sequences` | `gen_ai.request.stop_sequences` | Recommended | Direct mapping |
+| `tools` | `gen_ai.tool.definitions` | Opt-In | Transform if needed |
 
 Response mapping:
-| Anthropic Field | OTel Attribute |
-|-----------------|----------------|
-| `id` | `gen_ai.response.id` |
-| `model` | `gen_ai.response.model` |
-| `content[0].text` | Part of `gen_ai.output.messages` |
-| `content[*].type="tool_use"` | Part of `gen_ai.output.messages` |
-| `stop_reason` | Map to `gen_ai.output.messages[0].finish_reason` |
-| `usage.input_tokens` | `gen_ai.usage.input_tokens` |
-| `usage.output_tokens` | `gen_ai.usage.output_tokens` |
+| Anthropic Field | OTel Attribute | Required Level |
+|-----------------|----------------|----------------|
+| `id` | `gen_ai.response.id` | Recommended |
+| `model` | `gen_ai.response.model` | Recommended |
+| `content[0].text` | Part of `gen_ai.output.messages` | Opt-In |
+| `content[*].type="tool_use"` | Part of `gen_ai.output.messages` | Opt-In |
+| `stop_reason` | Map to `gen_ai.output.messages[0].finish_reason` | Recommended |
+| `usage.input_tokens` | `gen_ai.usage.input_tokens` | Recommended |
+| `usage.output_tokens` | `gen_ai.usage.output_tokens` | Recommended |
+| `usage.cache_creation_input_tokens` | `gen_ai.usage.cache_creation.input_tokens` | Recommended |
+| `usage.cache_read_input_tokens` | `gen_ai.usage.cache_read.input_tokens` | Recommended |
 
 ### Google (Gemini)
 
-| Google Parameter | OTel Attribute | Notes |
-|------------------|----------------|-------|
-| `contents` | `gen_ai.input.messages` | Already uses "parts" structure |
-| `systemInstruction` | `gen_ai.system_instructions` | Direct mapping |
-| `model` | `gen_ai.request.model` | Extract from full name |
-| `generationConfig.temperature` | `gen_ai.request.temperature` | Direct mapping |
-| `generationConfig.maxOutputTokens` | `gen_ai.request.max_tokens` | Direct mapping |
-| `generationConfig.topP` | `gen_ai.request.top_p` | Direct mapping |
-| `generationConfig.topK` | `gen_ai.request.top_k` | Direct mapping |
-| `generationConfig.stopSequences` | `gen_ai.request.stop_sequences` | Direct mapping |
-| `tools` | `gen_ai.tool.definitions` | Transform `function_declarations` |
+Request mapping:
+| Google Parameter | OTel Attribute | Required Level | Notes |
+|------------------|----------------|----------------|-------|
+| `contents` | `gen_ai.input.messages` | Opt-In | Already uses "parts" structure, map role "model"→"assistant" |
+| `systemInstruction` | `gen_ai.system_instructions` | Opt-In | Direct mapping |
+| `model` | `gen_ai.request.model` | Conditionally Required | Extract from full name (e.g., "models/gemini-pro" → "gemini-pro") |
+| `generationConfig.temperature` | `gen_ai.request.temperature` | Recommended | Direct mapping |
+| `generationConfig.maxOutputTokens` | `gen_ai.request.max_tokens` | Recommended | Direct mapping |
+| `generationConfig.topP` | `gen_ai.request.top_p` | Recommended | Direct mapping |
+| `generationConfig.topK` | `gen_ai.request.top_k` | Recommended | Direct mapping |
+| `generationConfig.stopSequences` | `gen_ai.request.stop_sequences` | Recommended | Direct mapping |
+| `generationConfig.seed` | `gen_ai.request.seed` | Conditionally Required | Include if provided |
+| `tools` | `gen_ai.tool.definitions` | Opt-In | Transform `function_declarations` |
 
 Response mapping:
-| Google Field | OTel Attribute |
-|--------------|----------------|
-| Response doesn't have ID | `gen_ai.response.id` = None |
-| Extracted from request | `gen_ai.response.model` |
-| `candidates[0].content.parts[0].text` | Part of `gen_ai.output.messages` |
-| `candidates[0].content.parts[*].functionCall` | Part of `gen_ai.output.messages` |
-| `candidates[0].finishReason` | Map to `gen_ai.output.messages[0].finish_reason` |
-| `usageMetadata.promptTokenCount` | `gen_ai.usage.input_tokens` |
-| `usageMetadata.candidatesTokenCount` | `gen_ai.usage.output_tokens` |
+| Google Field | OTel Attribute | Required Level | Notes |
+|--------------|----------------|----------------|-------|
+| N/A | `gen_ai.response.id` | Recommended | Google doesn't provide response IDs - set to None |
+| Extracted from request | `gen_ai.response.model` | Recommended | Use request model |
+| `candidates[0].content.parts[0].text` | Part of `gen_ai.output.messages` | Opt-In | Text content |
+| `candidates[0].content.parts[*].functionCall` | Part of `gen_ai.output.messages` | Opt-In | Tool calls (no IDs provided) |
+| `candidates[0].finishReason` | Map to `gen_ai.output.messages[0].finish_reason` | Recommended | Map: STOP→stop, MAX_TOKENS→max_tokens, SAFETY→content_filter |
+| `usageMetadata.promptTokenCount` | `gen_ai.usage.input_tokens` | Recommended | Direct mapping |
+| `usageMetadata.candidatesTokenCount` | `gen_ai.usage.output_tokens` | Recommended | Direct mapping |
+| `usageMetadata.cachedContentTokenCount` | `gen_ai.usage.cache_read.input_tokens` | Recommended | Cached input tokens |
+| `usageMetadata.thoughtsTokenCount` | Custom attribute | Recommended | Google-specific reasoning tokens (not in OTel spec yet) |
 
 ### Cohere
 
-| Cohere Parameter | OTel Attribute | Notes |
-|------------------|----------------|-------|
-| `message` | `gen_ai.input.messages` | Transform to array with user role |
-| `chat_history` | `gen_ai.input.messages` | Combine with message |
-| `preamble` | `gen_ai.system_instructions` | Direct mapping |
-| `model` | `gen_ai.request.model` | Direct mapping |
-| `temperature` | `gen_ai.request.temperature` | Direct mapping |
-| `max_tokens` | `gen_ai.request.max_tokens` | Direct mapping |
-| `p` | `gen_ai.request.top_p` | Direct mapping |
-| `k` | `gen_ai.request.top_k` | Direct mapping |
-| `stop_sequences` | `gen_ai.request.stop_sequences` | Direct mapping |
-| `tools` | `gen_ai.tool.definitions` | Transform format |
+Request mapping:
+| Cohere Parameter | OTel Attribute | Required Level | Notes |
+|------------------|----------------|----------------|-------|
+| `message` | `gen_ai.input.messages` | Opt-In | Transform to array with user role |
+| `chat_history` | `gen_ai.input.messages` | Opt-In | Combine with message |
+| `preamble` | `gen_ai.system_instructions` | Opt-In | Direct mapping |
+| `model` | `gen_ai.request.model` | Conditionally Required | Direct mapping |
+| `temperature` | `gen_ai.request.temperature` | Recommended | Direct mapping |
+| `max_tokens` | `gen_ai.request.max_tokens` | Recommended | Direct mapping |
+| `p` | `gen_ai.request.top_p` | Recommended | Direct mapping (Cohere uses 'p' instead of 'top_p') |
+| `k` | `gen_ai.request.top_k` | Recommended | Direct mapping (Cohere uses 'k' instead of 'top_k') |
+| `stop_sequences` | `gen_ai.request.stop_sequences` | Recommended | Direct mapping |
+| `seed` | `gen_ai.request.seed` | Conditionally Required | Include if provided |
+| `tools` | `gen_ai.tool.definitions` | Opt-In | Transform format |
 
 Response mapping:
-| Cohere Field | OTel Attribute |
-|--------------|----------------|
-| `generation_id` | `gen_ai.response.id` |
-| From request | `gen_ai.response.model` |
-| `text` | Part of `gen_ai.output.messages` |
-| `tool_calls` | Part of `gen_ai.output.messages` |
-| `finish_reason` | Map to `gen_ai.output.messages[0].finish_reason` |
-| `meta.tokens.input_tokens` | `gen_ai.usage.input_tokens` |
-| `meta.tokens.output_tokens` | `gen_ai.usage.output_tokens` |
+| Cohere Field | OTel Attribute | Required Level | Notes |
+|--------------|----------------|----------------|-------|
+| `generation_id` | `gen_ai.response.id` | Recommended | Direct mapping |
+| From request | `gen_ai.response.model` | Recommended | Echo request model |
+| `text` | Part of `gen_ai.output.messages` | Opt-In | Text content |
+| `tool_calls` | Part of `gen_ai.output.messages` | Opt-In | Tool calls |
+| `finish_reason` | Map to `gen_ai.output.messages[0].finish_reason` | Recommended | Map: COMPLETE→stop, MAX_TOKENS→max_tokens |
+| `meta.tokens.input_tokens` | `gen_ai.usage.input_tokens` | Recommended | Direct mapping |
+| `meta.tokens.output_tokens` | `gen_ai.usage.output_tokens` | Recommended | Direct mapping |
+
+---
+
+## Missing Attributes to Add
+
+Based on the OTel Gen-AI semantic conventions, these attributes are currently missing from our implementation and should be added:
+
+### High Priority (Conditionally Required)
+
+| Attribute | Type | Condition | Current Status | Implementation Notes |
+|-----------|------|-----------|----------------|---------------------|
+| `gen_ai.conversation.id` | string | When readily available | ❌ Not implemented | Add when session/conversation tracking is available |
+| `gen_ai.output.type` | string | When applicable | ❌ Not implemented | Extract from `response_format.type` (OpenAI), add to emit_inference_event() |
+| `gen_ai.request.choice.count` | int | If available and ≠ 1 | ❌ Not implemented | Extract from `n` parameter (OpenAI), add to emit_inference_event() |
+| `error.type` | string | If operation failed | ❌ Not implemented | Capture error class in exception handlers, add to event attributes |
+
+### Medium Priority (Recommended)
+
+| Attribute | Type | Current Status | Implementation Notes |
+|-----------|------|----------------|---------------------|
+| `gen_ai.request.frequency_penalty` | double | ✅ Partially | Only in OpenAI, add to Anthropic/Google event emission |
+| `gen_ai.request.presence_penalty` | double | ✅ Partially | Only in OpenAI, add to event emission |
+| `gen_ai.usage.cache_creation.input_tokens` | int | ❌ Not implemented | Anthropic provides this, add to emit_inference_event() |
+| `gen_ai.usage.cache_read.input_tokens` | int | ❌ Not implemented | Anthropic & OpenAI provide this, add to emit_inference_event() |
+
+### Implementation Checklist
+
+**For OpenAI:**
+- [ ] Add `gen_ai.output.type` from `response_format.type`
+- [ ] Add `gen_ai.request.choice.count` from `n` parameter
+- [ ] Add `gen_ai.usage.cache_read.input_tokens` from `usage.prompt_tokens_details.cached_tokens`
+- [ ] Add `gen_ai.request.frequency_penalty` to event emission
+- [ ] Add `gen_ai.request.presence_penalty` to event emission
+- [ ] Add error handling with `error.type` attribute
+
+**For Anthropic:**
+- [ ] Add `gen_ai.usage.cache_creation.input_tokens` from `usage.cache_creation_input_tokens`
+- [ ] Add `gen_ai.usage.cache_read.input_tokens` from `usage.cache_read_input_tokens`
+- [ ] Add error handling with `error.type` attribute
+
+**For Google AI Studio:**
+- [ ] Add `gen_ai.usage.cache_read.input_tokens` from `usageMetadata.cachedContentTokenCount`
+- [ ] Add `gen_ai.request.seed` when provided
+- [ ] Add error handling with `error.type` attribute
+
+**All Providers:**
+- [ ] Add `gen_ai.conversation.id` extraction when session tracking is available
+- [ ] Implement error.type capture in exception handlers
+- [ ] Update emit_inference_event() signature to accept new attributes
+- [ ] Update SemanticConvention constants for new attributes
 
 ---
 
@@ -499,19 +655,47 @@ emit_inference_event(
 
 ## Validation Checklist
 
-When implementing event emission:
+When implementing event emission, verify:
 
-- [ ] Event name is exactly `gen_ai.client.inference.operation.details`
+### Event Structure
+- [ ] Event name is exactly `gen_ai.client.inference.operation.details` (inference) or `gen_ai.evaluation.result` (evaluation)
+- [ ] Event body is empty string (all data in attributes per OTel spec)
+- [ ] Using OTel EventLoggerProvider (not span events)
+
+### Required Attributes
+- [ ] `gen_ai.operation.name` always present (inference events)
+- [ ] `gen_ai.evaluation.name` always present (evaluation events)
+
+### Conditionally Required Attributes
+- [ ] `error.type` included if operation failed
+- [ ] `server.port` included if `server.address` is set
+- [ ] `gen_ai.request.seed` included if seed was provided
+- [ ] `gen_ai.evaluation.score.label` or `gen_ai.evaluation.score.value` present (at least one)
+
+### Recommended Attributes
+- [ ] Request parameters included when available (`temperature`, `max_tokens`, `top_p`, etc.)
+- [ ] Response metadata included when available (`response_id`, `finish_reasons`, `response_model`)
+- [ ] Usage metrics included when available (`input_tokens`, `output_tokens`, cache tokens)
+- [ ] Server information included when known (`server.address`, `server.port`)
+
+### Opt-In Attributes (Content)
+- [ ] Content attributes ONLY included when `capture_message_content=True`
 - [ ] Input messages are structured objects (not JSON strings)
 - [ ] Output messages are structured objects (not JSON strings)
-- [ ] No data URIs in image references (only HTTP/HTTPS)
-- [ ] All required attributes present
-- [ ] Finish reasons mapped to OTel standard values
+- [ ] No data URIs in image references (only HTTP/HTTPS URLs)
 - [ ] Tool definitions included when tools are used
-- [ ] Request parameters included when available
-- [ ] Response metadata included when available
-- [ ] Usage tokens included when available
-- [ ] Server address/port included when known
+- [ ] System instructions included when present
+
+### Message Format
+- [ ] Input messages follow [OTel input schema](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-input-messages.json)
+- [ ] Output messages follow [OTel output schema](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/gen-ai/gen-ai-output-messages.json)
+- [ ] Finish reasons mapped to OTel standard values (not provider-specific)
+- [ ] Message parts use correct types: `text`, `uri`, `tool_call`, `tool_call_response`
+
+### Error Handling
+- [ ] Event emission wrapped in try/except (never raises)
+- [ ] Silent failures with warning logs
+- [ ] Instrumentation continues even if event emission fails
 
 ---
 
@@ -524,4 +708,15 @@ When implementing event emission:
 
 ---
 
-**Last Updated:** 2026-02-12
+## Summary of Requirement Levels
+
+| Level | Symbol | Meaning | Example |
+|-------|--------|---------|---------|
+| **Required** | 🔴 | MUST be present in every event | `gen_ai.operation.name` |
+| **Conditionally Required** | 🟡 | MUST be present when condition met | `error.type` (if error occurred) |
+| **Recommended** | 🟢 | SHOULD be present when available | `gen_ai.response.id`, `gen_ai.usage.input_tokens` |
+| **Opt-In** | 🔵 | Only when explicitly enabled (sensitive data) | `gen_ai.input.messages`, `gen_ai.output.messages` |
+
+---
+
+**Last Updated:** 2026-02-12 (Expanded with complete OTel attribute requirements)

--- a/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
@@ -28,6 +28,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
         capture_message_content = kwargs.get("capture_message_content", False)
         metrics = kwargs.get("metrics_dict")
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
 
         # sync
         wrap_function_wrapper(
@@ -42,6 +43,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -58,6 +60,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 

--- a/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
@@ -22,6 +22,7 @@ def messages(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Anthropic Messages.create calls.
@@ -40,6 +41,7 @@ def messages(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -63,6 +65,7 @@ def messages(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -95,6 +98,7 @@ def messages(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -119,7 +123,13 @@ def messages(
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
 
             return TracedSyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider,
             )
 
         else:
@@ -142,6 +152,7 @@ def messages(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 

--- a/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
@@ -22,6 +22,7 @@ def async_messages(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Anthropic AsyncMessages.create calls.
@@ -40,6 +41,7 @@ def async_messages(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -63,6 +65,7 @@ def async_messages(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -95,6 +98,7 @@ def async_messages(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -119,7 +123,13 @@ def async_messages(
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
 
             return TracedAsyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider,
             )
 
         else:
@@ -142,6 +152,7 @@ def async_messages(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 

--- a/sdk/python/src/openlit/instrumentation/anthropic/utils.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/utils.py
@@ -50,6 +50,353 @@ def format_content(messages):
     return "\n".join(formatted_messages)
 
 
+def build_input_messages(messages, system=None):
+    """
+    Convert Anthropic request messages to OTel input message structure.
+
+    Args:
+        messages: Anthropic messages array from request
+        system: Optional system instruction string
+
+    Returns:
+        List of ChatMessage objects with role and parts
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if not messages:
+        return []
+
+    otel_messages = []
+
+    # Add system message first if present
+    if system:
+        otel_messages.append(
+            {"role": "system", "parts": [{"type": "text", "content": system}]}
+        )
+
+    for message in messages:
+        try:
+            # Extract role
+            role = (
+                message.get("role", "user")
+                if isinstance(message, dict)
+                else getattr(message, "role", "user")
+            )
+
+            # Extract content
+            content = (
+                message.get("content", "")
+                if isinstance(message, dict)
+                else getattr(message, "content", "")
+            )
+
+            parts = []
+
+            if isinstance(content, list):
+                # Multi-part content (text, images, tool results)
+                for item in content:
+                    item_type = (
+                        item.get("type")
+                        if isinstance(item, dict)
+                        else getattr(item, "type", None)
+                    )
+
+                    if item_type == "text":
+                        text_content = (
+                            item.get("text", "")
+                            if isinstance(item, dict)
+                            else getattr(item, "text", "")
+                        )
+                        if text_content:
+                            parts.append({"type": "text", "content": text_content})
+
+                    elif item_type == "image":
+                        # Anthropic image format: {"type": "image", "source": {"type": "url", "url": "..."}}
+                        source = (
+                            item.get("source", {})
+                            if isinstance(item, dict)
+                            else getattr(item, "source", {})
+                        )
+                        if isinstance(source, dict) and source.get("type") == "url":
+                            url = source.get("url", "")
+                            if url and not url.startswith("data:"):
+                                parts.append(
+                                    {"type": "uri", "modality": "image", "uri": url}
+                                )
+
+                    elif item_type == "tool_use":
+                        # Anthropic tool use in request (assistant message)
+                        tool_id = (
+                            item.get("id", "")
+                            if isinstance(item, dict)
+                            else getattr(item, "id", "")
+                        )
+                        tool_name = (
+                            item.get("name", "")
+                            if isinstance(item, dict)
+                            else getattr(item, "name", "")
+                        )
+                        tool_input = (
+                            item.get("input", {})
+                            if isinstance(item, dict)
+                            else getattr(item, "input", {})
+                        )
+                        parts.append(
+                            {
+                                "type": "tool_call",
+                                "id": tool_id,
+                                "name": tool_name,
+                                "arguments": tool_input,
+                            }
+                        )
+
+                    elif item_type == "tool_result":
+                        # Anthropic tool result (user providing tool response)
+                        tool_id = (
+                            item.get("tool_use_id", "")
+                            if isinstance(item, dict)
+                            else getattr(item, "tool_use_id", "")
+                        )
+                        tool_content = (
+                            item.get("content", "")
+                            if isinstance(item, dict)
+                            else getattr(item, "content", "")
+                        )
+                        parts.append(
+                            {
+                                "type": "tool_call_response",
+                                "id": tool_id,
+                                "response": str(tool_content),
+                            }
+                        )
+
+            elif isinstance(content, str) and content:
+                # Simple string content
+                parts.append({"type": "text", "content": content})
+
+            if parts:
+                otel_messages.append({"role": role, "parts": parts})
+
+        except Exception as e:
+            logger.warning("Failed to process input message: %s", e, exc_info=True)
+            continue
+
+    return otel_messages
+
+
+def build_output_messages(response_text, finish_reason, tool_calls=None):
+    """
+    Convert Anthropic response to OTel output message structure.
+
+    Args:
+        response_text: Response text from model
+        finish_reason: Finish reason from Anthropic (end_turn, max_tokens, stop_sequence, tool_use)
+        tool_calls: Optional tool calls dict from response
+
+    Returns:
+        List with single OutputMessage
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    parts = []
+
+    try:
+        # Add text content if present
+        if response_text:
+            parts.append({"type": "text", "content": response_text})
+
+        # Add tool call if present
+        if tool_calls:
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": tool_calls.get("id", ""),
+                    "name": tool_calls.get("name", ""),
+                    "arguments": tool_calls.get("input", {}),
+                }
+            )
+
+        # Map Anthropic finish reasons to OTel standard
+        finish_reason_map = {
+            "end_turn": "stop",
+            "max_tokens": "max_tokens",
+            "stop_sequence": "stop",
+            "tool_use": "tool_calls",
+        }
+
+        otel_finish_reason = finish_reason_map.get(
+            finish_reason, finish_reason or "stop"
+        )
+
+        return [
+            {"role": "assistant", "parts": parts, "finish_reason": otel_finish_reason}
+        ]
+
+    except Exception as e:
+        logger.warning("Failed to build output messages: %s", e, exc_info=True)
+        return [{"role": "assistant", "parts": [], "finish_reason": "stop"}]
+
+
+def build_tool_definitions(tools):
+    """
+    Extract tool/function definitions from Anthropic request.
+
+    Args:
+        tools: Tools array from Anthropic request
+
+    Returns:
+        List of tool definition objects or None
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if not tools:
+        return None
+
+    try:
+        tool_definitions = []
+
+        for tool in tools:
+            try:
+                if isinstance(tool, dict):
+                    # Anthropic format already compatible with OTel
+                    tool_definitions.append(
+                        {
+                            "type": "function",
+                            "name": tool.get("name", ""),
+                            "description": tool.get("description", ""),
+                            "parameters": tool.get("input_schema", {}),
+                        }
+                    )
+                else:
+                    # Handle object format
+                    tool_definitions.append(
+                        {
+                            "type": "function",
+                            "name": getattr(tool, "name", ""),
+                            "description": getattr(tool, "description", ""),
+                            "parameters": getattr(tool, "input_schema", {}),
+                        }
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to process tool definition: %s", e, exc_info=True
+                )
+                continue
+
+        return tool_definitions if tool_definitions else None
+
+    except Exception as e:
+        logger.warning("Failed to build tool definitions: %s", e, exc_info=True)
+        return None
+
+
+def emit_inference_event(
+    event_provider,
+    operation_name,
+    request_model,
+    response_model,
+    input_messages=None,
+    output_messages=None,
+    tool_definitions=None,
+    server_address=None,
+    server_port=None,
+    **extra_attrs,
+):
+    """
+    Emit gen_ai.client.inference.operation.details event.
+
+    Args:
+        event_provider: The OTel event provider
+        operation_name: Operation type (chat)
+        request_model: Model from request
+        response_model: Model from response
+        input_messages: Structured input messages
+        output_messages: Structured output messages
+        tool_definitions: Tool definitions
+        server_address: Server address
+        server_port: Server port
+        **extra_attrs: Additional attributes (temperature, max_tokens, etc.)
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        if not event_provider:
+            return
+
+        from openlit.__helpers import otel_event
+
+        # Build event attributes
+        attributes = {
+            SemanticConvention.GEN_AI_OPERATION: operation_name,
+        }
+
+        # Add model attributes
+        if request_model:
+            attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+        if response_model:
+            attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = response_model
+
+        # Add server attributes
+        if server_address:
+            attributes[SemanticConvention.SERVER_ADDRESS] = server_address
+        if server_port:
+            attributes[SemanticConvention.SERVER_PORT] = server_port
+
+        # Add messages
+        if input_messages is not None:
+            attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = input_messages
+        if output_messages is not None:
+            attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = output_messages
+
+        # Add tool definitions
+        if tool_definitions is not None:
+            attributes[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+        # Map extra attributes
+        for key, value in extra_attrs.items():
+            if value is not None:
+                if key == "response_id":
+                    attributes[SemanticConvention.GEN_AI_RESPONSE_ID] = value
+                elif key == "finish_reasons":
+                    attributes[SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON] = value
+                elif key == "output_type":
+                    attributes[SemanticConvention.GEN_AI_OUTPUT_TYPE] = value
+                elif key == "temperature":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TEMPERATURE] = value
+                elif key == "max_tokens":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS] = value
+                elif key == "top_p":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TOP_P] = value
+                elif key == "top_k":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TOP_K] = value
+                elif key == "stop_sequences":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES] = value
+                elif key == "input_tokens":
+                    attributes[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] = value
+                elif key == "output_tokens":
+                    attributes[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] = value
+
+        # Create and emit event
+        event = otel_event(
+            name=SemanticConvention.GEN_AI_CLIENT_INFERENCE_OPERATION_DETAILS,
+            attributes=attributes,
+            body="",
+        )
+
+        event_provider.emit(event)
+
+    except Exception as e:
+        logger.warning("Failed to emit inference event: %s", e, exc_info=True)
+
+
 def process_chunk(scope, chunk):
     """
     Process a chunk of response data and update state.
@@ -101,6 +448,7 @@ def common_chat_logic(
     disable_metrics,
     version,
     is_stream,
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -197,19 +545,43 @@ def common_chat_logic(
             SemanticConvention.GEN_AI_CONTENT_COMPLETION, scope._llmresponse
         )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: formatted_messages,
-            },
-        )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_COMPLETION: scope._llmresponse,
-            },
-        )
+        # Emit inference event
+        if event_provider:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            try:
+                input_msgs = build_input_messages(
+                    scope._kwargs.get("messages", []),
+                    system=scope._kwargs.get("system"),
+                )
+                output_msgs = build_output_messages(
+                    scope._llmresponse, scope._finish_reason, scope._tool_calls
+                )
+                tool_defs = build_tool_definitions(scope._kwargs.get("tools"))
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=output_msgs,
+                    tool_definitions=tool_defs,
+                    server_address=scope._server_address,
+                    server_port=scope._server_port,
+                    response_id=scope._response_id,
+                    finish_reasons=[scope._finish_reason],
+                    temperature=scope._kwargs.get("temperature"),
+                    max_tokens=scope._kwargs.get("max_tokens"),
+                    top_p=scope._kwargs.get("top_p"),
+                    top_k=scope._kwargs.get("top_k"),
+                    stop_sequences=scope._kwargs.get("stop_sequences"),
+                    input_tokens=scope._input_tokens,
+                    output_tokens=scope._output_tokens,
+                )
+            except Exception as e:
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -244,6 +616,7 @@ def process_streaming_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="",
+    event_provider=None,
 ):
     """
     Process streaming chat response and generate telemetry.
@@ -266,6 +639,7 @@ def process_streaming_chat_response(
         disable_metrics,
         version,
         is_stream=True,
+        event_provider=event_provider,
     )
 
 
@@ -283,6 +657,7 @@ def process_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -330,6 +705,7 @@ def process_chat_response(
         disable_metrics,
         version,
         is_stream=False,
+        event_provider=event_provider,
     )
 
     return response

--- a/sdk/python/src/openlit/instrumentation/anthropic/utils.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/utils.py
@@ -429,9 +429,7 @@ def process_chunk(scope, chunk):
         scope._cache_creation_input_tokens = message_usage.get(
             "cache_creation_input_tokens", 0
         )
-        scope._cache_read_input_tokens = message_usage.get(
-            "cache_read_input_tokens", 0
-        )
+        scope._cache_read_input_tokens = message_usage.get("cache_read_input_tokens", 0)
         scope._response_model = chunked.get("message").get("model")
         scope._response_role = chunked.get("message").get("role")
 

--- a/sdk/python/src/openlit/instrumentation/azure_ai_inference/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/azure_ai_inference/__init__.py
@@ -32,6 +32,7 @@ class AzureAIInferenceInstrumentor(BaseInstrumentor):
         pricing_info = kwargs.get("pricing_info", {})
         capture_message_content = kwargs.get("capture_message_content", False)
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
         version = importlib.metadata.version("azure-ai-inference")
 
         # sync chat completions
@@ -47,6 +48,7 @@ class AzureAIInferenceInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -63,6 +65,7 @@ class AzureAIInferenceInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -79,6 +82,7 @@ class AzureAIInferenceInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -95,6 +99,7 @@ class AzureAIInferenceInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 

--- a/sdk/python/src/openlit/instrumentation/azure_ai_inference/async_azure_ai_inference.py
+++ b/sdk/python/src/openlit/instrumentation/azure_ai_inference/async_azure_ai_inference.py
@@ -30,6 +30,7 @@ def async_complete(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -48,6 +49,7 @@ def async_complete(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -72,6 +74,7 @@ def async_complete(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -88,6 +91,7 @@ def async_complete(
                 capture_message_content,
                 disable_metrics,
                 version,
+                event_provider=self._event_provider,
             )
 
         def __aiter__(self):
@@ -119,7 +123,13 @@ def async_complete(
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
 
             return TracedAsyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider=event_provider,
             )
 
         else:
@@ -140,6 +150,7 @@ def async_complete(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 
@@ -157,6 +168,7 @@ def async_embed(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI embedding function call
@@ -195,6 +207,7 @@ def async_embed(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/azure_ai_inference/azure_ai_inference.py
+++ b/sdk/python/src/openlit/instrumentation/azure_ai_inference/azure_ai_inference.py
@@ -30,6 +30,7 @@ def complete(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -48,6 +49,7 @@ def complete(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -72,6 +74,7 @@ def complete(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -88,6 +91,7 @@ def complete(
                 capture_message_content,
                 disable_metrics,
                 version,
+                event_provider=self._event_provider,
             )
 
         def __iter__(self):
@@ -119,7 +123,13 @@ def complete(
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
 
             return TracedSyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider=event_provider,
             )
 
         else:
@@ -140,6 +150,7 @@ def complete(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 
@@ -157,6 +168,7 @@ def embed(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI embedding function call
@@ -195,6 +207,7 @@ def embed(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/azure_ai_inference/utils.py
+++ b/sdk/python/src/openlit/instrumentation/azure_ai_inference/utils.py
@@ -15,6 +15,7 @@ from openlit.__helpers import (
     common_span_attributes,
     record_completion_metrics,
     record_embedding_metrics,
+    otel_event,
 )
 from openlit.semcov import SemanticConvention
 
@@ -195,9 +196,6 @@ def emit_inference_event(
     try:
         if not event_provider:
             return
-
-        from openlit.__helpers import otel_event
-        from openlit.semcov import SemanticConvention
 
         # Build base attributes
         attributes = {

--- a/sdk/python/src/openlit/instrumentation/azure_ai_inference/utils.py
+++ b/sdk/python/src/openlit/instrumentation/azure_ai_inference/utils.py
@@ -43,6 +43,231 @@ def format_content(messages):
     return "\n".join(formatted_messages)
 
 
+def build_input_messages(messages):
+    """
+    Convert Azure AI Inference messages to OTel input message structure.
+
+    Args:
+        messages: List of message objects (OpenAI-compatible format)
+
+    Returns:
+        List of ChatMessage objects following OTel schema
+    """
+    structured_messages = []
+
+    for msg in messages:
+        # Extract role
+        role = msg.get("role", "user")
+
+        # Build parts array
+        parts = []
+        content = msg.get("content", "")
+
+        if isinstance(content, str):
+            # Simple text content
+            parts.append({"type": "text", "content": content})
+        elif isinstance(content, list):
+            # Multi-part content (text, images, etc.)
+            for part in content:
+                if part.get("type") == "text":
+                    parts.append({"type": "text", "content": part.get("text", "")})
+                elif part.get("type") == "image_url":
+                    image_url = part.get("image_url", {}).get("url", "")
+                    # Skip data URIs for privacy
+                    if not image_url.startswith("data:"):
+                        parts.append(
+                            {"type": "uri", "modality": "image", "uri": image_url}
+                        )
+
+        # Handle tool calls (for assistant messages)
+        if "tool_calls" in msg:
+            for tool_call in msg.get("tool_calls", []):
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": tool_call.get("id", ""),
+                        "name": tool_call.get("function", {}).get("name", ""),
+                        "arguments": tool_call.get("function", {}).get("arguments", {}),
+                    }
+                )
+
+        # Handle tool responses (for tool role)
+        if role == "tool" and "tool_call_id" in msg:
+            parts.append(
+                {
+                    "type": "tool_call_response",
+                    "id": msg.get("tool_call_id", ""),
+                    "response": content,
+                }
+            )
+
+        if parts:
+            structured_messages.append({"role": role, "parts": parts})
+
+    return structured_messages
+
+
+def build_output_messages(response_text, finish_reason, tool_calls=None):
+    """
+    Convert Azure AI Inference response to OTel output message structure.
+
+    Args:
+        response_text: The text response
+        finish_reason: Azure AI finish reason value
+        tool_calls: Tool calls from response
+
+    Returns:
+        List with single OutputMessage following OTel schema
+    """
+    parts = []
+
+    # Add text content if present
+    if response_text:
+        parts.append({"type": "text", "content": response_text})
+
+    # Add tool calls if present
+    if tool_calls:
+        for tool_call in tool_calls:
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": tool_call.get("id", ""),
+                    "name": tool_call.get("function", {}).get("name", ""),
+                    "arguments": tool_call.get("function", {}).get("arguments", {}),
+                }
+            )
+
+    # Map Azure AI finish reasons to OTel standard (follows OpenAI)
+    finish_reason_map = {
+        "stop": "stop",
+        "length": "max_tokens",
+        "tool_calls": "tool_calls",
+        "content_filter": "content_filter",
+    }
+
+    otel_finish_reason = finish_reason_map.get(finish_reason, finish_reason)
+
+    return [{"role": "assistant", "parts": parts, "finish_reason": otel_finish_reason}]
+
+
+def build_tool_definitions(tools):
+    """
+    Extract tool definitions from request.
+
+    Args:
+        tools: Azure AI tools array (OpenAI-compatible format)
+
+    Returns:
+        List of tool definition objects or None
+    """
+    # Azure AI Inference uses OpenAI-compatible tool format
+    # Direct pass-through
+    return tools if tools else None
+
+
+def emit_inference_event(
+    event_provider,
+    operation_name,
+    request_model,
+    response_model,
+    input_messages=None,
+    output_messages=None,
+    tool_definitions=None,
+    server_address=None,
+    server_port=None,
+    **extra_attrs,
+):
+    """
+    Centralized function to emit gen_ai.client.inference.operation.details event.
+
+    Args:
+        event_provider: The OTel event provider
+        operation_name: Operation type (chat, completion, embedding, etc.)
+        request_model: Model specified in request
+        response_model: Model returned in response
+        input_messages: Structured input messages
+        output_messages: Structured output messages
+        tool_definitions: Tool/function definitions
+        server_address: API server address
+        server_port: API server port
+        **extra_attrs: Additional attributes (temperature, max_tokens, etc.)
+    """
+    try:
+        if not event_provider:
+            return
+
+        from openlit.__helpers import otel_event
+        from openlit.semcov import SemanticConvention
+
+        # Build base attributes
+        attributes = {
+            SemanticConvention.GEN_AI_OPERATION_NAME: operation_name,
+        }
+
+        # Add model attributes
+        if request_model:
+            attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+        if response_model:
+            attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = response_model
+
+        # Add server attributes
+        if server_address:
+            attributes["server.address"] = server_address
+        if server_port:
+            attributes["server.port"] = server_port
+
+        # Add messages (only if not None/empty)
+        if input_messages:
+            attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = input_messages
+        if output_messages:
+            attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = output_messages
+
+        # Add tool definitions (recommended)
+        if tool_definitions:
+            attributes[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+        # Map extra attributes to semantic conventions
+        attr_mapping = {
+            "temperature": SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
+            "max_tokens": SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
+            "top_p": SemanticConvention.GEN_AI_REQUEST_TOP_P,
+            "frequency_penalty": SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+            "presence_penalty": SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
+            "stop_sequences": SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
+            "seed": SemanticConvention.GEN_AI_REQUEST_SEED,
+            "response_id": SemanticConvention.GEN_AI_RESPONSE_ID,
+            "finish_reasons": SemanticConvention.GEN_AI_RESPONSE_FINISH_REASONS,
+            "choice_count": SemanticConvention.GEN_AI_RESPONSE_CHOICE_COUNT,
+            "output_type": SemanticConvention.GEN_AI_RESPONSE_OUTPUT_TYPE,
+            "input_tokens": SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
+            "output_tokens": SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
+            "reasoning_tokens": "gen_ai.usage.reasoning_tokens",  # Azure-specific
+            "encoding_format": "gen_ai.request.encoding_format",  # For embeddings
+            "dimensions": "gen_ai.request.dimensions",  # For embeddings
+            "cache_creation_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            "cache_read_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        }
+
+        for key, value in extra_attrs.items():
+            if value is not None and key in attr_mapping:
+                attributes[attr_mapping[key]] = value
+
+        # Create and emit event
+        event = otel_event(
+            name=SemanticConvention.GEN_AI_CLIENT_INFERENCE_OPERATION_DETAILS,
+            attributes=attributes,
+            body="",  # Per spec, all data in attributes
+        )
+
+        event_provider.emit(event)
+
+    except Exception as e:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning("Failed to emit inference event: %s", e, exc_info=True)
+
+
 def process_chunk(scope, chunk):
     """
     Process a chunk of response data and update state.
@@ -133,6 +358,7 @@ def common_chat_logic(
     disable_metrics,
     version,
     is_stream,
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -273,19 +499,46 @@ def common_chat_logic(
                 SemanticConvention.GEN_AI_CONTENT_REASONING, scope._reasoning_content
             )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
-            },
-        )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_COMPLETION: scope._llmresponse,
-            },
-        )
+        # Emit OTel log event
+        if event_provider:
+            try:
+                # Build structured messages
+                input_msgs = build_input_messages(scope._kwargs.get("messages", []))
+                output_msgs = build_output_messages(
+                    scope._llmresponse, scope._finish_reason, tool_calls=scope._tools
+                )
+                tool_defs = build_tool_definitions(scope._kwargs.get("tools"))
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=output_msgs,
+                    tool_definitions=tool_defs,
+                    server_address=scope._server_address,
+                    server_port=scope._server_port,
+                    response_id=scope._response_id,
+                    finish_reasons=[scope._finish_reason],
+                    temperature=scope._kwargs.get("temperature"),
+                    max_tokens=scope._kwargs.get("max_tokens"),
+                    top_p=scope._kwargs.get("top_p"),
+                    frequency_penalty=scope._kwargs.get("frequency_penalty"),
+                    presence_penalty=scope._kwargs.get("presence_penalty"),
+                    stop_sequences=scope._kwargs.get("stop"),
+                    seed=scope._kwargs.get("seed"),
+                    input_tokens=scope._input_tokens,
+                    output_tokens=scope._output_tokens,
+                    reasoning_tokens=scope._reasoning_tokens
+                    if hasattr(scope, "_reasoning_tokens")
+                    else None,
+                )
+            except Exception as e:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -320,6 +573,7 @@ def process_streaming_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="",
+    event_provider=None,
 ):
     """
     Process streaming chat request and generate Telemetry
@@ -335,6 +589,7 @@ def process_streaming_chat_response(
         disable_metrics,
         version,
         is_stream=True,
+        event_provider=event_provider,
     )
 
 
@@ -352,6 +607,7 @@ def process_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -419,6 +675,7 @@ def process_chat_response(
         disable_metrics,
         version,
         is_stream=False,
+        event_provider=event_provider,
     )
 
     return response
@@ -433,6 +690,7 @@ def common_embedding_logic(
     capture_message_content,
     disable_metrics,
     version,
+    event_provider=None,
 ):
     """
     Process embedding request and generate Telemetry
@@ -484,15 +742,41 @@ def common_embedding_logic(
             str(scope._kwargs.get("input", "")),
         )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: str(
-                    scope._kwargs.get("input", "")
-                ),
-            },
-        )
+        # Emit OTel log event
+        if event_provider:
+            try:
+                # For embeddings, input is text strings, output is empty
+                # Build input messages from embedding input
+                input_text = scope._kwargs.get("input", [])
+                if isinstance(input_text, str):
+                    input_text = [input_text]
+
+                # Create simple text input messages
+                input_msgs = [
+                    {"role": "user", "parts": [{"type": "text", "content": text}]}
+                    for text in input_text
+                ]
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=[],  # Embeddings don't have text output
+                    tool_definitions=None,
+                    server_address=scope._server_address,
+                    server_port=scope._server_port,
+                    response_id=scope._response_id,
+                    input_tokens=scope._input_tokens,
+                    encoding_format=scope._kwargs.get("encoding_format"),
+                    dimensions=scope._kwargs.get("dimensions"),
+                )
+            except Exception as e:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -529,6 +813,7 @@ def process_embedding_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -556,6 +841,7 @@ def process_embedding_response(
         capture_message_content,
         disable_metrics,
         version,
+        event_provider=event_provider,
     )
 
     return response

--- a/sdk/python/src/openlit/instrumentation/bedrock/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/__init__.py
@@ -27,6 +27,7 @@ class BedrockInstrumentor(BaseInstrumentor):
         capture_message_content = kwargs.get("capture_message_content", False)
         metrics = kwargs.get("metrics_dict")
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
 
         # sync
         wrap_function_wrapper(
@@ -41,6 +42,7 @@ class BedrockInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -57,6 +59,7 @@ class BedrockInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -22,6 +22,7 @@ def converse(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for AWS Bedrock converse calls.
@@ -67,6 +68,7 @@ def converse(
                         disable_metrics=disable_metrics,
                         version=version,
                         llm_config=llm_config,
+                        event_provider=event_provider,
                         **method_kwargs,
                     )
 
@@ -99,6 +101,7 @@ def converse_stream(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for AWS Bedrock converse_stream calls.
@@ -117,6 +120,7 @@ def converse_stream(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped_response = wrapped_response
@@ -145,6 +149,7 @@ def converse_stream(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             if hasattr(self.__wrapped_stream, "__enter__"):
@@ -195,6 +200,7 @@ def converse_stream(
                             disable_metrics=disable_metrics,
                             version=version,
                             llm_config=llm_config,
+                            event_provider=self._event_provider,
                         )
 
                 except Exception as e:
@@ -232,6 +238,7 @@ def converse_stream(
                 method_kwargs,
                 server_address,
                 server_port,
+                event_provider=event_provider,
             )
 
         # Get the original client instance from the wrapper

--- a/sdk/python/src/openlit/instrumentation/bedrock/utils.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/utils.py
@@ -14,6 +14,7 @@ from openlit.__helpers import (
     record_completion_metrics,
     common_span_attributes,
     handle_exception,
+    otel_event,
 )
 from openlit.semcov import SemanticConvention
 
@@ -221,9 +222,6 @@ def emit_inference_event(
     try:
         if not event_provider:
             return
-
-        from openlit.__helpers import otel_event
-        from openlit.semcov import SemanticConvention
 
         # Build base attributes
         attributes = {
@@ -437,6 +435,7 @@ def common_chat_logic(
                     scope._finish_reason,
                     tool_calls=None,  # No tool support yet
                 )
+                # pylint: disable=assignment-from-none
                 tool_defs = build_tool_definitions(
                     scope._kwargs.get("toolConfig", {}).get("tools")
                 )

--- a/sdk/python/src/openlit/instrumentation/bedrock/utils.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/utils.py
@@ -55,6 +55,243 @@ def format_content(messages):
     return "\n".join(formatted_messages)
 
 
+def build_input_messages(messages):
+    """
+    Convert Bedrock messages to OTel input message structure.
+
+    Args:
+        messages: List of Bedrock message objects or dicts
+
+    Returns:
+        List of ChatMessage objects following OTel schema
+    """
+    structured_messages = []
+
+    for message in messages:
+        # Extract role and content
+        if isinstance(message, dict):
+            role = message.get("role", "user")
+            content = message.get("content", [])
+        else:
+            # Handle Bedrock object format
+            role = getattr(message, "role", "user")
+            content = getattr(message, "content", [])
+
+        # Ensure content is a list
+        if isinstance(content, str):
+            content = [{"text": content}]
+        elif not isinstance(content, list):
+            content = [{"text": str(content)}]
+
+        # Build parts array
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                # Handle text blocks
+                if "text" in part:
+                    parts.append({"type": "text", "content": part.get("text", "")})
+                elif part.get("type") == "text":
+                    parts.append({"type": "text", "content": part.get("text", "")})
+
+                # Handle image blocks - only include if has URL (skip embedded bytes)
+                elif "image" in part:
+                    image_data = part.get("image", {})
+                    source = image_data.get("source", {})
+                    # Only include if URL-based, skip bytes
+                    if "url" in source:
+                        parts.append(
+                            {
+                                "type": "uri",
+                                "modality": "image",
+                                "uri": source.get("url"),
+                            }
+                        )
+
+                # Handle document blocks - skip if has embedded bytes
+                elif "document" in part:
+                    document_data = part.get("document", {})
+                    source = document_data.get("source", {})
+                    # Only include if URL-based
+                    if "url" in source:
+                        parts.append(
+                            {
+                                "type": "uri",
+                                "modality": "document",
+                                "uri": source.get("url"),
+                                "name": document_data.get("name", ""),
+                            }
+                        )
+
+        if parts:
+            structured_messages.append({"role": role, "parts": parts})
+
+    return structured_messages
+
+
+def build_output_messages(response_text, finish_reason, tool_calls=None):
+    """
+    Convert Bedrock response to OTel output message structure.
+
+    Args:
+        response_text: The text response from Bedrock
+        finish_reason: Bedrock stopReason value
+        tool_calls: Tool calls (reserved for future, currently None)
+
+    Returns:
+        List with single OutputMessage following OTel schema
+    """
+    parts = []
+
+    # Add text content if present
+    if response_text:
+        parts.append({"type": "text", "content": response_text})
+
+    # Add tool calls if present (future support)
+    if tool_calls:
+        for tool_call in tool_calls:
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": tool_call.get("id", ""),
+                    "name": tool_call.get("name", ""),
+                    "arguments": tool_call.get("arguments", {}),
+                }
+            )
+
+    # Map Bedrock finish reasons to OTel standard
+    finish_reason_map = {
+        "end_turn": "stop",
+        "max_tokens": "max_tokens",
+        "stop_sequence": "stop",
+        "tool_use": "tool_calls",
+        "content_filtered": "content_filter",
+        "guardrail_intervention": "content_filter",
+    }
+
+    otel_finish_reason = finish_reason_map.get(finish_reason, finish_reason)
+
+    return [{"role": "assistant", "parts": parts, "finish_reason": otel_finish_reason}]
+
+
+def build_tool_definitions(tools):
+    """
+    Extract tool definitions from Bedrock toolConfig.
+
+    Args:
+        tools: Bedrock tools array from toolConfig
+
+    Returns:
+        List of tool definition objects or None
+
+    Note: Currently returns None as Bedrock tool instrumentation is not yet implemented.
+          Reserved for future when tool support is added.
+    """
+    # Bedrock tool support not yet instrumented
+    # Will be implemented when tool calls are added to instrumentation
+    return None
+
+
+def emit_inference_event(
+    event_provider,
+    operation_name,
+    request_model,
+    response_model,
+    input_messages=None,
+    output_messages=None,
+    tool_definitions=None,
+    server_address=None,
+    server_port=None,
+    **extra_attrs,
+):
+    """
+    Centralized function to emit gen_ai.client.inference.operation.details event.
+
+    Args:
+        event_provider: The OTel event provider
+        operation_name: Operation type (chat, completion, embedding, etc.)
+        request_model: Model specified in request
+        response_model: Model returned in response
+        input_messages: Structured input messages
+        output_messages: Structured output messages
+        tool_definitions: Tool/function definitions
+        server_address: API server address
+        server_port: API server port
+        **extra_attrs: Additional attributes (temperature, max_tokens, etc.)
+    """
+    try:
+        if not event_provider:
+            return
+
+        from openlit.__helpers import otel_event
+        from openlit.semcov import SemanticConvention
+
+        # Build base attributes
+        attributes = {
+            SemanticConvention.GEN_AI_OPERATION_NAME: operation_name,
+        }
+
+        # Add model attributes
+        if request_model:
+            attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+        if response_model:
+            attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = response_model
+
+        # Add server attributes
+        if server_address:
+            attributes["server.address"] = server_address
+        if server_port:
+            attributes["server.port"] = server_port
+
+        # Add messages (only if not None/empty)
+        if input_messages:
+            attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = input_messages
+        if output_messages:
+            attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = output_messages
+
+        # Add tool definitions (recommended)
+        if tool_definitions:
+            attributes[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+        # Map extra attributes to semantic conventions
+        attr_mapping = {
+            "temperature": SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
+            "max_tokens": SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
+            "top_p": SemanticConvention.GEN_AI_REQUEST_TOP_P,
+            "top_k": SemanticConvention.GEN_AI_REQUEST_TOP_K,
+            "frequency_penalty": SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+            "presence_penalty": SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
+            "stop_sequences": SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
+            "seed": SemanticConvention.GEN_AI_REQUEST_SEED,
+            "response_id": SemanticConvention.GEN_AI_RESPONSE_ID,
+            "finish_reasons": SemanticConvention.GEN_AI_RESPONSE_FINISH_REASONS,
+            "choice_count": SemanticConvention.GEN_AI_RESPONSE_CHOICE_COUNT,
+            "output_type": SemanticConvention.GEN_AI_RESPONSE_OUTPUT_TYPE,
+            "input_tokens": SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
+            "output_tokens": SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
+            "cache_creation_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            "cache_read_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        }
+
+        for key, value in extra_attrs.items():
+            if value is not None and key in attr_mapping:
+                attributes[attr_mapping[key]] = value
+
+        # Create and emit event
+        event = otel_event(
+            name=SemanticConvention.GEN_AI_CLIENT_INFERENCE_OPERATION_DETAILS,
+            attributes=attributes,
+            body="",  # Per spec, all data in attributes
+        )
+
+        event_provider.emit(event)
+
+    except Exception as e:
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning("Failed to emit inference event: %s", e, exc_info=True)
+
+
 def process_chunk(self, chunk):
     """
     Process a chunk of response data and update state.
@@ -107,6 +344,7 @@ def common_chat_logic(
     version,
     llm_config,
     is_stream,
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -189,19 +427,48 @@ def common_chat_logic(
             SemanticConvention.GEN_AI_CONTENT_COMPLETION, scope._llmresponse
         )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: formatted_messages,
-            },
-        )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_COMPLETION: scope._llmresponse,
-            },
-        )
+        # Emit OTel log event
+        if event_provider:
+            try:
+                # Build structured messages
+                input_msgs = build_input_messages(scope._kwargs.get("messages", []))
+                output_msgs = build_output_messages(
+                    scope._llmresponse,
+                    scope._finish_reason,
+                    tool_calls=None,  # No tool support yet
+                )
+                tool_defs = build_tool_definitions(
+                    scope._kwargs.get("toolConfig", {}).get("tools")
+                )
+
+                # Extract inferenceConfig parameters
+                inference_config = llm_config or {}
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=output_msgs,
+                    tool_definitions=tool_defs,
+                    server_address=scope._server_address,
+                    server_port=scope._server_port,
+                    response_id=scope._response_id if scope._response_id else None,
+                    finish_reasons=[scope._finish_reason],
+                    temperature=inference_config.get("temperature"),
+                    max_tokens=inference_config.get("maxTokens"),
+                    top_p=inference_config.get("topP"),
+                    top_k=inference_config.get("topK"),
+                    stop_sequences=inference_config.get("stopSequences"),
+                    input_tokens=scope._input_tokens,
+                    output_tokens=scope._output_tokens,
+                )
+            except Exception as e:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -237,6 +504,7 @@ def process_streaming_chat_response(
     disable_metrics=False,
     version="",
     llm_config=None,
+    event_provider=None,
 ):
     """
     Process streaming chat response and generate telemetry.
@@ -257,6 +525,7 @@ def process_streaming_chat_response(
             version,
             llm_config,
             is_stream=True,
+            event_provider=event_provider,
         )
     except Exception as e:
         handle_exception(scope._span, e)
@@ -278,6 +547,7 @@ def process_chat_response(
     disable_metrics=False,
     version="1.0.0",
     llm_config=None,
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -324,6 +594,7 @@ def process_chat_response(
             version,
             llm_config,
             is_stream=False,
+            event_provider=event_provider,
         )
 
         return response

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/__init__.py
@@ -34,6 +34,7 @@ class GoogleAIStudioInstrumentor(BaseInstrumentor):
         pricing_info = kwargs.get("pricing_info", {})
         capture_message_content = kwargs.get("capture_message_content", False)
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
         version = importlib.metadata.version("google-genai")
 
         # sync generate
@@ -49,6 +50,7 @@ class GoogleAIStudioInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -65,6 +67,7 @@ class GoogleAIStudioInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -81,6 +84,7 @@ class GoogleAIStudioInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -97,6 +101,7 @@ class GoogleAIStudioInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/async_google_ai_studio.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/async_google_ai_studio.py
@@ -22,6 +22,7 @@ def async_generate(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -61,6 +62,7 @@ def async_generate(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                 )
 
             except Exception as e:
@@ -81,6 +83,7 @@ def async_generate_stream(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -99,6 +102,7 @@ def async_generate_stream(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -120,6 +124,7 @@ def async_generate_stream(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -154,6 +159,7 @@ def async_generate_stream(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
 
                 except Exception as e:
@@ -176,7 +182,13 @@ def async_generate_stream(
         span = tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT)
 
         return TracedAsyncStream(
-            awaited_wrapped, span, span_name, kwargs, server_address, server_port
+            awaited_wrapped,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider,
         )
 
     return wrapper

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/google_ai_studio.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/google_ai_studio.py
@@ -22,6 +22,7 @@ def generate(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -61,6 +62,7 @@ def generate(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                 )
 
             except Exception as e:
@@ -81,6 +83,7 @@ def generate_stream(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -99,6 +102,7 @@ def generate_stream(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -120,6 +124,7 @@ def generate_stream(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -154,6 +159,7 @@ def generate_stream(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
 
                 except Exception as e:
@@ -176,7 +182,13 @@ def generate_stream(
         span = tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT)
 
         return TracedSyncStream(
-            awaited_wrapped, span, span_name, kwargs, server_address, server_port
+            awaited_wrapped,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider,
         )
 
     return wrapper

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -72,6 +72,339 @@ def format_content(messages):
     return prompt
 
 
+def build_input_messages(contents, system_instruction=None):
+    """
+    Convert Google AI Studio contents to OTel input message structure.
+
+    Args:
+        contents: Contents array from Google AI Studio request
+        system_instruction: Optional system instruction
+
+    Returns:
+        List of ChatMessage objects with role and parts
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if not contents:
+        return []
+
+    otel_messages = []
+
+    # Add system instruction first if present
+    if system_instruction:
+        system_text = ""
+        if isinstance(system_instruction, str):
+            system_text = system_instruction
+        elif hasattr(system_instruction, "parts"):
+            # Extract text from parts
+            for part in system_instruction.parts:
+                if hasattr(part, "text") and part.text:
+                    system_text += part.text
+
+        if system_text:
+            otel_messages.append(
+                {"role": "system", "parts": [{"type": "text", "content": system_text}]}
+            )
+
+    for content in contents:
+        try:
+            # Extract role - Google uses "user" and "model"
+            role = getattr(content, "role", "user")
+            if role == "model":
+                role = "assistant"
+
+            parts_list = []
+
+            # Google already uses "parts" structure
+            if hasattr(content, "parts"):
+                for part in content.parts:
+                    # Text content
+                    if hasattr(part, "text") and part.text:
+                        parts_list.append({"type": "text", "content": part.text})
+
+                    # File data with URI (skip inline_data to avoid data URIs)
+                    if hasattr(part, "file_data") and part.file_data:
+                        file_uri = getattr(part.file_data, "file_uri", None)
+                        mime_type = getattr(part.file_data, "mime_type", "")
+                        if file_uri and not file_uri.startswith("data:"):
+                            modality = (
+                                "image"
+                                if "image" in mime_type
+                                else "video"
+                                if "video" in mime_type
+                                else "file"
+                            )
+                            parts_list.append(
+                                {"type": "uri", "modality": modality, "uri": file_uri}
+                            )
+
+                    # Function call (tool call from assistant)
+                    if hasattr(part, "function_call") and part.function_call:
+                        fc = part.function_call
+                        parts_list.append(
+                            {
+                                "type": "tool_call",
+                                "id": "",  # Google doesn't provide ID
+                                "name": getattr(fc, "name", ""),
+                                "arguments": dict(getattr(fc, "args", {})),
+                            }
+                        )
+
+                    # Function response (tool result from user)
+                    if hasattr(part, "function_response") and part.function_response:
+                        fr = part.function_response
+                        parts_list.append(
+                            {
+                                "type": "tool_call_response",
+                                "id": "",  # Google doesn't provide ID
+                                "response": str(getattr(fr, "response", "")),
+                            }
+                        )
+
+            if parts_list:
+                otel_messages.append({"role": role, "parts": parts_list})
+
+        except Exception as e:
+            logger.warning("Failed to process input message: %s", e, exc_info=True)
+            continue
+
+    return otel_messages
+
+
+def build_output_messages(response_text, finish_reason, function_calls=None):
+    """
+    Convert Google AI Studio response to OTel output message structure.
+
+    Args:
+        response_text: Response text from model
+        finish_reason: Finish reason from Google (STOP, MAX_TOKENS, SAFETY, etc.)
+        function_calls: Optional function calls dict from response
+
+    Returns:
+        List with single OutputMessage
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    parts = []
+
+    try:
+        # Add text content if present
+        if response_text:
+            parts.append({"type": "text", "content": response_text})
+
+        # Add function calls if present
+        if function_calls:
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": "",  # Google doesn't provide IDs
+                    "name": function_calls.get("name", ""),
+                    "arguments": function_calls.get("args", {}),
+                }
+            )
+
+        # Map Google finish reasons to OTel standard
+        finish_reason_map = {
+            "STOP": "stop",
+            "MAX_TOKENS": "max_tokens",
+            "SAFETY": "content_filter",
+            "RECITATION": "content_filter",
+            "OTHER": "other",
+            "FINISH_REASON_UNSPECIFIED": "other",
+        }
+
+        otel_finish_reason = finish_reason_map.get(
+            finish_reason.upper() if finish_reason else "", finish_reason or "stop"
+        )
+
+        return [
+            {"role": "assistant", "parts": parts, "finish_reason": otel_finish_reason}
+        ]
+
+    except Exception as e:
+        logger.warning("Failed to build output messages: %s", e, exc_info=True)
+        return [{"role": "assistant", "parts": [], "finish_reason": "stop"}]
+
+
+def build_tool_definitions(tools):
+    """
+    Extract tool/function definitions from Google AI Studio request.
+
+    Args:
+        tools: Tools from Google AI Studio request
+
+    Returns:
+        List of tool definition objects or None
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    if not tools:
+        return None
+
+    try:
+        tool_definitions = []
+
+        # Google uses function_declarations
+        if hasattr(tools, "function_declarations"):
+            for func_decl in tools.function_declarations:
+                try:
+                    # Convert Google schema to OTel format
+                    params = {}
+                    if hasattr(func_decl, "parameters"):
+                        params = {
+                            "type": getattr(func_decl.parameters, "type", "object"),
+                            "properties": dict(
+                                getattr(func_decl.parameters, "properties", {})
+                            ),
+                            "required": list(
+                                getattr(func_decl.parameters, "required", [])
+                            ),
+                        }
+
+                    tool_definitions.append(
+                        {
+                            "type": "function",
+                            "name": getattr(func_decl, "name", ""),
+                            "description": getattr(func_decl, "description", ""),
+                            "parameters": params,
+                        }
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Failed to process tool definition: %s", e, exc_info=True
+                    )
+                    continue
+        elif isinstance(tools, list):
+            # Handle list format
+            for tool in tools:
+                if isinstance(tool, dict) and "function_declarations" in tool:
+                    for func_decl in tool["function_declarations"]:
+                        tool_definitions.append(
+                            {
+                                "type": "function",
+                                "name": func_decl.get("name", ""),
+                                "description": func_decl.get("description", ""),
+                                "parameters": func_decl.get("parameters", {}),
+                            }
+                        )
+
+        return tool_definitions if tool_definitions else None
+
+    except Exception as e:
+        logger.warning("Failed to build tool definitions: %s", e, exc_info=True)
+        return None
+
+
+def emit_inference_event(
+    event_provider,
+    operation_name,
+    request_model,
+    response_model,
+    input_messages=None,
+    output_messages=None,
+    tool_definitions=None,
+    server_address=None,
+    server_port=None,
+    **extra_attrs,
+):
+    """
+    Emit gen_ai.client.inference.operation.details event.
+
+    Args:
+        event_provider: The OTel event provider
+        operation_name: Operation type (chat)
+        request_model: Model from request
+        response_model: Model from response
+        input_messages: Structured input messages
+        output_messages: Structured output messages
+        tool_definitions: Tool definitions
+        server_address: Server address
+        server_port: Server port
+        **extra_attrs: Additional attributes (temperature, max_tokens, etc.)
+    """
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    try:
+        if not event_provider:
+            return
+
+        from openlit.__helpers import otel_event
+
+        # Build event attributes
+        attributes = {
+            SemanticConvention.GEN_AI_OPERATION: operation_name,
+        }
+
+        # Add model attributes
+        if request_model:
+            attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+        if response_model:
+            attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = response_model
+
+        # Add server attributes
+        if server_address:
+            attributes[SemanticConvention.SERVER_ADDRESS] = server_address
+        if server_port:
+            attributes[SemanticConvention.SERVER_PORT] = server_port
+
+        # Add messages
+        if input_messages is not None:
+            attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = input_messages
+        if output_messages is not None:
+            attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = output_messages
+
+        # Add tool definitions
+        if tool_definitions is not None:
+            attributes[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+        # Map extra attributes
+        for key, value in extra_attrs.items():
+            if value is not None:
+                if key == "response_id":
+                    attributes[SemanticConvention.GEN_AI_RESPONSE_ID] = value
+                elif key == "finish_reasons":
+                    attributes[SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON] = value
+                elif key == "output_type":
+                    attributes[SemanticConvention.GEN_AI_OUTPUT_TYPE] = value
+                elif key == "temperature":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TEMPERATURE] = value
+                elif key in ("max_tokens", "max_output_tokens"):
+                    attributes[SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS] = value
+                elif key == "top_p":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TOP_P] = value
+                elif key == "top_k":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_TOP_K] = value
+                elif key == "stop_sequences":
+                    attributes[SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES] = value
+                elif key == "input_tokens":
+                    attributes[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] = value
+                elif key == "output_tokens":
+                    attributes[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] = value
+                elif key == "reasoning_tokens":
+                    # Google-specific: thoughts/reasoning tokens
+                    attributes["gen_ai.usage.reasoning_tokens"] = value
+
+        # Create and emit event
+        event = otel_event(
+            name=SemanticConvention.GEN_AI_CLIENT_INFERENCE_OPERATION_DETAILS,
+            attributes=attributes,
+            body="",
+        )
+
+        event_provider.emit(event)
+
+    except Exception as e:
+        logger.warning("Failed to emit inference event: %s", e, exc_info=True)
+
+
 def process_chunk(self, chunk):
     """
     Process a chunk of response data and update state.
@@ -121,6 +454,7 @@ def common_chat_logic(
     disable_metrics,
     version,
     is_stream,
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -213,24 +547,56 @@ def common_chat_logic(
             SemanticConvention.GEN_AI_TOOL_ARGS, str(scope._tools.get("args", ""))
         )
 
-    # To be removed one the change to span_attributes (from span events) is complete
+    # Span Attributes for Content
     if capture_message_content:
         scope._span.set_attribute(SemanticConvention.GEN_AI_CONTENT_PROMPT, prompt)
         scope._span.set_attribute(
             SemanticConvention.GEN_AI_CONTENT_COMPLETION, scope._llmresponse
         )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
-            },
-        )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_COMPLETION: scope._llmresponse,
-            },
-        )
+
+        # Emit inference event
+        if event_provider:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            try:
+                input_msgs = build_input_messages(
+                    scope._kwargs.get("contents", []),
+                    system_instruction=getattr(
+                        inference_config, "system_instruction", None
+                    ),
+                )
+                output_msgs = build_output_messages(
+                    scope._llmresponse,
+                    scope._finish_reason,
+                    function_calls=scope._tools,
+                )
+                tool_defs = build_tool_definitions(
+                    getattr(inference_config, "tools", None)
+                )
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=output_msgs,
+                    tool_definitions=tool_defs,
+                    server_address=scope._server_address,
+                    server_port=scope._server_port,
+                    finish_reasons=[scope._finish_reason],
+                    temperature=getattr(inference_config, "temperature", None),
+                    max_output_tokens=getattr(inference_config, "max_tokens", None),
+                    top_p=getattr(inference_config, "top_p", None),
+                    top_k=getattr(inference_config, "top_k", None),
+                    stop_sequences=getattr(inference_config, "stop_sequences", None),
+                    input_tokens=scope._input_tokens,
+                    output_tokens=scope._output_tokens,
+                    reasoning_tokens=scope._reasoning_tokens,
+                )
+            except Exception as e:
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -273,6 +639,7 @@ def process_streaming_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="",
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -288,6 +655,7 @@ def process_streaming_chat_response(
         disable_metrics,
         version,
         is_stream=True,
+        event_provider=event_provider,
     )
 
 
@@ -308,6 +676,7 @@ def process_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -354,6 +723,7 @@ def process_chat_response(
         disable_metrics,
         version,
         is_stream=False,
+        event_provider=event_provider,
     )
 
     return response

--- a/sdk/python/src/openlit/instrumentation/litellm/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/__init__.py
@@ -27,6 +27,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):
         pricing_info = kwargs.get("pricing_info", {})
         capture_message_content = kwargs.get("capture_message_content", False)
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
         version = importlib.metadata.version("litellm")
 
         # Chat completions
@@ -42,6 +43,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -58,6 +60,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -74,6 +77,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 
@@ -90,6 +94,7 @@ class LiteLLMInstrumentor(BaseInstrumentor):
                 capture_message_content,
                 metrics,
                 disable_metrics,
+                event_provider,
             ),
         )
 

--- a/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/async_litellm.py
@@ -23,6 +23,7 @@ def acompletion(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -41,6 +42,7 @@ def acompletion(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -63,6 +65,7 @@ def acompletion(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -95,6 +98,7 @@ def acompletion(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=self._event_provider,
                     )
                     # End the span after processing
                     self._span.end()
@@ -123,7 +127,13 @@ def acompletion(
             awaited_wrapped = await wrapped(*args, **kwargs)
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
             return TracedAsyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider=event_provider,
             )
         else:
             # Handling for non-streaming responses
@@ -146,6 +156,7 @@ def acompletion(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -166,6 +177,7 @@ def aembedding(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI embedding function call
@@ -203,6 +215,7 @@ def aembedding(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/litellm/litellm.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/litellm.py
@@ -23,6 +23,7 @@ def completion(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI function call
@@ -41,6 +42,7 @@ def completion(
             kwargs,
             server_address,
             server_port,
+            event_provider=None,
             **args,
         ):
             self.__wrapped__ = wrapped
@@ -63,6 +65,7 @@ def completion(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -95,6 +98,7 @@ def completion(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=self._event_provider,
                     )
                     # End the span after processing
                     self._span.end()
@@ -123,7 +127,13 @@ def completion(
             awaited_wrapped = wrapped(*args, **kwargs)
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
             return TracedSyncStream(
-                awaited_wrapped, span, span_name, kwargs, server_address, server_port
+                awaited_wrapped,
+                span,
+                span_name,
+                kwargs,
+                server_address,
+                server_port,
+                event_provider=event_provider,
             )
         else:
             # Handling for non-streaming responses
@@ -146,6 +156,7 @@ def completion(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -166,6 +177,7 @@ def embedding(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for GenAI embedding function call
@@ -203,6 +215,7 @@ def embedding(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/litellm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/utils.py
@@ -15,6 +15,7 @@ from openlit.__helpers import (
     common_span_attributes,
     record_completion_metrics,
     record_embedding_metrics,
+    otel_event,
 )
 from openlit.semcov import SemanticConvention
 
@@ -195,9 +196,6 @@ def emit_inference_event(
     try:
         if not event_provider:
             return
-
-        from openlit.__helpers import otel_event
-        from openlit.semcov import SemanticConvention
 
         # Build base attributes
         attributes = {

--- a/sdk/python/src/openlit/instrumentation/litellm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/utils.py
@@ -258,6 +258,7 @@ def emit_inference_event(
 
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 

--- a/sdk/python/src/openlit/instrumentation/litellm/utils.py
+++ b/sdk/python/src/openlit/instrumentation/litellm/utils.py
@@ -43,6 +43,227 @@ def format_content(messages):
     return "\n".join(formatted_messages)
 
 
+def build_input_messages(messages):
+    """
+    Convert LiteLLM messages (OpenAI-compatible format) to OTel input message structure.
+
+    Args:
+        messages: List of message objects from LiteLLM request
+
+    Returns:
+        List of ChatMessage objects following OTel schema
+    """
+    structured_messages = []
+
+    for msg in messages:
+        # Extract role
+        role = msg.get("role", "user")
+
+        # Build parts array
+        parts = []
+        content = msg.get("content", "")
+
+        if isinstance(content, str):
+            # Simple text content
+            parts.append({"type": "text", "content": content})
+        elif isinstance(content, list):
+            # Multi-part content (text, images, etc.)
+            for part in content:
+                if part.get("type") == "text":
+                    parts.append({"type": "text", "content": part.get("text", "")})
+                elif part.get("type") == "image_url":
+                    image_url = part.get("image_url", {}).get("url", "")
+                    # Skip data URIs for privacy
+                    if not image_url.startswith("data:"):
+                        parts.append(
+                            {"type": "uri", "modality": "image", "uri": image_url}
+                        )
+
+        # Handle tool calls (for assistant messages)
+        if "tool_calls" in msg:
+            for tool_call in msg.get("tool_calls", []):
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": tool_call.get("id", ""),
+                        "name": tool_call.get("function", {}).get("name", ""),
+                        "arguments": tool_call.get("function", {}).get("arguments", {}),
+                    }
+                )
+
+        # Handle tool responses (for tool role)
+        if role == "tool" and "tool_call_id" in msg:
+            parts.append(
+                {
+                    "type": "tool_call_response",
+                    "id": msg.get("tool_call_id", ""),
+                    "response": content,
+                }
+            )
+
+        if parts:
+            structured_messages.append({"role": role, "parts": parts})
+
+    return structured_messages
+
+
+def build_output_messages(response_text, finish_reason, tool_calls=None):
+    """
+    Convert LiteLLM response to OTel output message structure.
+
+    Args:
+        response_text: The text response
+        finish_reason: LiteLLM finish reason value
+        tool_calls: Tool calls from response
+
+    Returns:
+        List with single OutputMessage following OTel schema
+    """
+    parts = []
+
+    # Add text content if present
+    if response_text:
+        parts.append({"type": "text", "content": response_text})
+
+    # Add tool calls if present
+    if tool_calls:
+        for tool_call in tool_calls:
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": tool_call.get("id", ""),
+                    "name": tool_call.get("function", {}).get("name", ""),
+                    "arguments": tool_call.get("function", {}).get("arguments", {}),
+                }
+            )
+
+    # Map LiteLLM finish reasons to OTel standard
+    finish_reason_map = {
+        "stop": "stop",
+        "length": "max_tokens",
+        "tool_calls": "tool_calls",
+        "content_filter": "content_filter",
+    }
+
+    otel_finish_reason = finish_reason_map.get(finish_reason, finish_reason)
+
+    return [{"role": "assistant", "parts": parts, "finish_reason": otel_finish_reason}]
+
+
+def build_tool_definitions(tools):
+    """
+    Extract tool definitions from request.
+
+    Args:
+        tools: LiteLLM tools array (OpenAI-compatible format)
+
+    Returns:
+        List of tool definition objects or None
+    """
+    # LiteLLM uses OpenAI-compatible tool format
+    # Direct pass-through
+    return tools if tools else None
+
+
+def emit_inference_event(
+    event_provider,
+    operation_name,
+    request_model,
+    response_model,
+    input_messages=None,
+    output_messages=None,
+    tool_definitions=None,
+    server_address=None,
+    server_port=None,
+    **extra_attrs,
+):
+    """
+    Centralized function to emit gen_ai.client.inference.operation.details event.
+
+    Args:
+        event_provider: The OTel event provider
+        operation_name: Operation type (chat, completion, embedding, etc.)
+        request_model: Model specified in request
+        response_model: Model returned in response
+        input_messages: Structured input messages
+        output_messages: Structured output messages
+        tool_definitions: Tool/function definitions
+        server_address: API server address
+        server_port: API server port
+        **extra_attrs: Additional attributes (temperature, max_tokens, etc.)
+    """
+    try:
+        if not event_provider:
+            return
+
+        from openlit.__helpers import otel_event
+        from openlit.semcov import SemanticConvention
+
+        # Build base attributes
+        attributes = {
+            SemanticConvention.GEN_AI_OPERATION_NAME: operation_name,
+        }
+
+        # Add model attributes
+        if request_model:
+            attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+        if response_model:
+            attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = response_model
+
+        # Add server attributes
+        if server_address:
+            attributes["server.address"] = server_address
+        if server_port:
+            attributes["server.port"] = server_port
+
+        # Add messages (only if not None/empty)
+        if input_messages:
+            attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = input_messages
+        if output_messages:
+            attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = output_messages
+
+        # Add tool definitions (recommended)
+        if tool_definitions:
+            attributes[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = tool_definitions
+
+        # Map extra attributes to semantic conventions
+        attr_mapping = {
+            "temperature": SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
+            "max_tokens": SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
+            "top_p": SemanticConvention.GEN_AI_REQUEST_TOP_P,
+            "frequency_penalty": SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
+            "presence_penalty": SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
+            "stop_sequences": SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
+            "seed": SemanticConvention.GEN_AI_REQUEST_SEED,
+            "response_id": SemanticConvention.GEN_AI_RESPONSE_ID,
+            "finish_reasons": SemanticConvention.GEN_AI_RESPONSE_FINISH_REASONS,
+            "choice_count": SemanticConvention.GEN_AI_RESPONSE_CHOICE_COUNT,
+            "output_type": SemanticConvention.GEN_AI_RESPONSE_OUTPUT_TYPE,
+            "input_tokens": SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS,
+            "output_tokens": SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS,
+            "cache_creation_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+            "cache_read_input_tokens": SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        }
+
+        for key, value in extra_attrs.items():
+            if value is not None and key in attr_mapping:
+                attributes[attr_mapping[key]] = value
+
+        # Create and emit event
+        event = otel_event(
+            name=SemanticConvention.GEN_AI_CLIENT_INFERENCE_OPERATION_DETAILS,
+            attributes=attributes,
+            body="",  # Per spec, all data in attributes
+        )
+
+        event_provider.emit(event)
+
+    except Exception as e:
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.warning("Failed to emit inference event: %s", e, exc_info=True)
+
+
 def process_chunk(scope, chunk):
     """
     Process a chunk of response data and update state.
@@ -118,6 +339,7 @@ def common_chat_logic(
     disable_metrics,
     version,
     is_stream,
+    event_provider=None,
 ):
     """
     Process chat request and generate Telemetry
@@ -256,19 +478,40 @@ def common_chat_logic(
             SemanticConvention.GEN_AI_CONTENT_COMPLETION, scope._llmresponse
         )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: prompt,
-            },
-        )
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_COMPLETION_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_COMPLETION: scope._llmresponse,
-            },
-        )
+        # Emit OTel log event
+        if event_provider:
+            try:
+                input_msgs = build_input_messages(scope._kwargs.get("messages", []))
+                output_msgs = build_output_messages(
+                    scope._llmresponse, scope._finish_reason, scope._tools
+                )
+                tool_defs = build_tool_definitions(scope._kwargs.get("tools"))
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=output_msgs,
+                    tool_definitions=tool_defs,
+                    server_address="api.litellm.ai",
+                    server_port=443,
+                    response_id=scope._response_id,
+                    finish_reasons=[scope._finish_reason],
+                    temperature=scope._kwargs.get("temperature"),
+                    max_tokens=scope._kwargs.get("max_tokens"),
+                    top_p=scope._kwargs.get("top_p"),
+                    frequency_penalty=scope._kwargs.get("frequency_penalty"),
+                    presence_penalty=scope._kwargs.get("presence_penalty"),
+                    input_tokens=scope._input_tokens,
+                    output_tokens=scope._output_tokens,
+                )
+            except Exception as e:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 
@@ -303,6 +546,7 @@ def process_streaming_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="",
+    event_provider=None,
 ):
     """
     Process streaming chat request and generate Telemetry
@@ -318,6 +562,7 @@ def process_streaming_chat_response(
         disable_metrics,
         version,
         is_stream=True,
+        event_provider=event_provider,
     )
 
 
@@ -335,6 +580,7 @@ def process_chat_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -383,6 +629,7 @@ def process_chat_response(
         disable_metrics,
         version,
         is_stream=False,
+        event_provider=event_provider,
     )
 
     return response
@@ -402,6 +649,7 @@ def process_embedding_response(
     capture_message_content=False,
     disable_metrics=False,
     version="1.0.0",
+    event_provider=None,
     **kwargs,
 ):
     """
@@ -469,15 +717,38 @@ def process_embedding_response(
             str(scope._kwargs.get("input", "")),
         )
 
-        # To be removed once the change to span_attributes (from span events) is complete
-        scope._span.add_event(
-            name=SemanticConvention.GEN_AI_CONTENT_PROMPT_EVENT,
-            attributes={
-                SemanticConvention.GEN_AI_CONTENT_PROMPT: str(
-                    scope._kwargs.get("input", "")
-                ),
-            },
-        )
+        # Emit OTel log event
+        if event_provider:
+            try:
+                # For embeddings, input is text strings, output is empty
+                input_text = scope._kwargs.get("input", [])
+                if isinstance(input_text, str):
+                    input_text = [input_text]
+
+                # Create simple text input messages
+                input_msgs = [
+                    {"role": "user", "parts": [{"type": "text", "content": text}]}
+                    for text in input_text
+                ]
+
+                emit_inference_event(
+                    event_provider=event_provider,
+                    operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                    request_model=request_model,
+                    response_model=scope._response_model,
+                    input_messages=input_msgs,
+                    output_messages=[],  # Embeddings don't have text output
+                    tool_definitions=None,
+                    server_address="api.litellm.ai",
+                    server_port=443,
+                    response_id=None,
+                    input_tokens=scope._input_tokens,
+                )
+            except Exception as e:
+                import logging
+
+                logger = logging.getLogger(__name__)
+                logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
     scope._span.set_status(Status(StatusCode.OK))
 

--- a/sdk/python/src/openlit/instrumentation/ollama/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/__init__.py
@@ -64,6 +64,7 @@ class OllamaInstrumentor(BaseInstrumentor):
         pricing_info = kwargs.get("pricing_info", {})
         capture_message_content = kwargs.get("capture_message_content", False)
         disable_metrics = kwargs.get("disable_metrics")
+        event_provider = kwargs.get("event_provider")
         version = importlib.metadata.version("ollama")
 
         # Build wrapper factories for chat and embeddings
@@ -76,6 +77,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
         sync_generate_wrap = generate(
             version,
@@ -86,6 +88,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
         sync_emb_wrap = embeddings(
             version,
@@ -96,6 +99,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
         async_chat_wrap = async_chat(
             version,
@@ -106,6 +110,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
         async_generate_wrap = async_generate(
             version,
@@ -116,6 +121,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
         async_emb_wrap = async_embeddings(
             version,
@@ -126,6 +132,7 @@ class OllamaInstrumentor(BaseInstrumentor):
             capture_message_content,
             metrics,
             disable_metrics,
+            event_provider,
         )
 
         # Patch underlying request methods to ensure instrumentation regardless of import order

--- a/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/async_ollama.py
@@ -25,6 +25,7 @@ def async_chat(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama async chat function call
@@ -44,6 +45,7 @@ def async_chat(
             server_address,
             server_port,
             args,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -64,6 +66,7 @@ def async_chat(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -98,6 +101,7 @@ def async_chat(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -130,6 +134,7 @@ def async_chat(
                 server_address,
                 server_port,
                 args,
+                event_provider,
             )
 
         else:
@@ -153,6 +158,7 @@ def async_chat(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -173,6 +179,7 @@ def async_generate(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama async generate function call
@@ -192,6 +199,7 @@ def async_generate(
             server_address,
             server_port,
             args,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -212,6 +220,7 @@ def async_generate(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
@@ -246,6 +255,7 @@ def async_generate(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -278,6 +288,7 @@ def async_generate(
                 server_address,
                 server_port,
                 args,
+                event_provider,
             )
 
         else:
@@ -301,6 +312,7 @@ def async_generate(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -321,6 +333,7 @@ def async_embeddings(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama async embeddings function call
@@ -360,6 +373,7 @@ def async_embeddings(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/ollama/ollama.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/ollama.py
@@ -25,6 +25,7 @@ def chat(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama chat function call
@@ -44,6 +45,7 @@ def chat(
             server_address,
             server_port,
             args,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -64,6 +66,7 @@ def chat(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -98,6 +101,7 @@ def chat(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -130,6 +134,7 @@ def chat(
                 server_address,
                 server_port,
                 args,
+                event_provider,
             )
 
         else:
@@ -153,6 +158,7 @@ def chat(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -173,6 +179,7 @@ def generate(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama generate function call
@@ -192,6 +199,7 @@ def generate(
             server_address,
             server_port,
             args,
+            event_provider=None,
         ):
             self.__wrapped__ = wrapped
             self._span = span
@@ -212,6 +220,7 @@ def generate(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._event_provider = event_provider
 
         def __enter__(self):
             self.__wrapped__.__enter__()
@@ -246,6 +255,7 @@ def generate(
                             capture_message_content=capture_message_content,
                             disable_metrics=disable_metrics,
                             version=version,
+                            event_provider=self._event_provider,
                         )
                 except Exception as e:
                     handle_exception(self._span, e)
@@ -278,6 +288,7 @@ def generate(
                 server_address,
                 server_port,
                 args,
+                event_provider,
             )
 
         else:
@@ -301,6 +312,7 @@ def generate(
                         capture_message_content=capture_message_content,
                         disable_metrics=disable_metrics,
                         version=version,
+                        event_provider=event_provider,
                         **kwargs,
                     )
 
@@ -321,6 +333,7 @@ def embeddings(
     capture_message_content,
     metrics,
     disable_metrics,
+    event_provider=None,
 ):
     """
     Generates a telemetry wrapper for Ollama embeddings function call
@@ -360,6 +373,7 @@ def embeddings(
                     capture_message_content=capture_message_content,
                     disable_metrics=disable_metrics,
                     version=version,
+                    event_provider=event_provider,
                     **kwargs,
                 )
 

--- a/sdk/python/src/openlit/instrumentation/ollama/utils.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/utils.py
@@ -65,25 +65,31 @@ def build_input_messages(messages):
                 elif part.get("type") == "image_url":
                     image_url = part.get("image_url", {}).get("url", "")
                     if not image_url.startswith("data:"):
-                        parts.append({"type": "uri", "modality": "image", "uri": image_url})
+                        parts.append(
+                            {"type": "uri", "modality": "image", "uri": image_url}
+                        )
 
         # Handle tool calls
         if "tool_calls" in msg:
             for tool_call in msg.get("tool_calls", []):
-                parts.append({
-                    "type": "tool_call",
-                    "id": tool_call.get("id", ""),
-                    "name": tool_call.get("function", {}).get("name", ""),
-                    "arguments": tool_call.get("function", {}).get("arguments", {}),
-                })
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": tool_call.get("id", ""),
+                        "name": tool_call.get("function", {}).get("name", ""),
+                        "arguments": tool_call.get("function", {}).get("arguments", {}),
+                    }
+                )
 
         # Handle tool responses
         if role == "tool" and "tool_call_id" in msg:
-            parts.append({
-                "type": "tool_call_response",
-                "id": msg.get("tool_call_id", ""),
-                "response": content,
-            })
+            parts.append(
+                {
+                    "type": "tool_call_response",
+                    "id": msg.get("tool_call_id", ""),
+                    "response": content,
+                }
+            )
 
         if parts:
             structured_messages.append({"role": role, "parts": parts})
@@ -102,12 +108,14 @@ def build_output_messages(response_text, finish_reason, tool_calls=None):
 
     if tool_calls:
         for tool_call in tool_calls:
-            parts.append({
-                "type": "tool_call",
-                "id": tool_call.get("id", ""),
-                "name": tool_call.get("function", {}).get("name", ""),
-                "arguments": tool_call.get("function", {}).get("arguments", {}),
-            })
+            parts.append(
+                {
+                    "type": "tool_call",
+                    "id": tool_call.get("id", ""),
+                    "name": tool_call.get("function", {}).get("name", ""),
+                    "arguments": tool_call.get("function", {}).get("arguments", {}),
+                }
+            )
 
     # Ollama uses done_reason field - map to OTel standard
     finish_reason_map = {
@@ -139,7 +147,7 @@ def emit_inference_event(
     tool_definitions=None,
     server_address=None,
     server_port=None,
-    **extra_attrs
+    **extra_attrs,
 ):
     """
     Centralized function to emit gen_ai.client.inference.operation.details event.
@@ -191,6 +199,7 @@ def emit_inference_event(
         event_provider.emit(event)
     except Exception as e:
         import logging
+
         logger = logging.getLogger(__name__)
         logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
@@ -380,9 +389,15 @@ def common_chat_logic(
         if event_provider:
             try:
                 json_body = scope._kwargs.get("json", {}) or {}
-                input_msgs = build_input_messages(json_body.get("messages", scope._kwargs.get("messages", [])))
-                output_msgs = build_output_messages(scope._llmresponse, scope._finish_reason, scope._tools)
-                tool_defs = build_tool_definitions(json_body.get("tools", scope._kwargs.get("tools")))
+                input_msgs = build_input_messages(
+                    json_body.get("messages", scope._kwargs.get("messages", []))
+                )
+                output_msgs = build_output_messages(
+                    scope._llmresponse, scope._finish_reason, scope._tools
+                )
+                tool_defs = build_tool_definitions(
+                    json_body.get("tools", scope._kwargs.get("tools"))
+                )
 
                 # Extract options for parameters
                 options = json_body.get("options", scope._kwargs.get("options", {}))
@@ -408,6 +423,7 @@ def common_chat_logic(
                 )
             except Exception as e:
                 import logging
+
                 logger = logging.getLogger(__name__)
                 logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
@@ -558,9 +574,15 @@ def common_generate_logic(
                 json_body = scope._kwargs.get("json", {}) or {}
 
                 # For generate operation, input is a prompt string, not messages
-                input_msgs = [{"role": "user", "parts": [{"type": "text", "content": prompt}]}]
-                output_msgs = build_output_messages(scope._llmresponse, scope._finish_reason, scope._tools)
-                tool_defs = build_tool_definitions(json_body.get("tools", scope._kwargs.get("tools")))
+                input_msgs = [
+                    {"role": "user", "parts": [{"type": "text", "content": prompt}]}
+                ]
+                output_msgs = build_output_messages(
+                    scope._llmresponse, scope._finish_reason, scope._tools
+                )
+                tool_defs = build_tool_definitions(
+                    json_body.get("tools", scope._kwargs.get("tools"))
+                )
 
                 # Extract options for parameters
                 options = json_body.get("options", scope._kwargs.get("options", {}))
@@ -586,6 +608,7 @@ def common_generate_logic(
                 )
             except Exception as e:
                 import logging
+
                 logger = logging.getLogger(__name__)
                 logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
@@ -700,6 +723,7 @@ def common_embedding_logic(
                 )
             except Exception as e:
                 import logging
+
                 logger = logging.getLogger(__name__)
                 logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 

--- a/sdk/python/src/openlit/instrumentation/ollama/utils.py
+++ b/sdk/python/src/openlit/instrumentation/ollama/utils.py
@@ -16,6 +16,7 @@ from openlit.__helpers import (
     create_metrics_attributes,
     common_span_attributes,
     record_completion_metrics,
+    otel_event,
 )
 from openlit.semcov import SemanticConvention
 
@@ -147,8 +148,6 @@ def emit_inference_event(
     try:
         if not event_provider:
             return
-
-        from openlit.__helpers import otel_event
 
         attributes = {SemanticConvention.GEN_AI_OPERATION_NAME: operation_name}
 

--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -1322,7 +1322,9 @@ def process_chat_response(
     scope._output_tokens = response_dict.get("usage", {}).get("completion_tokens", 0)
 
     # Extract cache tokens (OpenAI prompt caching)
-    prompt_tokens_details = response_dict.get("usage", {}).get("prompt_tokens_details", {})
+    prompt_tokens_details = response_dict.get("usage", {}).get(
+        "prompt_tokens_details", {}
+    )
     scope._cache_read_input_tokens = prompt_tokens_details.get("cached_tokens", 0)
 
     scope._timestamps = []

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -56,6 +56,7 @@ class SemanticConvention:
     GEN_AI_ENDPOINT = "gen_ai.endpoint"
     GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
     GEN_AI_REQUEST_SEED = "gen_ai.request.seed"
+    GEN_AI_REQUEST_CHOICE_COUNT = "gen_ai.request.choice.count"
     GEN_AI_REQUEST_ENCODING_FORMATS = "gen_ai.request.encoding_formats"
     GEN_AI_REQUEST_FREQUENCY_PENALTY = "gen_ai.request.frequency_penalty"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
@@ -64,6 +65,9 @@ class SemanticConvention:
     GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
     GEN_AI_REQUEST_TOP_K = "gen_ai.request.top_k"
     GEN_AI_REQUEST_TOP_P = "gen_ai.request.top_p"
+
+    # GenAI Conversation Attributes (OTel Semconv)
+    GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
 
     # GenAI Response Attributes (OTel Semconv)
     GEN_AI_TOKEN_TYPE = "gen_ai.token.type"
@@ -74,6 +78,10 @@ class SemanticConvention:
     GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
     GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
     GEN_AI_USAGE_REASONING_TOKENS = "gen_ai.usage.reasoning_tokens"
+    GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = (
+        "gen_ai.usage.cache_creation.input_tokens"
+    )
+    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
     GEN_AI_USAGE_READ_UNITS = "gen_ai.usage.read_units"
     GEN_AI_USAGE_RERANK_UNITS = "gen_ai.usage.rerank_units"
     GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"


### PR DESCRIPTION
### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Adopt OpenTelemetry Gen-AI event-based instrumentation for Anthropic and Google AI Studio clients and align attribute usage with the latest semantic conventions.

Enhancements:
- Refine OTEL attribute taxonomy and documentation, clarifying required vs conditionally required vs recommended vs opt-in fields and updating provider-specific mapping tables.
- Introduce structured input/output message builders and tool definition extractors for Anthropic and Google AI Studio to conform to OTel Gen-AI message schemas.
- Add reusable inference event emitters for Anthropic, Google AI Studio, and enhance OpenAI emission to include cache token metrics and choice counts via semantic-convention constants.
- Extend Anthropic and Google AI Studio instrumentations to capture prompt caching metrics, reasoning tokens, and server metadata while routing telemetry through the new event provider.
- Update semantic convention constants to cover conversation IDs, request choice counts, and cache token usage to support richer, standardized observability.