### PR TITLE
fix(ci): replace pull_request_target with pull_request to prevent secret exfiltration

### DIFF
--- a/.github/workflows/pricing-test.yml
+++ b/.github/workflows/pricing-test.yml
@@ -5,13 +5,16 @@ on:
       branches: [ "main" ]
       paths:
       - 'assets/pricing.json'
-    pull_request_target:
+    pull_request:
       branches: [ "main" ]
       paths:
       - 'assets/pricing.json'
     workflow_dispatch:
     schedule:
       - cron: '0 0 1-31/15 * *'
+
+permissions:
+  contents: read
 
 jobs:
   validate-pricing:
@@ -20,8 +23,6 @@ jobs:
     steps:
       - name: Checkout base code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Validate JSON structure
         id: validate

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,10 +1,13 @@
 name: Pylint
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -16,8 +19,6 @@ jobs:
     steps:
     - name: Checkout base code
       uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,13 +5,16 @@ on:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
     paths:
       - 'sdk/python/**'
   workflow_dispatch:
   schedule:
     - cron: '0 0 1-31/15 * *'
+
+permissions:
+  contents: read
 
 env:
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -50,8 +53,6 @@ jobs:
     steps:
     - name: Checkout base code
       uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,39 +16,39 @@ on:
 permissions:
   contents: read
 
-env:
-  OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-  CO_API_KEY: ${{ secrets.CO_API_KEY }}
-  ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-  MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-  PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
-  GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-  QDRANT_URL: ${{ secrets.QDRANT_URL }}
-  QDRANT_API_TOKEN: ${{ secrets.QDRANT_API_TOKEN }}
-  MILVUS_URL: ${{ secrets.MILVUS_URL }}
-  MILVUS_API_TOKEN: ${{ secrets.MILVUS_API_TOKEN }}
-  ELEVEN_API_KEY: ${{ secrets.ELEVEN_API_KEY }}
-  GOOGLE_AI_STUDIO_API_TOKEN: ${{ secrets.GOOGLE_AI_STUDIO_API_TOKEN }}
-  AZURE_AI_INFERENCE_API_TOKEN: ${{ secrets.AZURE_AI_INFERENCE_API_TOKEN }}
-  REKA_API_KEY: ${{ secrets.REKA_API_KEY }}
-  PREM_API_KEY: ${{ secrets.PREM_API_KEY }}
-  MULTION_API_KEY: ${{ secrets.MULTION_API_KEY }}
-  XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
-  JULEP_API_KEY: ${{ secrets.JULEP_API_KEY }}
-  ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
-  ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
-  AI21_API_KEY: ${{ secrets.AI21_API_KEY }}
-  ASSEMBLYAI_API_KEY: ${{ secrets.ASSEMBLYAI_API_KEY }}
-  FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
-  TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      CO_API_KEY: ${{ secrets.CO_API_KEY }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
+      PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+      GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+      QDRANT_URL: ${{ secrets.QDRANT_URL }}
+      QDRANT_API_TOKEN: ${{ secrets.QDRANT_API_TOKEN }}
+      MILVUS_URL: ${{ secrets.MILVUS_URL }}
+      MILVUS_API_TOKEN: ${{ secrets.MILVUS_API_TOKEN }}
+      ELEVEN_API_KEY: ${{ secrets.ELEVEN_API_KEY }}
+      GOOGLE_AI_STUDIO_API_TOKEN: ${{ secrets.GOOGLE_AI_STUDIO_API_TOKEN }}
+      AZURE_AI_INFERENCE_API_TOKEN: ${{ secrets.AZURE_AI_INFERENCE_API_TOKEN }}
+      REKA_API_KEY: ${{ secrets.REKA_API_KEY }}
+      PREM_API_KEY: ${{ secrets.PREM_API_KEY }}
+      MULTION_API_KEY: ${{ secrets.MULTION_API_KEY }}
+      XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
+      JULEP_API_KEY: ${{ secrets.JULEP_API_KEY }}
+      ASTRA_DB_API_ENDPOINT: ${{ secrets.ASTRA_DB_API_ENDPOINT }}
+      ASTRA_DB_APPLICATION_TOKEN: ${{ secrets.ASTRA_DB_APPLICATION_TOKEN }}
+      AI21_API_KEY: ${{ secrets.AI21_API_KEY }}
+      ASSEMBLYAI_API_KEY: ${{ secrets.ASSEMBLYAI_API_KEY }}
+      FIRECRAWL_API_KEY: ${{ secrets.FIRECRAWL_API_KEY }}
+      TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
 
     steps:
     - name: Checkout base code

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -1,10 +1,13 @@
 name: Test OpenLIT
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main]
     paths:
       - 'src/**'
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -13,8 +16,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary                                                                                                                                   
                                                                                                                                             
  Fixes GHSA-9jgv-x8cq-296q — CI/CD secret exfiltration via `pull_request_target`.

  Four workflows were using `pull_request_target` (which runs with the base repo's secrets and a write-privileged `GITHUB_TOKEN`) while checking out and executing code from the PR head commit. This allowed an attacker to open a forked PR, inject malicious code into test files or dependencies, and exfiltrate all configured secrets including 20+ LLM API keys and GCP credentials.

  ## Changes

  - **`pylint.yml`** — `pull_request_target` → `pull_request`, removed `ref: head.sha`, added `permissions: contents: read`
  - **`python-tests.yml`** — `pull_request_target` → `pull_request`, removed `ref: head.sha`, added `permissions: contents: read`
  - **`ui-test.yml`** — `pull_request_target` → `pull_request`, removed `ref: head.sha`, added `permissions: contents: read`
  - **`pricing-test.yml`** — `pull_request_target` → `pull_request`, removed `ref: head.sha`, added `permissions: contents: read`

  ## Security Impact

  With `pull_request`, workflows triggered by forked PRs run in the fork's security context — `secrets.*` resolve to empty strings and `GITHUB_TOKEN` is read-only and fork-scoped. API-key-dependent tests will still run with full credentials on `push` to `main`, `workflow_dispatch`, and `schedule`.

  `typescript-tests.yml` and `operator-tests.yml` were already using `pull_request` correctly and were not affected.

Fixes https://github.com/openlit/openlit/security/advisories/GHSA-9jgv-x8cq-296q

## Summary by Sourcery

Harden CI workflows against secret exfiltration by adjusting pull-request triggers and permissions for PR-originated runs.

Bug Fixes:
- Run pylint, Python tests, UI tests, and pricing validation workflows on pull_request instead of pull_request_target to avoid executing forked PR code with repository secrets and elevated GITHUB_TOKEN permissions.

CI:
- Set GitHub Actions permissions to contents: read for pylint, Python tests, UI tests, and pricing validation workflows to minimize token scope on PR runs.
- Stop explicitly checking out the PR head SHA in affected workflows so they run against the default merge commit context instead of arbitrary forked code.