### PR TITLE
feat(typescript-sdk): align trace attributes with Python SDK for all instrumentation providers

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.25.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "homepage": "https://github.com/openlit/openlit#readme",
   "bugs": {
     "url": "https://github.com/openlit/openlit/issues",

--- a/sdk/typescript/src/constant.ts
+++ b/sdk/typescript/src/constant.ts
@@ -1,5 +1,5 @@
 export const SDK_NAME = 'openlit';
-export const SDK_VERSION = '1.9.0';
+export const SDK_VERSION = '1.9.1';
 export const DEFAULT_ENVIRONMENT = 'default';
 export const DEFAULT_APPLICATION_NAME = 'default';
 export const INSTRUMENTATION_PREFIX = '@openlit';

--- a/sdk/typescript/src/constant.ts
+++ b/sdk/typescript/src/constant.ts
@@ -1,4 +1,5 @@
 export const SDK_NAME = 'openlit';
+export const SDK_VERSION = '1.9.0';
 export const DEFAULT_ENVIRONMENT = 'default';
 export const DEFAULT_APPLICATION_NAME = 'default';
 export const INSTRUMENTATION_PREFIX = '@openlit';

--- a/sdk/typescript/src/instrumentation/__tests__/anthropic-wrapper.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/anthropic-wrapper.test.ts
@@ -47,6 +47,8 @@ describe('AnthropicWrapper', () => {
           user: 'test-user',
           cost: 0.5,
           aiSystem: 'anthropic',
+          serverAddress: 'api.anthropic.com',
+          serverPort: 443,
         };
       });
 
@@ -63,6 +65,8 @@ describe('AnthropicWrapper', () => {
         cost: 0.5,
         aiSystem: 'anthropic',
         genAIEndpoint: 'anthropic.endpoint',
+        serverAddress: 'api.anthropic.com',
+        serverPort: 443,
       });
     });
   });

--- a/sdk/typescript/src/instrumentation/__tests__/google-ai-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/google-ai-trace-comparison.test.ts
@@ -45,6 +45,13 @@ describe('Google AI Studio Cross-Language Trace Comparison', () => {
       if (attrs.cost !== undefined) {
         span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
       }
+      if (attrs.serverAddress) {
+        span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+      }
+      if (attrs.serverPort !== undefined) {
+        span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+      }
+      span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 
@@ -100,6 +107,10 @@ describe('Google AI Studio Cross-Language Trace Comparison', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 5);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 10);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, 15);
+      // Python SDK parity: server.address, server.port, gen_ai.sdk.version
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_ADDRESS, 'generativelanguage.googleapis.com');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_PORT, 443);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 });

--- a/sdk/typescript/src/instrumentation/__tests__/groq-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/groq-trace-comparison.test.ts
@@ -61,6 +61,13 @@ describe('Groq Cross-Language Trace Comparison', () => {
       if (attrs.cost !== undefined) {
         span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
       }
+      if (attrs.serverAddress) {
+        span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+      }
+      if (attrs.serverPort !== undefined) {
+        span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+      }
+      span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 
@@ -119,6 +126,10 @@ describe('Groq Cross-Language Trace Comparison', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, 100);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, ['stop']);
+      // Python SDK parity: server.address, server.port, gen_ai.sdk.version
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_ADDRESS, 'api.groq.com');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_PORT, 443);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
 
     it('should set streaming attributes matching Python SDK', async () => {

--- a/sdk/typescript/src/instrumentation/__tests__/mistral-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/mistral-trace-comparison.test.ts
@@ -47,6 +47,13 @@ describe('Mistral Cross-Language Trace Comparison', () => {
       if (attrs.cost !== undefined) {
         span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
       }
+      if (attrs.serverAddress) {
+        span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+      }
+      if (attrs.serverPort !== undefined) {
+        span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+      }
+      span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 
@@ -99,6 +106,10 @@ describe('Mistral Cross-Language Trace Comparison', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 8);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 15);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, 23);
+      // Python SDK parity: server.address, server.port, gen_ai.sdk.version
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_ADDRESS, 'api.mistral.ai');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_PORT, 443);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 

--- a/sdk/typescript/src/instrumentation/__tests__/together-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/together-trace-comparison.test.ts
@@ -46,6 +46,13 @@ describe('Together AI Cross-Language Trace Comparison', () => {
       if (attrs.cost !== undefined) {
         span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
       }
+      if (attrs.serverAddress) {
+        span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+      }
+      if (attrs.serverPort !== undefined) {
+        span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+      }
+      span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 
@@ -99,6 +106,10 @@ describe('Together AI Cross-Language Trace Comparison', () => {
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 9);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 12);
       expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS, 21);
+      // Python SDK parity: server.address, server.port, gen_ai.sdk.version
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_ADDRESS, 'api.together.xyz');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_PORT, 443);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
     });
   });
 });

--- a/sdk/typescript/src/instrumentation/__tests__/trace-comparison-utils.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/trace-comparison-utils.ts
@@ -146,6 +146,9 @@ function compareAttributes(
     'gen_ai.endpoint',
     'gen_ai.environment',
     'gen_ai.application_name',
+    'server.address',
+    'server.port',
+    'gen_ai.sdk.version',
   ];
   
   for (const key of allKeys) {

--- a/sdk/typescript/src/instrumentation/google-ai/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/google-ai/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper from '../base-wrapper';
 
 class GoogleAIWrapper extends BaseWrapper {
   static aiSystem = 'google_ai_studio';
+  static serverAddress = 'generativelanguage.googleapis.com';
+  static serverPort = 443;
   
   static _patchGenerateContent(tracer: Tracer): any {
     const genAIEndpoint = 'google.generativeai.models.generate_content';
@@ -265,6 +267,8 @@ class GoogleAIWrapper extends BaseWrapper {
       user: undefined,
       cost,
       aiSystem: GoogleAIWrapper.aiSystem,
+      serverAddress: GoogleAIWrapper.serverAddress,
+      serverPort: GoogleAIWrapper.serverPort,
     });
 
     // Response model

--- a/sdk/typescript/src/instrumentation/groq/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/groq/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper from '../base-wrapper';
 
 class GroqWrapper extends BaseWrapper {
   static aiSystem = 'groq';
+  static serverAddress = 'api.groq.com';
+  static serverPort = 443;
   
   static _patchChatCompletionCreate(tracer: Tracer): any {
     const genAIEndpoint = 'groq.chat.completions';
@@ -306,6 +308,8 @@ class GroqWrapper extends BaseWrapper {
       user,
       cost,
       aiSystem: GroqWrapper.aiSystem,
+      serverAddress: GroqWrapper.serverAddress,
+      serverPort: GroqWrapper.serverPort,
     });
 
     // Response model

--- a/sdk/typescript/src/instrumentation/langchain/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/langchain/wrapper.ts
@@ -251,6 +251,8 @@ class OpenLITCallbackHandler {
         model: responseModel,
         cost,
         aiSystem: SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
+        serverAddress: 'localhost',
+        serverPort: 80,
       });
 
       const metricParams: BaseSpanAttributes = {
@@ -258,6 +260,8 @@ class OpenLITCallbackHandler {
         model: responseModel,
         cost,
         aiSystem: SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
+        serverAddress: 'localhost',
+        serverPort: 80,
       };
       span.setStatus({ code: 1 });
       span.end();

--- a/sdk/typescript/src/instrumentation/llamaindex/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/llamaindex/wrapper.ts
@@ -57,7 +57,7 @@ class LlamaIndexWrapper extends BaseWrapper {
 
             const { address, port } = LlamaIndexWrapper._extractServerInfo(this);
 
-            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, cost, aiSystem });
+            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, cost, aiSystem, serverAddress: address, serverPort: port });
 
             span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT);
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
@@ -126,7 +126,7 @@ class LlamaIndexWrapper extends BaseWrapper {
 
             const { address, port } = LlamaIndexWrapper._extractServerInfo(this);
 
-            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, cost, aiSystem });
+            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, cost, aiSystem, serverAddress: address, serverPort: port });
 
             span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT);
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
@@ -188,7 +188,7 @@ class LlamaIndexWrapper extends BaseWrapper {
 
             const { address, port } = LlamaIndexWrapper._extractServerInfo(llm || this);
 
-            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, aiSystem });
+            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, aiSystem, serverAddress: address, serverPort: port });
 
             span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK);
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
@@ -260,7 +260,7 @@ class LlamaIndexWrapper extends BaseWrapper {
 
             const { address, port } = LlamaIndexWrapper._extractServerInfo(llm || this);
 
-            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, aiSystem });
+            LlamaIndexWrapper.setBaseSpanAttributes(span, { genAIEndpoint, model: modelId, aiSystem, serverAddress: address, serverPort: port });
 
             span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK);
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);

--- a/sdk/typescript/src/instrumentation/mistral/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/mistral/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper, { BaseSpanAttributes } from '../base-wrapper';
 
 class MistralWrapper extends BaseWrapper {
   static aiSystem = 'mistral';
+  static serverAddress = 'api.mistral.ai';
+  static serverPort = 443;
   
   static _patchChatCompletionCreate(tracer: Tracer): any {
     const genAIEndpoint = 'mistral.chat.completions';
@@ -292,6 +294,8 @@ class MistralWrapper extends BaseWrapper {
       user,
       cost,
       aiSystem: MistralWrapper.aiSystem,
+      serverAddress: MistralWrapper.serverAddress,
+      serverPort: MistralWrapper.serverPort,
     });
 
     // Response model
@@ -399,6 +403,8 @@ class MistralWrapper extends BaseWrapper {
               user,
               cost,
               aiSystem: MistralWrapper.aiSystem,
+              serverAddress: MistralWrapper.serverAddress,
+              serverPort: MistralWrapper.serverPort,
             });
 
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_ENCODING_FORMATS, [encoding_format]);

--- a/sdk/typescript/src/instrumentation/ollama/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/ollama/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper, { BaseSpanAttributes } from '../base-wrapper';
 
 export default class OllamaWrapper extends BaseWrapper {
   static aiSystem = 'ollama';
+  static serverAddress = '127.0.0.1';
+  static serverPort = 11434;
 
   static _patchChat(tracer: Tracer): any {
     const genAIEndpoint = 'ollama.chat';
@@ -183,6 +185,8 @@ export default class OllamaWrapper extends BaseWrapper {
       user,
       cost,
       aiSystem: OllamaWrapper.aiSystem,
+      serverAddress: OllamaWrapper.serverAddress,
+      serverPort: OllamaWrapper.serverPort,
     });
 
     // Response model

--- a/sdk/typescript/src/instrumentation/openai/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/openai/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper, { BaseSpanAttributes } from '../base-wrapper';
 
 class OpenAIWrapper extends BaseWrapper {
   static aiSystem = SemanticConvention.GEN_AI_SYSTEM_OPENAI;
+  static serverAddress = 'api.openai.com';
+  static serverPort = 443;
   static _patchChatCompletionCreate(tracer: Tracer): any {
     const genAIEndpoint = 'openai.resources.chat.completions';
     return (originalMethod: (...args: any[]) => any) => {
@@ -316,11 +318,13 @@ class OpenAIWrapper extends BaseWrapper {
       user,
       cost,
       aiSystem: OpenAIWrapper.aiSystem,
+      serverAddress: OpenAIWrapper.serverAddress,
+      serverPort: OpenAIWrapper.serverPort,
     });
 
     // Response model
     span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, responseModel);
-    
+
     // OpenAI-specific attributes
     if (result.system_fingerprint) {
       span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT, result.system_fingerprint);
@@ -470,15 +474,11 @@ class OpenAIWrapper extends BaseWrapper {
               user,
               cost,
               aiSystem: OpenAIWrapper.aiSystem,
+              serverAddress: OpenAIWrapper.serverAddress,
+              serverPort: OpenAIWrapper.serverPort,
             });
 
-            // Set missing critical attributes to match Python SDK
-            span.setAttribute(SemanticConvention.SERVER_ADDRESS, 'api.openai.com');
-            span.setAttribute(SemanticConvention.SERVER_PORT, 443);
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
-            span.setAttribute(SemanticConvention.GEN_AI_SERVER_TBT, 0);
-            span.setAttribute(SemanticConvention.GEN_AI_SERVER_TTFT, 0);
-            span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.7.0');
 
             // Request Params attributes : Start
             span.setAttribute(SemanticConvention.GEN_AI_REQUEST_ENCODING_FORMATS, [encoding_format]);
@@ -550,12 +550,14 @@ class OpenAIWrapper extends BaseWrapper {
               validation_file,
             } = args[0];
 
-            // Set base span attribues
+            // Set base span attributes
             OpenAIWrapper.setBaseSpanAttributes(span, {
               genAIEndpoint,
               model,
               user,
               aiSystem: OpenAIWrapper.aiSystem,
+              serverAddress: OpenAIWrapper.serverAddress,
+              serverPort: OpenAIWrapper.serverPort,
             });
 
             span.setAttribute(
@@ -652,6 +654,8 @@ class OpenAIWrapper extends BaseWrapper {
               user,
               cost,
               aiSystem: OpenAIWrapper.aiSystem,
+              serverAddress: OpenAIWrapper.serverAddress,
+              serverPort: OpenAIWrapper.serverPort,
             });
 
             // Request Params attributes : Start
@@ -745,6 +749,8 @@ class OpenAIWrapper extends BaseWrapper {
               user,
               cost,
               aiSystem: OpenAIWrapper.aiSystem,
+              serverAddress: OpenAIWrapper.serverAddress,
+              serverPort: OpenAIWrapper.serverPort,
             });
 
             // Request Params attributes : Start
@@ -827,6 +833,8 @@ class OpenAIWrapper extends BaseWrapper {
               user,
               cost,
               aiSystem: OpenAIWrapper.aiSystem,
+              serverAddress: OpenAIWrapper.serverAddress,
+              serverPort: OpenAIWrapper.serverPort,
             });
 
             // Request Params attributes : Start
@@ -1115,6 +1123,8 @@ class OpenAIWrapper extends BaseWrapper {
       user: '',
       cost,
       aiSystem: OpenAIWrapper.aiSystem,
+      serverAddress: OpenAIWrapper.serverAddress,
+      serverPort: OpenAIWrapper.serverPort,
     });
 
     // Response attributes

--- a/sdk/typescript/src/instrumentation/together/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/together/wrapper.ts
@@ -6,6 +6,8 @@ import BaseWrapper from '../base-wrapper';
 
 class TogetherWrapper extends BaseWrapper {
   static aiSystem = 'together';
+  static serverAddress = 'api.together.xyz';
+  static serverPort = 443;
   
   static _patchChatCompletionCreate(tracer: Tracer): any {
     const genAIEndpoint = 'together.chat.completions';
@@ -287,6 +289,8 @@ class TogetherWrapper extends BaseWrapper {
       user,
       cost,
       aiSystem: TogetherWrapper.aiSystem,
+      serverAddress: TogetherWrapper.serverAddress,
+      serverPort: TogetherWrapper.serverPort,
     });
 
     // Response model

--- a/sdk/typescript/src/otel/metrics.ts
+++ b/sdk/typescript/src/otel/metrics.ts
@@ -35,6 +35,9 @@ export default class Metrics {
   >;
   static genaiServerTbt: ReturnType<ReturnType<typeof metrics.getMeter>['createHistogram']>;
   static genaiServerTtft: ReturnType<ReturnType<typeof metrics.getMeter>['createHistogram']>;
+  static genaiClientTimeToFirstChunk: ReturnType<ReturnType<typeof metrics.getMeter>['createHistogram']>;
+  static genaiClientTimePerOutputChunk: ReturnType<ReturnType<typeof metrics.getMeter>['createHistogram']>;
+  static genaiServerRequestDuration: ReturnType<ReturnType<typeof metrics.getMeter>['createHistogram']>;
   static dbClientOperationDuration: ReturnType<
     ReturnType<typeof metrics.getMeter>['createHistogram']
   >;
@@ -80,6 +83,36 @@ export default class Metrics {
         explicitBucketBoundaries: GEN_AI_SERVER_TFTT,
       },
     });
+    this.genaiClientTimeToFirstChunk = this.meter.createHistogram(
+      SemanticConvention.GEN_AI_CLIENT_OPERATION_TIME_TO_FIRST_CHUNK,
+      {
+        description: 'Time from client request to first response chunk',
+        unit: 's',
+        advice: {
+          explicitBucketBoundaries: GEN_AI_CLIENT_OPERATION_DURATION_BUCKETS,
+        },
+      }
+    );
+    this.genaiClientTimePerOutputChunk = this.meter.createHistogram(
+      SemanticConvention.GEN_AI_CLIENT_OPERATION_TIME_PER_OUTPUT_CHUNK,
+      {
+        description: 'Time between consecutive response chunks from client perspective',
+        unit: 's',
+        advice: {
+          explicitBucketBoundaries: GEN_AI_CLIENT_OPERATION_DURATION_BUCKETS,
+        },
+      }
+    );
+    this.genaiServerRequestDuration = this.meter.createHistogram(
+      SemanticConvention.GEN_AI_SERVER_REQUEST_DURATION,
+      {
+        description: 'Total server-side processing time from request receipt to response transmission',
+        unit: 's',
+        advice: {
+          explicitBucketBoundaries: GEN_AI_CLIENT_OPERATION_DURATION_BUCKETS,
+        },
+      }
+    );
     this.dbClientOperationDuration = this.meter.createHistogram(
       SemanticConvention.DB_CLIENT_OPERATION_DURATION,
       {

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -57,6 +57,9 @@ export default class SemanticConvention {
   static GEN_AI_USAGE_COMPLETION_TOKENS_DETAILS_REASONING = 'gen_ai.usage.completion_tokens_details.reasoning';
   static GEN_AI_USAGE_PROMPT_TOKENS_DETAILS_CACHE_READ = 'gen_ai.usage.prompt_tokens_details.cache_read';
   static GEN_AI_USAGE_PROMPT_TOKENS_DETAILS_CACHE_WRITE = 'gen_ai.usage.prompt_tokens_details.cache_write';
+  // OTel semconv standard cache token attribute names (aligned with Python SDK)
+  static GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS = 'gen_ai.usage.cache_creation.input_tokens';
+  static GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = 'gen_ai.usage.cache_read.input_tokens';
 
   // GenAI Response
   static GEN_AI_RESPONSE_ID = 'gen_ai.response.id';
@@ -162,6 +165,9 @@ export default class SemanticConvention {
   static DB_UPDATE_VALUES = 'db.update.values';
   static DB_UPDATE_ID = 'db.update.id';
   static GEN_AI_CLIENT_OPERATION_DURATION = 'gen_ai.client.operation.duration';
+  static GEN_AI_CLIENT_OPERATION_TIME_TO_FIRST_CHUNK = 'gen_ai.client.operation.time_to_first_chunk';
+  static GEN_AI_CLIENT_OPERATION_TIME_PER_OUTPUT_CHUNK = 'gen_ai.client.operation.time_per_output_chunk';
+  static GEN_AI_SERVER_REQUEST_DURATION = 'gen_ai.server.request.duration';
   static GEN_AI_CLIENT_TOKEN_USAGE = 'gen_ai.client.token.usage';
   static GEN_AI_SERVER_TBT = 'gen_ai.server.time_per_output_token';
   static GEN_AI_SERVER_TTFT = 'gen_ai.server.time_to_first_token';


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:

This PR brings the TypeScript SDK's trace output into full parity with the Python SDK, ensuring consistent observability data across both language implementations.

#### Attribute Parity with Python SDK
- Added `server.address` and `server.port` OTel span attributes to all instrumentation providers (OpenAI, Anthropic, Groq, Mistral, Cohere, Together, Google AI, Ollama, Bedrock, LangChain, LlamaIndex)
- Added `gen_ai.sdk.version` to every span via `base-wrapper.ts`, sourced from a new `SDK_VERSION` constant in `constant.ts`
- Extended `BaseSpanAttributes` type with optional `serverAddress` and `serverPort` fields; `setBaseSpanAttributes` now handles them centrally

#### Anthropic Wrapper Improvements
- Added `gen_ai.system.instructions` attribute from the system field in message requests
- Extracted tool call data from `tool_use` content blocks: sets `gen_ai.tool.name`, `gen_ai.tool.call.id`, and `gen_ai.tool.call.arguments`
- Added `gen_ai.output.type` (text vs json) based on presence of tool use blocks

#### Bedrock Cache Token Fix
- Fixed non-streaming path to use standard OTel attribute names: `gen_ai.usage.cache_read_input_tokens` and `gen_ai.usage.cache_creation_input_tokens` (was incorrectly using `prompt_tokens_details.*` names)

#### Streaming Metrics (Cohere, Vercel AI)
- Added TTFT/TBT tracking and OTel histogram metrics (`gen_ai.client.time_to_first_token`, `gen_ai.server.time_to_first_token`, `gen_ai.client.time_per_output_token`) to Cohere and Vercel AI streaming paths
- Added new histogram metric definitions to `otel/metrics.ts`

#### New Semantic Conventions
- Added `GEN_AI_CLIENT_TIME_TO_FIRST_TOKEN`, `GEN_AI_CLIENT_TIME_PER_OUTPUT_TOKEN`, `GEN_AI_SYSTEM_INSTRUCTIONS`, `GEN_AI_OUTPUT_TYPE`, `GEN_AI_OUTPUT_TYPE_TEXT`, `GEN_AI_OUTPUT_TYPE_JSON` constants

#### Test Updates
- Updated trace comparison test mocks to verify `server.address`, `server.port`, and `gen_ai.sdk.version` are set for all providers (Groq, Mistral, Together, Google AI)
- Added `server.address`, `server.port`, `gen_ai.sdk.version` to `criticalAttributes` in `trace-comparison-utils.ts`
- Fixed `anthropic-wrapper.test.ts` mock and assertion for updated `BaseSpanAttributes` shape

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Align TypeScript SDK tracing and metrics with the Python SDK across providers, adding standardized server metadata, SDK version tagging, enhanced streaming metrics, and updated semantic conventions.

New Features:
- Add standard server.address and server.port span attributes across all supported GenAI instrumentation providers via shared base span handling.
- Tag all spans with a gen_ai.sdk.version attribute sourced from a centralized SDK_VERSION constant.
- Expose new GenAI streaming and latency metrics (time to first chunk/token, time per output chunk/token, and server request duration) through additional histograms and semantic conventions.
- Enrich Anthropic traces with system instructions, tool call metadata, output type classification, and prompt cache token usage attributes.

Bug Fixes:
- Correct Bedrock prompt cache token attributes to use the standard gen_ai.usage.cache_* semantic convention instead of nonstandard prompt_tokens_details names.

Enhancements:
- Centralize base span attribute setting (including SDK version and server metadata) in BaseWrapper to ensure consistent trace output across providers.
- Improve streaming instrumentation for Anthropic, Cohere, Bedrock, and Vercel AI by computing TTFT/TBT from chunk timestamps and recording corresponding span attributes and metrics.
- Extend semantic conventions with standard cache token and client/server streaming duration attributes to match the Python SDK.

Tests:
- Update cross-language trace comparison tests to assert server.address, server.port, and gen_ai.sdk.version parity for multiple providers.
- Adjust Anthropic wrapper tests and shared trace comparison utilities to account for the expanded BaseSpanAttributes and new critical attributes.