### PR TITLE
feat: Support Otel Logs as an option in evals export

### DIFF
--- a/docs/latest/sdk/configuration.mdx
+++ b/docs/latest/sdk/configuration.mdx
@@ -59,6 +59,14 @@ These options apply to database instrumentations like PostgreSQL (psycopg3):
 | `capture_parameters` | `--capture_parameters` | `OPENLIT_CAPTURE_PARAMETERS` | Capture database query parameters in spans (security risk - may expose sensitive data) | `False` | No |
 | `enable_sqlcommenter` | `--enable_sqlcommenter` | `OPENLIT_ENABLE_SQLCOMMENTER` | Inject OpenTelemetry trace context as SQL comments for database log correlation | `False` | No |
 
+### Evaluation export options
+
+Configure how evaluation results are exported:
+
+| Parameter | CLI Argument | Environment Variable | Description | Default | Required |
+|-----------|--------------|---------------------|-------------|---------|----------|
+| `evals_logs_export` | `--evals_logs_export` | `OPENLIT_EVALS_LOGS_EXPORT` | Emit evaluation results as OTel Log Records instead of OTel Events. Useful for backends like Grafana Loki that handle logs better than events. | `True` | No |
+
 <Warning>
 **Security Notice**: Enabling `capture_parameters` records query parameters (the values passed to `$1`, `$2`, etc.) in your traces. This may expose sensitive data like passwords, API keys, or personal information. Only enable in development environments or when you're certain parameters don't contain sensitive data.
 </Warning>

--- a/docs/latest/sdk/features/evaluations.mdx
+++ b/docs/latest/sdk/features/evaluations.mdx
@@ -22,6 +22,23 @@ The OpenLIT SDK provides tools to evaluate AI-generated text, ensuring it aligns
   </Card>
 </CardGroup>
 
+## Export configuration
+
+By default, evaluation results are emitted as **OTel Log Records**. If your backend supports OTel Events natively, you can switch to event-based export:
+
+```python
+import openlit
+
+# Use OTel Events instead of Log Records
+openlit.init(evals_logs_export=False)
+```
+
+| Parameter | Environment Variable | Description | Default |
+|-----------|---------------------|-------------|---------|
+| `evals_logs_export` | `OPENLIT_EVALS_LOGS_EXPORT` | Emit evaluation results as OTel Log Records instead of OTel Events | `True` |
+
+<Info>Both modes carry the same keys and value types — the only difference is the transport (event attributes vs JSON in the log body).</Info>
+
 ## Evaluations
 
 ### Hallucination Detection

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.37.2"
+version = "1.37.4"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -82,7 +82,7 @@ class OpenlitConfig:
         # Database instrumentation options
         cls.capture_parameters = False
         cls.enable_sqlcommenter = False
-        cls.otel_logs = False
+        cls.otel_logs = True
 
     @classmethod
     def update_config(
@@ -101,7 +101,7 @@ class OpenlitConfig:
         detailed_tracing,
         capture_parameters=False,
         enable_sqlcommenter=False,
-        otel_logs=False,
+        otel_logs=True,
     ):
         """
         Updates the configuration based on provided parameters.
@@ -233,7 +233,7 @@ def init(
     collect_system_metrics=False,
     capture_parameters=False,
     enable_sqlcommenter=False,
-    otel_logs=False,
+    otel_logs=True,
 ):
     """
     Initializes the openLIT configuration and setups tracing.
@@ -313,7 +313,7 @@ def init(
             capture_parameters = env_config["capture_parameters"]
         if enable_sqlcommenter is False and "enable_sqlcommenter" in env_config:
             enable_sqlcommenter = env_config["enable_sqlcommenter"]
-        if otel_logs is False and "otel_logs" in env_config:
+        if otel_logs is True and "otel_logs" in env_config:
             otel_logs = env_config["otel_logs"]
 
     except ImportError:

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -82,6 +82,7 @@ class OpenlitConfig:
         # Database instrumentation options
         cls.capture_parameters = False
         cls.enable_sqlcommenter = False
+        cls.otel_logs = False
 
     @classmethod
     def update_config(
@@ -100,6 +101,7 @@ class OpenlitConfig:
         detailed_tracing,
         capture_parameters=False,
         enable_sqlcommenter=False,
+        otel_logs=False,
     ):
         """
         Updates the configuration based on provided parameters.
@@ -120,6 +122,7 @@ class OpenlitConfig:
             detailed_tracing (bool): Flag to enable detailed component-level tracing.
             capture_parameters (bool): Capture database query parameters (security risk).
             enable_sqlcommenter (bool): Inject trace context as SQL comments.
+            otel_logs (bool): Emit as OTEL Log Records instead of OTEL Events.
         """
         cls.environment = environment
         cls.application_name = application_name
@@ -135,6 +138,7 @@ class OpenlitConfig:
         cls.detailed_tracing = detailed_tracing
         cls.capture_parameters = capture_parameters
         cls.enable_sqlcommenter = enable_sqlcommenter
+        cls.otel_logs = otel_logs
 
 
 def module_exists(module_name):
@@ -229,6 +233,7 @@ def init(
     collect_system_metrics=False,
     capture_parameters=False,
     enable_sqlcommenter=False,
+    otel_logs=False,
 ):
     """
     Initializes the openLIT configuration and setups tracing.
@@ -308,6 +313,8 @@ def init(
             capture_parameters = env_config["capture_parameters"]
         if enable_sqlcommenter is False and "enable_sqlcommenter" in env_config:
             enable_sqlcommenter = env_config["enable_sqlcommenter"]
+        if otel_logs is False and "otel_logs" in env_config:
+            otel_logs = env_config["otel_logs"]
 
     except ImportError:
         # Fallback if config module is not available - continue without env var support
@@ -392,6 +399,7 @@ def init(
             detailed_tracing,
             capture_parameters,
             enable_sqlcommenter,
+            otel_logs,
         )
 
         # Create instrumentor instances dynamically

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -82,7 +82,7 @@ class OpenlitConfig:
         # Database instrumentation options
         cls.capture_parameters = False
         cls.enable_sqlcommenter = False
-        cls.otel_logs = True
+        cls.evals_logs_export = True
 
     @classmethod
     def update_config(
@@ -101,7 +101,7 @@ class OpenlitConfig:
         detailed_tracing,
         capture_parameters=False,
         enable_sqlcommenter=False,
-        otel_logs=True,
+        evals_logs_export=True,
     ):
         """
         Updates the configuration based on provided parameters.
@@ -122,7 +122,7 @@ class OpenlitConfig:
             detailed_tracing (bool): Flag to enable detailed component-level tracing.
             capture_parameters (bool): Capture database query parameters (security risk).
             enable_sqlcommenter (bool): Inject trace context as SQL comments.
-            otel_logs (bool): Emit as OTEL Log Records instead of OTEL Events.
+            evals_logs_export (bool): Emit evaluation results as OTEL Log Records instead of OTEL Events.
         """
         cls.environment = environment
         cls.application_name = application_name
@@ -138,7 +138,7 @@ class OpenlitConfig:
         cls.detailed_tracing = detailed_tracing
         cls.capture_parameters = capture_parameters
         cls.enable_sqlcommenter = enable_sqlcommenter
-        cls.otel_logs = otel_logs
+        cls.evals_logs_export = evals_logs_export
 
 
 def module_exists(module_name):
@@ -233,7 +233,7 @@ def init(
     collect_system_metrics=False,
     capture_parameters=False,
     enable_sqlcommenter=False,
-    otel_logs=True,
+    evals_logs_export=True,
 ):
     """
     Initializes the openLIT configuration and setups tracing.
@@ -313,8 +313,8 @@ def init(
             capture_parameters = env_config["capture_parameters"]
         if enable_sqlcommenter is False and "enable_sqlcommenter" in env_config:
             enable_sqlcommenter = env_config["enable_sqlcommenter"]
-        if otel_logs is True and "otel_logs" in env_config:
-            otel_logs = env_config["otel_logs"]
+        if evals_logs_export is True and "evals_logs_export" in env_config:
+            evals_logs_export = env_config["evals_logs_export"]
 
     except ImportError:
         # Fallback if config module is not available - continue without env var support
@@ -399,7 +399,7 @@ def init(
             detailed_tracing,
             capture_parameters,
             enable_sqlcommenter,
-            otel_logs,
+            evals_logs_export,
         )
 
         # Create instrumentor instances dynamically

--- a/sdk/python/src/openlit/cli/config.py
+++ b/sdk/python/src/openlit/cli/config.py
@@ -110,10 +110,10 @@ PARAMETER_CONFIG = {
         "cli_help": "Inject OpenTelemetry trace context as SQL comments for database log correlation",
         "cli_type": bool,
     },
-    "otel_logs": {
+    "evals_logs_export": {
         "default": True,
-        "env_var": "OPENLIT_OTEL_LOGS",
-        "cli_help": "Emit telemetry as OTEL Log Records instead of OTEL Events",
+        "env_var": "OPENLIT_EVALS_LOGS_EXPORT",
+        "cli_help": "Emit evaluation results as OTEL Log Records instead of OTEL Events",
         "cli_type": bool,
     },
     # Parameters that are not exposed via CLI (internal use only)

--- a/sdk/python/src/openlit/cli/config.py
+++ b/sdk/python/src/openlit/cli/config.py
@@ -111,7 +111,7 @@ PARAMETER_CONFIG = {
         "cli_type": bool,
     },
     "otel_logs": {
-        "default": False,
+        "default": True,
         "env_var": "OPENLIT_OTEL_LOGS",
         "cli_help": "Emit telemetry as OTEL Log Records instead of OTEL Events",
         "cli_type": bool,

--- a/sdk/python/src/openlit/cli/config.py
+++ b/sdk/python/src/openlit/cli/config.py
@@ -110,6 +110,12 @@ PARAMETER_CONFIG = {
         "cli_help": "Inject OpenTelemetry trace context as SQL comments for database log correlation",
         "cli_type": bool,
     },
+    "otel_logs": {
+        "default": False,
+        "env_var": "OPENLIT_OTEL_LOGS",
+        "cli_help": "Emit telemetry as OTEL Log Records instead of OTEL Events",
+        "cli_type": bool,
+    },
     # Parameters that are not exposed via CLI (internal use only)
     "tracer": {
         "default": None,

--- a/sdk/python/src/openlit/evals/utils.py
+++ b/sdk/python/src/openlit/evals/utils.py
@@ -327,24 +327,20 @@ def emit_evaluation_event(
             attributes[SemanticConvention.ERROR_TYPE] = error_type
         else:
             if score_value is not None:
-                attributes[
-                    SemanticConvention.GEN_AI_EVALUATION_SCORE_VALUE
-                ] = float(score_value)
+                attributes[SemanticConvention.GEN_AI_EVALUATION_SCORE_VALUE] = float(
+                    score_value
+                )
             if score_label:
                 attributes[SemanticConvention.GEN_AI_EVALUATION_SCORE_LABEL] = (
                     score_label
                 )
 
         if explanation:
-            attributes[SemanticConvention.GEN_AI_EVALUATION_EXPLANATION] = (
-                explanation
-            )
+            attributes[SemanticConvention.GEN_AI_EVALUATION_EXPLANATION] = explanation
         if response_id:
             attributes[SemanticConvention.GEN_AI_RESPONSE_ID] = response_id
 
         if get_evals_logs_export_config():
-            import json
-
             _emit_as_log_record(json.dumps(attributes))
         else:
             _emit_as_event(event_provider, attributes)
@@ -367,17 +363,16 @@ def _emit_as_event(event_provider, attributes):
 
 def _emit_as_log_record(body):
     """Emit evaluation result as an OTel Log Record via LoggingHandler."""
-    import logging as stdlib_logging
     from opentelemetry._logs import get_logger_provider
     from opentelemetry.sdk._logs import LoggingHandler
 
-    otel_logger = stdlib_logging.getLogger("openlit.evals.otel")
+    otel_logger = logging.getLogger("openlit.evals.otel")
     if not any(isinstance(h, LoggingHandler) for h in otel_logger.handlers):
         handler = LoggingHandler(
-            level=stdlib_logging.DEBUG,
+            level=logging.DEBUG,
             logger_provider=get_logger_provider(),
         )
         otel_logger.addHandler(handler)
-        otel_logger.setLevel(stdlib_logging.DEBUG)
+        otel_logger.setLevel(logging.DEBUG)
 
     otel_logger.info(body)

--- a/sdk/python/src/openlit/evals/utils.py
+++ b/sdk/python/src/openlit/evals/utils.py
@@ -362,17 +362,13 @@ def _emit_as_event(event_provider, attributes):
 
 
 def _emit_as_log_record(body):
-    """Emit evaluation result as an OTel Log Record via LoggingHandler."""
-    from opentelemetry._logs import get_logger_provider
-    from opentelemetry.sdk._logs import LoggingHandler
+    """Emit evaluation result as an OTel Log Record via the Logger API directly."""
+    from opentelemetry._logs import get_logger_provider, LogRecord, SeverityNumber
 
-    otel_logger = logging.getLogger("openlit.evals.otel")
-    if not any(isinstance(h, LoggingHandler) for h in otel_logger.handlers):
-        handler = LoggingHandler(
-            level=logging.DEBUG,
-            logger_provider=get_logger_provider(),
+    otel_logger = get_logger_provider().get_logger("openlit.evals")
+    otel_logger.emit(
+        LogRecord(
+            body=body,
+            severity_number=SeverityNumber.INFO,
         )
-        otel_logger.addHandler(handler)
-        otel_logger.setLevel(logging.DEBUG)
-
-    otel_logger.info(body)
+    )

--- a/sdk/python/src/openlit/evals/utils.py
+++ b/sdk/python/src/openlit/evals/utils.py
@@ -271,9 +271,9 @@ def get_event_provider():
         return None
 
 
-def get_otel_logs_config():
+def get_evals_logs_export_config():
     """
-    Safely retrieve the otel_logs flag from OpenLIT's global configuration.
+    Safely retrieve the evals_logs_export flag from OpenLIT's global configuration.
 
     Returns:
         True if OTEL Log Records should be used instead of Events, else False.
@@ -282,9 +282,9 @@ def get_otel_logs_config():
         # pylint: disable=cyclic-import
         from openlit import OpenlitConfig
 
-        return getattr(OpenlitConfig, "otel_logs", False)
+        return getattr(OpenlitConfig, "evals_logs_export", True)
     except (ImportError, AttributeError):
-        return False
+        return True
 
 
 def emit_evaluation_event(
@@ -299,9 +299,9 @@ def emit_evaluation_event(
     """
     Emit gen_ai.evaluation.result as an OTel Event or OTel Log Record.
 
-    By default, emits as an OTel Event. When ``otel_logs=True`` is set in
-    ``openlit.init()``, emits as an OTel Log Record instead (useful for
-    backends like Grafana Loki that handle logs better than events).
+    By default, emits as an OTel Log Record. When ``evals_logs_export=False``
+    is set in ``openlit.init()``, emits as an OTel Event instead (useful for
+    backends that support events natively).
 
     Both paths carry the same keys and value types; the only difference is
     the transport (event attributes vs JSON string in the log body).
@@ -342,7 +342,7 @@ def emit_evaluation_event(
         if response_id:
             attributes[SemanticConvention.GEN_AI_RESPONSE_ID] = response_id
 
-        if get_otel_logs_config():
+        if get_evals_logs_export_config():
             import json
 
             _emit_as_log_record(json.dumps(attributes))

--- a/sdk/python/src/openlit/guard/utils.py
+++ b/sdk/python/src/openlit/guard/utils.py
@@ -98,13 +98,13 @@ def llm_response_openai(prompt: str, model: str, base_url: str) -> str:
     if base_url is None:
         base_url = "https://api.openai.com/v1"
 
-    response = client.beta.chat.completions.parse(
+    response = client.chat.completions.create(
         model=model,
         messages=[
             {"role": "user", "content": prompt},
         ],
         temperature=0.0,
-        response_format=JsonOutput,
+        response_format={"type": "json_object"},
     )
     return response.choices[0].message.content
 


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->
As Grafana Loki optimization, IT would make more sense if the eval results are sent as a LogRecord. So adding the user optionality. The default option as still the event export as I know we dont wanna change that

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add optional support for exporting evaluation results as OpenTelemetry log records instead of events, configurable via OpenLIT settings and CLI/environment.

New Features:
- Allow evaluations to be emitted as OTEL Log Records as an alternative to OTEL Events, controlled by a new otel_logs configuration flag exposed via init(), config, and environment variables.

Enhancements:
- Refactor evaluation emission to route through helper functions for event and log-record export paths.

Build:
- Bump Python SDK package version to 1.37.4 to publish the new logging option.