### PR TITLE
fix: Issues in Agno and Langgraph instrumentation

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.37.4"
+version = "1.37.5"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/instrumentation/agno/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/agno/__init__.py
@@ -96,12 +96,23 @@ class AgnoInstrumentor(BaseInstrumentor):
         # Patch OpenTelemetry's context detach to suppress benign errors in async/threaded scenarios
         self._patch_otel_context_detach()
 
+        # Detect agno version for method name compatibility.
+        # agno < 2.5.3 used private methods (_run, _arun, _arun_stream, _run_tool).
+        # agno >= 2.5.3 replaced them with public methods (run, arun) and removed _run_tool.
+        try:
+            from agno.agent.agent import Agent as _AgnoAgent
+        except ImportError:
+            _AgnoAgent = None
+
+        _has_private_run = _AgnoAgent is not None and hasattr(_AgnoAgent, "_run")
+
         # Workflow Operations (Always Instrumented)
+        _run_method = "_run" if _has_private_run else "run"
         wrap_function_wrapper(
             "agno.agent.agent",
-            "Agent._run",
+            f"Agent.{_run_method}",
             agent_run_wrap(
-                "agent._run",
+                f"agent.{_run_method}",
                 version,
                 environment,
                 application_name,
@@ -129,29 +140,32 @@ class AgnoInstrumentor(BaseInstrumentor):
             ),
         )
 
-        # CRITICAL: Agent._run_tool is the bridge between agent and tool execution
-        wrap_function_wrapper(
-            "agno.agent.agent",
-            "Agent._run_tool",
-            agent_run_tool_wrap(
-                "agent._run_tool",
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-            ),
-        )
+        # CRITICAL: Agent._run_tool is the bridge between agent and tool execution.
+        # Removed in agno >= 2.5.3 — only wrap if it exists.
+        if _AgnoAgent is not None and hasattr(_AgnoAgent, "_run_tool"):
+            wrap_function_wrapper(
+                "agno.agent.agent",
+                "Agent._run_tool",
+                agent_run_tool_wrap(
+                    "agent._run_tool",
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                ),
+            )
 
         # Async Operations
+        _arun_method = "_arun" if _has_private_run else "arun"
         wrap_function_wrapper(
             "agno.agent.agent",
-            "Agent._arun",
+            f"Agent.{_arun_method}",
             async_agent_run_wrap(
-                "agent._arun",
+                f"agent.{_arun_method}",
                 version,
                 environment,
                 application_name,
@@ -163,21 +177,23 @@ class AgnoInstrumentor(BaseInstrumentor):
             ),
         )
 
-        wrap_function_wrapper(
-            "agno.agent.agent",
-            "Agent._arun_stream",
-            async_agent_run_stream_wrap(
-                "agent._arun_stream",
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-            ),
-        )
+        # Agent._arun_stream removed in agno >= 2.5.3 (streaming merged into arun).
+        if _AgnoAgent is not None and hasattr(_AgnoAgent, "_arun_stream"):
+            wrap_function_wrapper(
+                "agno.agent.agent",
+                "Agent._arun_stream",
+                async_agent_run_stream_wrap(
+                    "agent._arun_stream",
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                ),
+            )
 
         wrap_function_wrapper(
             "agno.agent.agent",

--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -39,7 +39,7 @@ def async_agent_run_wrap(
     Wrap Agno Agent.arun method with comprehensive async instrumentation using process functions only.
     """
 
-    async def wrapper(wrapped, instance, args, kwargs):
+    def wrapper(wrapped, instance, args, kwargs):
         # Extract agent name for span naming with fallback to agent_id
         agent_name = (
             getattr(instance, "name", None)
@@ -48,18 +48,145 @@ def async_agent_run_wrap(
         )
         span_name = f"agent {agent_name}"
 
-        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-            start_time = time.time()
-            response = await wrapped(*args, **kwargs)
+        # agno >= 2.5.3: Agent.arun(stream=True) returns an async generator directly,
+        # not a coroutine. We use a plain def wrapper (not async def) so we can return
+        # either an async gen or a coroutine transparently — an async def wrapper always
+        # wraps its return value inside a new coroutine, breaking the async gen path.
+        if kwargs.get("stream", False):
+            return _arun_stream_wrapper(
+                wrapped,
+                instance,
+                args,
+                kwargs,
+                span_name,
+                tracer,
+                pricing_info,
+                environment,
+                application_name,
+                metrics,
+                capture_message_content,
+                disable_metrics,
+                version,
+            )
 
+        # Non-streaming: return the coroutine from the inner async function directly.
+        return _arun_wrapper(
+            wrapped,
+            instance,
+            args,
+            kwargs,
+            span_name,
+            tracer,
+            pricing_info,
+            environment,
+            application_name,
+            metrics,
+            capture_message_content,
+            disable_metrics,
+            version,
+        )
+
+    return wrapper
+
+
+async def _arun_wrapper(
+    wrapped,
+    instance,
+    args,
+    kwargs,
+    span_name,
+    tracer,
+    pricing_info,
+    environment,
+    application_name,
+    metrics,
+    capture_message_content,
+    disable_metrics,
+    version,
+):
+    """Coroutine helper for the non-streaming Agent.arun path."""
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        start_time = time.time()
+        response = await wrapped(*args, **kwargs)
+        try:
+            process_agent_request(
+                span,
+                instance,
+                args,
+                kwargs,
+                response,
+                start_time,
+                pricing_info,
+                environment,
+                application_name,
+                metrics,
+                capture_message_content,
+                disable_metrics,
+                version,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+            )
+            span.set_status(Status(StatusCode.OK))
+        except Exception as e:
+            handle_exception(span, e)
+            logger.error("Error in async agent.arun trace creation: %s", e)
+        return response
+
+
+async def _arun_stream_wrapper(
+    wrapped,
+    instance,
+    args,
+    kwargs,
+    span_name,
+    tracer,
+    pricing_info,
+    environment,
+    application_name,
+    metrics,
+    capture_message_content,
+    disable_metrics,
+    version,
+):
+    """
+    Async generator wrapper for Agent.arun(stream=True).
+    Keeps the span open for the full duration of iteration.
+    """
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        start_time = time.time()
+        final_response = None
+        try:
             try:
-                # Process request using utils function with ALL attributes from semcov
+                from agno.run.agent import RunOutput  # noqa: WPS433
+            except Exception:
+                RunOutput = None
+            yield_run_output = kwargs.get("yield_run_output", None) or kwargs.get(
+                "yield_run_response", None
+            )
+            new_kwargs = dict(kwargs)
+            new_kwargs["yield_run_output"] = True
+            async for response in wrapped(*args, **new_kwargs):
+                if RunOutput and isinstance(response, RunOutput):
+                    final_response = response
+                    if yield_run_output:
+                        yield response
+                else:
+                    yield response
+            if not RunOutput:
+                final_response = getattr(instance, "run_response", None)
+        except GeneratorExit:
+            pass
+        except Exception as e:
+            handle_exception(span, e)
+            logger.error("Error in async agent.arun stream: %s", e)
+            raise
+        finally:
+            try:
                 process_agent_request(
                     span,
                     instance,
                     args,
                     kwargs,
-                    response,
+                    final_response,
                     start_time,
                     pricing_info,
                     environment,
@@ -70,18 +197,10 @@ def async_agent_run_wrap(
                     version,
                     SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
                 )
-
-                # Mark span as successful
                 span.set_status(Status(StatusCode.OK))
-
             except Exception as e:
-                # Handle instrumentation exceptions - log but don't raise
                 handle_exception(span, e)
-                logger.error("Error in async agent.arun trace creation: %s", e)
-
-            return response
-
-    return wrapper
+                logger.error("Error in async agent.arun stream telemetry: %s", e)
 
 
 def async_agent_continue_run_wrap(

--- a/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
@@ -281,8 +281,8 @@ def _process_stream_chunk(chunk, execution_state, stream_mode):
                             content = get_message_content(msg)
                             if content:
                                 execution_state["final_response"] = (
-                                    (execution_state["final_response"] or "") + content
-                                )
+                                    execution_state["final_response"] or ""
+                                ) + content
                 elif key == "messages" and isinstance(chunk_value, list):
                     # Direct messages in chunk
                     execution_state["message_count"] += len(chunk_value)
@@ -290,8 +290,8 @@ def _process_stream_chunk(chunk, execution_state, stream_mode):
                         content = get_message_content(msg)
                         if content:
                             execution_state["final_response"] = (
-                                (execution_state["final_response"] or "") + content
-                            )
+                                execution_state["final_response"] or ""
+                            ) + content
 
         # Handle tuple format for some stream modes:
         # - (node_name_str, value_dict) for stream_mode="updates" etc.
@@ -311,8 +311,8 @@ def _process_stream_chunk(chunk, execution_state, stream_mode):
                             content = get_message_content(msg)
                             if content:
                                 execution_state["final_response"] = (
-                                    (execution_state["final_response"] or "") + content
-                                )
+                                    execution_state["final_response"] or ""
+                                ) + content
             else:
                 # Format: (message_object, metadata_dict) for stream_mode="messages"
                 # chunk[0] is a LangChain message (AIMessage, HumanMessage, etc.)
@@ -331,8 +331,8 @@ def _process_stream_chunk(chunk, execution_state, stream_mode):
                 content = get_message_content(message_obj)
                 if content:
                     execution_state["final_response"] = (
-                        (execution_state["final_response"] or "") + content
-                    )
+                        execution_state["final_response"] or ""
+                    ) + content
 
     except Exception:
         # Don't fail on chunk processing errors

--- a/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
@@ -280,30 +280,59 @@ def _process_stream_chunk(chunk, execution_state, stream_mode):
                         for msg in msg_list:
                             content = get_message_content(msg)
                             if content:
-                                execution_state["final_response"] = content
+                                execution_state["final_response"] = (
+                                    (execution_state["final_response"] or "") + content
+                                )
                 elif key == "messages" and isinstance(chunk_value, list):
                     # Direct messages in chunk
                     execution_state["message_count"] += len(chunk_value)
                     for msg in chunk_value:
                         content = get_message_content(msg)
                         if content:
-                            execution_state["final_response"] = content
+                            execution_state["final_response"] = (
+                                (execution_state["final_response"] or "") + content
+                            )
 
-        # Handle tuple format (node_name, value) for some stream modes
+        # Handle tuple format for some stream modes:
+        # - (node_name_str, value_dict) for stream_mode="updates" etc.
+        # - (message_object, metadata_dict) for stream_mode="messages"
         elif isinstance(chunk, tuple) and len(chunk) >= 2:
-            node_name, value = chunk[0], chunk[1]
-            if node_name not in ("__start__", "__end__", "__interrupt__"):
-                if node_name not in execution_state["executed_nodes"]:
-                    execution_state["executed_nodes"].append(node_name)
-
-            if isinstance(value, dict) and "messages" in value:
-                msg_list = value["messages"]
-                if isinstance(msg_list, list):
-                    execution_state["message_count"] += len(msg_list)
-                    for msg in msg_list:
-                        content = get_message_content(msg)
-                        if content:
-                            execution_state["final_response"] = content
+            if isinstance(chunk[0], str):
+                # Format: (node_name, value) — node_name is a plain string
+                node_name, value = chunk[0], chunk[1]
+                if node_name not in ("__start__", "__end__", "__interrupt__"):
+                    if node_name not in execution_state["executed_nodes"]:
+                        execution_state["executed_nodes"].append(node_name)
+                if isinstance(value, dict) and "messages" in value:
+                    msg_list = value["messages"]
+                    if isinstance(msg_list, list):
+                        execution_state["message_count"] += len(msg_list)
+                        for msg in msg_list:
+                            content = get_message_content(msg)
+                            if content:
+                                execution_state["final_response"] = (
+                                    (execution_state["final_response"] or "") + content
+                                )
+            else:
+                # Format: (message_object, metadata_dict) for stream_mode="messages"
+                # chunk[0] is a LangChain message (AIMessage, HumanMessage, etc.)
+                # chunk[1] is a metadata dict containing "langgraph_node"
+                message_obj, metadata = chunk[0], chunk[1]
+                if isinstance(metadata, dict):
+                    node_name = metadata.get("langgraph_node", "")
+                    if (
+                        node_name
+                        and isinstance(node_name, str)
+                        and node_name not in ("__start__", "__end__", "__interrupt__")
+                        and node_name not in execution_state["executed_nodes"]
+                    ):
+                        execution_state["executed_nodes"].append(node_name)
+                execution_state["message_count"] += 1
+                content = get_message_content(message_obj)
+                if content:
+                    execution_state["final_response"] = (
+                        (execution_state["final_response"] or "") + content
+                    )
 
     except Exception:
         # Don't fail on chunk processing errors

--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -69,31 +69,31 @@ def general_wrap(
             operation_type, gen_ai_endpoint, instance, args, kwargs
         )
 
+        # Stream operations manage their own span lifetime inside the generator
+        if gen_ai_endpoint == "graph_stream":
+            return _handle_stream(
+                wrapped,
+                instance,
+                args,
+                kwargs,
+                span_name,
+                tracer,
+                operation_type,
+                server_address,
+                server_port,
+                environment,
+                application_name,
+                metrics,
+                capture_message_content,
+                disable_metrics,
+                version,
+                gen_ai_endpoint,
+            )
+
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
 
             try:
-                # Handle stream operations specially
-                if gen_ai_endpoint == "graph_stream":
-                    return _handle_stream(
-                        wrapped,
-                        instance,
-                        args,
-                        kwargs,
-                        span,
-                        start_time,
-                        operation_type,
-                        server_address,
-                        server_port,
-                        environment,
-                        application_name,
-                        metrics,
-                        capture_message_content,
-                        disable_metrics,
-                        version,
-                        gen_ai_endpoint,
-                    )
-
                 # Execute the wrapped function
                 response = wrapped(*args, **kwargs)
 
@@ -131,8 +131,8 @@ def _handle_stream(
     instance,
     args,
     kwargs,
-    span,
-    start_time,
+    span_name,
+    tracer,
     operation_type,
     server_address,
     server_port,
@@ -147,58 +147,56 @@ def _handle_stream(
     """
     Handle streaming responses with proper telemetry.
 
-    Returns a generator that wraps the stream and captures telemetry.
+    Returns a generator that owns the span lifetime — the span stays open
+    for the entire iteration and is closed only after the last chunk.
     """
-    # Set basic attributes directly without using common_framework_span_attributes
-    # (since we don't have _end_time for streaming until it completes)
-    span.set_attribute("telemetry.sdk.name", "openlit")
-    span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
-    span.set_attribute(
-        SemanticConvention.GEN_AI_PROVIDER_NAME,
-        SemanticConvention.GEN_AI_SYSTEM_LANGGRAPH,
-    )
-    span.set_attribute(SemanticConvention.GEN_AI_OPERATION, endpoint)
-    span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, "unknown")
-    span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
-    span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
-    span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
-    span.set_attribute(SemanticConvention.GEN_AI_APPLICATION_NAME, application_name)
 
-    span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_type)
-    span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
-    span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, True)
+    def stream_wrapper():
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
 
-    # Track execution state
-    execution_state = {
-        "executed_nodes": [],
-        "message_count": 0,
-        "chunk_count": 0,
-        "final_response": None,
-    }
+            span.set_attribute("telemetry.sdk.name", "openlit")
+            span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+            span.set_attribute(
+                SemanticConvention.GEN_AI_PROVIDER_NAME,
+                SemanticConvention.GEN_AI_SYSTEM_LANGGRAPH,
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, "unknown")
+            span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+            span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+            span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
+            span.set_attribute(SemanticConvention.GEN_AI_APPLICATION_NAME, application_name)
+            span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_type)
+            span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
+            span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, True)
 
-    # Capture input messages
-    input_data = args[0] if args else kwargs.get("input", {})
-    messages = extract_messages_from_input(input_data)
-    if messages:
-        execution_state["message_count"] = len(messages)
-        if capture_message_content:
-            for i, msg in enumerate(messages[:3]):
-                content = get_message_content(msg)
-                role = get_message_role(msg)
-                if content:
-                    span.set_attribute(f"gen_ai.prompt.{i}.content", content[:500])
-                    span.set_attribute(f"gen_ai.prompt.{i}.role", role)
+            # Track execution state
+            execution_state = {
+                "executed_nodes": [],
+                "message_count": 0,
+                "chunk_count": 0,
+                "final_response": None,
+            }
 
-    try:
-        # Get the stream
-        stream_gen = wrapped(*args, **kwargs)
+            # Capture input messages
+            input_data = args[0] if args else kwargs.get("input", {})
+            messages = extract_messages_from_input(input_data)
+            if messages:
+                execution_state["message_count"] = len(messages)
+                if capture_message_content:
+                    for i, msg in enumerate(messages[:3]):
+                        content = get_message_content(msg)
+                        role = get_message_role(msg)
+                        if content:
+                            span.set_attribute(f"gen_ai.prompt.{i}.content", content[:500])
+                            span.set_attribute(f"gen_ai.prompt.{i}.role", role)
 
-        def stream_wrapper():
             try:
+                stream_gen = wrapped(*args, **kwargs)
+
                 for chunk in stream_gen:
                     execution_state["chunk_count"] += 1
 
-                    # Process chunk
                     if isinstance(chunk, dict):
                         for key in chunk:
                             # Track node executions
@@ -218,11 +216,53 @@ def _handle_stream(
                                     for msg in msg_list:
                                         content = get_message_content(msg)
                                         if content:
-                                            execution_state["final_response"] = content
+                                            execution_state["final_response"] = (
+                                                (execution_state["final_response"] or "") + content
+                                            )
+
+                    # Handle tuple format for some stream modes:
+                    # - (node_name_str, value_dict) for stream_mode="updates" etc.
+                    # - (message_object, metadata_dict) for stream_mode="messages"
+                    elif isinstance(chunk, tuple) and len(chunk) >= 2:
+                        if isinstance(chunk[0], str):
+                            # Format: (node_name, value) — node_name is a plain string
+                            node_name, value = chunk[0], chunk[1]
+                            if node_name not in ("__start__", "__end__", "__interrupt__"):
+                                if node_name not in execution_state["executed_nodes"]:
+                                    execution_state["executed_nodes"].append(node_name)
+                            if isinstance(value, dict) and "messages" in value:
+                                msg_list = value["messages"]
+                                if isinstance(msg_list, list):
+                                    execution_state["message_count"] += len(msg_list)
+                                    for msg in msg_list:
+                                        content = get_message_content(msg)
+                                        if content:
+                                            execution_state["final_response"] = (
+                                                (execution_state["final_response"] or "") + content
+                                            )
+                        else:
+                            # Format: (message_object, metadata_dict) for stream_mode="messages"
+                            # chunk[0] is a LangChain message (AIMessage, HumanMessage, etc.)
+                            # chunk[1] is a metadata dict containing "langgraph_node"
+                            message_obj, metadata = chunk[0], chunk[1]
+                            if isinstance(metadata, dict):
+                                node_name = metadata.get("langgraph_node", "")
+                                if (
+                                    node_name
+                                    and isinstance(node_name, str)
+                                    and node_name not in ("__start__", "__end__", "__interrupt__")
+                                    and node_name not in execution_state["executed_nodes"]
+                                ):
+                                    execution_state["executed_nodes"].append(node_name)
+                            execution_state["message_count"] += 1
+                            content = get_message_content(message_obj)
+                            if content:
+                                execution_state["final_response"] = (
+                                    (execution_state["final_response"] or "") + content
+                                )
 
                     yield chunk
 
-                # Set final attributes
                 _finalize_stream_span(
                     span, execution_state, capture_message_content, start_time
                 )
@@ -231,11 +271,7 @@ def _handle_stream(
                 handle_exception(span, e)
                 raise
 
-        return stream_wrapper()
-
-    except Exception as e:
-        handle_exception(span, e)
-        raise
+    return stream_wrapper()
 
 
 def _finalize_stream_span(span, execution_state, capture_message_content, start_time):

--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -165,7 +165,9 @@ def _handle_stream(
             span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
             span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
             span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
-            span.set_attribute(SemanticConvention.GEN_AI_APPLICATION_NAME, application_name)
+            span.set_attribute(
+                SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+            )
             span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_type)
             span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
             span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, True)
@@ -188,7 +190,9 @@ def _handle_stream(
                         content = get_message_content(msg)
                         role = get_message_role(msg)
                         if content:
-                            span.set_attribute(f"gen_ai.prompt.{i}.content", content[:500])
+                            span.set_attribute(
+                                f"gen_ai.prompt.{i}.content", content[:500]
+                            )
                             span.set_attribute(f"gen_ai.prompt.{i}.role", role)
 
             try:
@@ -217,8 +221,8 @@ def _handle_stream(
                                         content = get_message_content(msg)
                                         if content:
                                             execution_state["final_response"] = (
-                                                (execution_state["final_response"] or "") + content
-                                            )
+                                                execution_state["final_response"] or ""
+                                            ) + content
 
                     # Handle tuple format for some stream modes:
                     # - (node_name_str, value_dict) for stream_mode="updates" etc.
@@ -227,7 +231,11 @@ def _handle_stream(
                         if isinstance(chunk[0], str):
                             # Format: (node_name, value) — node_name is a plain string
                             node_name, value = chunk[0], chunk[1]
-                            if node_name not in ("__start__", "__end__", "__interrupt__"):
+                            if node_name not in (
+                                "__start__",
+                                "__end__",
+                                "__interrupt__",
+                            ):
                                 if node_name not in execution_state["executed_nodes"]:
                                     execution_state["executed_nodes"].append(node_name)
                             if isinstance(value, dict) and "messages" in value:
@@ -238,8 +246,8 @@ def _handle_stream(
                                         content = get_message_content(msg)
                                         if content:
                                             execution_state["final_response"] = (
-                                                (execution_state["final_response"] or "") + content
-                                            )
+                                                execution_state["final_response"] or ""
+                                            ) + content
                         else:
                             # Format: (message_object, metadata_dict) for stream_mode="messages"
                             # chunk[0] is a LangChain message (AIMessage, HumanMessage, etc.)
@@ -250,16 +258,18 @@ def _handle_stream(
                                 if (
                                     node_name
                                     and isinstance(node_name, str)
-                                    and node_name not in ("__start__", "__end__", "__interrupt__")
-                                    and node_name not in execution_state["executed_nodes"]
+                                    and node_name
+                                    not in ("__start__", "__end__", "__interrupt__")
+                                    and node_name
+                                    not in execution_state["executed_nodes"]
                                 ):
                                     execution_state["executed_nodes"].append(node_name)
                             execution_state["message_count"] += 1
                             content = get_message_content(message_obj)
                             if content:
                                 execution_state["final_response"] = (
-                                    (execution_state["final_response"] or "") + content
-                                )
+                                    execution_state["final_response"] or ""
+                                ) + content
 
                     yield chunk
 


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: resolves #1027  and resolved #1007 

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Fix and improve Agno and LangGraph instrumentation for streaming and async agent operations.

Bug Fixes:
- Ensure LangGraph streaming spans are managed for the full stream lifetime and correctly accumulate final response content across all chunk formats.
- Restore compatibility of async Agno Agent.arun instrumentation with newer Agno versions where arun(stream=True) returns an async generator and internal method names have changed.
- Handle LangGraph async streaming chunks that use tuple-based message formats so executed nodes, message counts, and final responses are captured accurately.

Enhancements:
- Make Agno instrumentation resilient to Agno version changes by dynamically detecting available Agent methods and only wrapping tool and stream helpers when present.

Build:
- Bump Python SDK package version to 1.37.5.