### PR TITLE
feat: Add Agent SRE instrumentation for SLO/chaos observability

### DIFF
--- a/sdk/python/src/openlit/_instrumentors.py
+++ b/sdk/python/src/openlit/_instrumentors.py
@@ -54,6 +54,7 @@ MODULE_NAME_MAP = {
     "sarvam": "sarvamai",
     "browser-use": "browser_use",
     "mcp": "mcp",
+    "agent-sre": "agent_sre",
     # Database instrumentations
     "psycopg": "psycopg",
     "psycopg-pool": "psycopg_pool",
@@ -124,6 +125,7 @@ INSTRUMENTOR_MAP = {
     "sarvam": "openlit.instrumentation.sarvam.SarvamInstrumentor",
     "browser-use": "openlit.instrumentation.browser_use.BrowserUseInstrumentor",
     "mcp": "openlit.instrumentation.mcp.MCPInstrumentor",
+    "agent-sre": "openlit.instrumentation.agent_sre.AgentSREInstrumentor",
     # Database instrumentations
     "psycopg": "openlit.instrumentation.psycopg.PsycopgInstrumentor",
     "psycopg-pool": "openlit.instrumentation.psycopg.PsycopgInstrumentor",

--- a/sdk/python/src/openlit/instrumentation/agent_sre/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/agent_sre/__init__.py
@@ -1,0 +1,127 @@
+"""
+OpenLIT Agent SRE Instrumentation
+
+Auto-instruments agent-sre (https://github.com/imran-siddique/agent-sre)
+to capture SLO evaluations, chaos experiments, error budget events,
+and resilience scores as OpenTelemetry spans and metrics.
+"""
+
+from typing import Collection
+import importlib.metadata
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from wrapt import wrap_function_wrapper
+
+from openlit.instrumentation.agent_sre.agent_sre import (
+    wrap_slo_evaluate,
+    wrap_chaos_start,
+    wrap_chaos_complete,
+    wrap_error_budget_record,
+    wrap_sli_record,
+)
+
+_instruments = ("agent-sre >= 1.0.0",)
+
+# SLO/SLI operations
+SLO_OPERATIONS = [
+    ("agent_sre.slo.objectives", "SLO.evaluate", "slo_evaluate"),
+    ("agent_sre.slo.objectives", "ErrorBudget.record_event", "error_budget_record"),
+]
+
+# Chaos operations
+CHAOS_OPERATIONS = [
+    ("agent_sre.chaos.engine", "ChaosExperiment.start", "chaos_start"),
+    ("agent_sre.chaos.engine", "ChaosExperiment.complete", "chaos_complete"),
+    ("agent_sre.chaos.engine", "ChaosExperiment.abort", "chaos_abort"),
+]
+
+# SLI recording (detailed tracing)
+SLI_OPERATIONS = [
+    ("agent_sre.slo.indicators", "TaskSuccessRate.record", "sli_task_success"),
+    ("agent_sre.slo.indicators", "ResponseLatency.record", "sli_response_latency"),
+    ("agent_sre.slo.indicators", "ToolCallAccuracy.record", "sli_tool_accuracy"),
+    ("agent_sre.slo.indicators", "PolicyCompliance.record", "sli_policy_compliance"),
+    ("agent_sre.slo.indicators", "HallucinationRate.record", "sli_hallucination"),
+]
+
+# Map of wrapper functions by operation type
+WRAPPER_MAP = {
+    "slo_evaluate": wrap_slo_evaluate,
+    "error_budget_record": wrap_error_budget_record,
+    "chaos_start": wrap_chaos_start,
+    "chaos_complete": wrap_chaos_complete,
+    "chaos_abort": wrap_chaos_complete,  # Same pattern as complete
+    "sli_task_success": wrap_sli_record,
+    "sli_response_latency": wrap_sli_record,
+    "sli_tool_accuracy": wrap_sli_record,
+    "sli_policy_compliance": wrap_sli_record,
+    "sli_hallucination": wrap_sli_record,
+}
+
+
+class AgentSREInstrumentor(BaseInstrumentor):
+    """
+    Instrumentor for Agent SRE — AI-native SRE framework.
+
+    Captures SLO evaluations, chaos experiments, error budget consumption,
+    and SLI measurements as OpenTelemetry spans and metrics visible in
+    OpenLit's dashboard.
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        version = importlib.metadata.version("agent-sre")
+        environment = kwargs.get("environment", "default")
+        application_name = kwargs.get("application_name", "default")
+        tracer = kwargs.get("tracer")
+        pricing_info = kwargs.get("pricing_info", {})
+        capture_message_content = kwargs.get("capture_message_content", False)
+        metrics = kwargs.get("metrics_dict")
+        disable_metrics = kwargs.get("disable_metrics")
+        detailed_tracing = kwargs.get("detailed_tracing", False)
+
+        common_args = (
+            version,
+            environment,
+            application_name,
+            tracer,
+            pricing_info,
+            capture_message_content,
+            metrics,
+            disable_metrics,
+        )
+
+        # SLO operations (always enabled)
+        for module, method, op_type in SLO_OPERATIONS:
+            try:
+                wrapper_fn = WRAPPER_MAP[op_type]
+                wrap_function_wrapper(
+                    module, method, wrapper_fn(op_type, *common_args),
+                )
+            except Exception:
+                pass
+
+        # Chaos operations (always enabled)
+        for module, method, op_type in CHAOS_OPERATIONS:
+            try:
+                wrapper_fn = WRAPPER_MAP[op_type]
+                wrap_function_wrapper(
+                    module, method, wrapper_fn(op_type, *common_args),
+                )
+            except Exception:
+                pass
+
+        # SLI operations (detailed tracing only)
+        if detailed_tracing:
+            for module, method, op_type in SLI_OPERATIONS:
+                try:
+                    wrapper_fn = WRAPPER_MAP[op_type]
+                    wrap_function_wrapper(
+                        module, method, wrapper_fn(op_type, *common_args),
+                    )
+                except Exception:
+                    pass
+
+    def _uninstrument(self, **kwargs):
+        """Uninstrument Agent SRE operations."""

--- a/sdk/python/src/openlit/instrumentation/agent_sre/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/agent_sre/__init__.py
@@ -1,7 +1,7 @@
 """
 OpenLIT Agent SRE Instrumentation
 
-Auto-instruments agent-sre (https://github.com/imran-siddique/agent-sre)
+Auto-instruments agent-sre (https://github.com/microsoft/agent-governance-toolkit)
 to capture SLO evaluations, chaos experiments, error budget events,
 and resilience scores as OpenTelemetry spans and metrics.
 """

--- a/sdk/python/src/openlit/instrumentation/agent_sre/agent_sre.py
+++ b/sdk/python/src/openlit/instrumentation/agent_sre/agent_sre.py
@@ -1,0 +1,233 @@
+"""
+Agent SRE sync wrappers for OpenLIT instrumentation.
+
+Wraps SLO evaluation, chaos experiments, error budget events, and SLI
+recordings with OpenTelemetry spans and metrics.
+"""
+
+import time
+from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry import context as context_api
+from openlit.__helpers import handle_exception
+from openlit.instrumentation.agent_sre.utils import (
+    set_slo_span_attributes,
+    set_chaos_span_attributes,
+    set_error_budget_span_attributes,
+    set_sli_span_attributes,
+    record_sre_metrics,
+)
+
+
+def wrap_slo_evaluate(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wrapper for SLO.evaluate() — captures SLO status as a span."""
+
+    def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        slo_name = getattr(instance, "name", "unknown")
+        span_name = f"slo.evaluate {slo_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+            start_time = time.time()
+
+            try:
+                response = wrapped(*args, **kwargs)
+
+                set_slo_span_attributes(
+                    span, instance, response, version, environment,
+                    application_name,
+                )
+
+                if not disable_metrics and metrics:
+                    record_sre_metrics(
+                        metrics, "slo_evaluate", instance, response,
+                        time.time() - start_time,
+                    )
+
+                return response
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper
+
+
+def wrap_chaos_start(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wrapper for ChaosExperiment.start() — creates chaos experiment span."""
+
+    def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        exp_name = getattr(instance, "name", "unknown")
+        span_name = f"chaos.start {exp_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+            try:
+                response = wrapped(*args, **kwargs)
+
+                set_chaos_span_attributes(
+                    span, instance, "start", version, environment,
+                    application_name,
+                )
+
+                if not disable_metrics and metrics:
+                    record_sre_metrics(
+                        metrics, "chaos_start", instance, None,
+                        0,
+                    )
+
+                return response
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper
+
+
+def wrap_chaos_complete(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wrapper for ChaosExperiment.complete()/abort() — records experiment result."""
+
+    def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        exp_name = getattr(instance, "name", "unknown")
+        action = "complete" if "complete" in gen_ai_endpoint else "abort"
+        span_name = f"chaos.{action} {exp_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+            start_time = time.time()
+
+            try:
+                response = wrapped(*args, **kwargs)
+
+                set_chaos_span_attributes(
+                    span, instance, action, version, environment,
+                    application_name,
+                )
+
+                if not disable_metrics and metrics:
+                    record_sre_metrics(
+                        metrics, f"chaos_{action}", instance, None,
+                        time.time() - start_time,
+                    )
+
+                return response
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper
+
+
+def wrap_error_budget_record(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wrapper for ErrorBudget.record_event() — tracks budget consumption."""
+
+    def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        good = args[0] if args else kwargs.get("good", True)
+        event_type = "good" if good else "bad"
+        span_name = f"error_budget.record {event_type}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+            try:
+                response = wrapped(*args, **kwargs)
+
+                set_error_budget_span_attributes(
+                    span, instance, good, version, environment,
+                    application_name,
+                )
+
+                if not disable_metrics and metrics:
+                    record_sre_metrics(
+                        metrics, "error_budget_record", instance,
+                        {"good": good}, 0,
+                    )
+
+                return response
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper
+
+
+def wrap_sli_record(
+    gen_ai_endpoint,
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wrapper for SLI.record() — captures individual SLI measurements."""
+
+    def wrapper(wrapped, instance, args, kwargs):
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        sli_name = getattr(instance, "name", gen_ai_endpoint)
+        span_name = f"sli.record {sli_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+            try:
+                response = wrapped(*args, **kwargs)
+
+                set_sli_span_attributes(
+                    span, instance, args, version, environment,
+                    application_name,
+                )
+
+                return response
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper

--- a/sdk/python/src/openlit/instrumentation/agent_sre/utils.py
+++ b/sdk/python/src/openlit/instrumentation/agent_sre/utils.py
@@ -1,0 +1,183 @@
+"""
+Utility functions for Agent SRE instrumentation.
+
+Sets span attributes and records metrics for SLO, chaos, error budget,
+and SLI operations following OpenTelemetry semantic conventions.
+"""
+
+from opentelemetry.trace import StatusCode
+
+
+# Semantic conventions for Agent SRE spans
+AGENT_SRE_SYSTEM = "agent_sre"
+ATTR_SRE_VERSION = "agent.sre.version"
+ATTR_ENVIRONMENT = "deployment.environment"
+ATTR_APPLICATION = "application.name"
+
+# SLO attributes
+ATTR_SLO_NAME = "agent.sre.slo.name"
+ATTR_SLO_STATUS = "agent.sre.slo.status"
+ATTR_SLO_DESCRIPTION = "agent.sre.slo.description"
+ATTR_ERROR_BUDGET_TOTAL = "agent.sre.error_budget.total"
+ATTR_ERROR_BUDGET_CONSUMED = "agent.sre.error_budget.consumed"
+ATTR_ERROR_BUDGET_REMAINING = "agent.sre.error_budget.remaining_percent"
+ATTR_BURN_RATE = "agent.sre.burn_rate"
+ATTR_IS_EXHAUSTED = "agent.sre.error_budget.is_exhausted"
+
+# Chaos attributes
+ATTR_CHAOS_ID = "agent.sre.chaos.experiment_id"
+ATTR_CHAOS_NAME = "agent.sre.chaos.experiment_name"
+ATTR_CHAOS_TARGET = "agent.sre.chaos.target_agent"
+ATTR_CHAOS_STATE = "agent.sre.chaos.state"
+ATTR_CHAOS_DURATION = "agent.sre.chaos.duration_seconds"
+ATTR_CHAOS_BLAST_RADIUS = "agent.sre.chaos.blast_radius"
+ATTR_CHAOS_FAULT_COUNT = "agent.sre.chaos.fault_count"
+ATTR_CHAOS_INJECTION_COUNT = "agent.sre.chaos.injection_count"
+ATTR_CHAOS_RESILIENCE_SCORE = "agent.sre.chaos.resilience_score"
+ATTR_CHAOS_RESILIENCE_PASSED = "agent.sre.chaos.resilience_passed"
+ATTR_CHAOS_ABORT_REASON = "agent.sre.chaos.abort_reason"
+
+# SLI attributes
+ATTR_SLI_NAME = "agent.sre.sli.name"
+ATTR_SLI_VALUE = "agent.sre.sli.value"
+ATTR_SLI_TARGET = "agent.sre.sli.target"
+ATTR_SLI_WINDOW = "agent.sre.sli.window"
+
+# Error budget event attributes
+ATTR_BUDGET_EVENT_GOOD = "agent.sre.error_budget.event_good"
+
+
+def _set_common_attributes(span, version, environment, application_name):
+    """Set common attributes on all Agent SRE spans."""
+    span.set_attribute(ATTR_SRE_VERSION, version)
+    span.set_attribute(ATTR_ENVIRONMENT, environment)
+    span.set_attribute(ATTR_APPLICATION, application_name)
+    span.set_attribute("gen_ai.system", AGENT_SRE_SYSTEM)
+
+
+def set_slo_span_attributes(span, slo, status, version, environment, application_name):
+    """Set attributes for SLO evaluation spans."""
+    _set_common_attributes(span, version, environment, application_name)
+
+    span.set_attribute(ATTR_SLO_NAME, getattr(slo, "name", "unknown"))
+    span.set_attribute(ATTR_SLO_STATUS, status.value if hasattr(status, "value") else str(status))
+    span.set_attribute(ATTR_SLO_DESCRIPTION, getattr(slo, "description", ""))
+
+    budget = getattr(slo, "error_budget", None)
+    if budget:
+        span.set_attribute(ATTR_ERROR_BUDGET_TOTAL, budget.total)
+        span.set_attribute(ATTR_ERROR_BUDGET_CONSUMED, budget.consumed)
+        span.set_attribute(ATTR_ERROR_BUDGET_REMAINING, budget.remaining_percent)
+        span.set_attribute(ATTR_BURN_RATE, budget.burn_rate())
+        span.set_attribute(ATTR_IS_EXHAUSTED, budget.is_exhausted)
+
+    # Set span status based on SLO status
+    status_val = status.value if hasattr(status, "value") else str(status)
+    if status_val in ("exhausted", "critical"):
+        span.set_status(StatusCode.ERROR, f"SLO {slo.name} is {status_val}")
+    else:
+        span.set_status(StatusCode.OK)
+
+
+def set_chaos_span_attributes(span, experiment, action, version, environment, application_name):
+    """Set attributes for chaos experiment spans."""
+    _set_common_attributes(span, version, environment, application_name)
+
+    span.set_attribute(ATTR_CHAOS_ID, getattr(experiment, "experiment_id", ""))
+    span.set_attribute(ATTR_CHAOS_NAME, getattr(experiment, "name", "unknown"))
+    span.set_attribute(ATTR_CHAOS_TARGET, getattr(experiment, "target_agent", ""))
+    span.set_attribute(ATTR_CHAOS_STATE, getattr(experiment, "state", None) and experiment.state.value or "unknown")
+    span.set_attribute(ATTR_CHAOS_DURATION, getattr(experiment, "duration_seconds", 0))
+    span.set_attribute(ATTR_CHAOS_BLAST_RADIUS, getattr(experiment, "blast_radius", 1.0))
+
+    faults = getattr(experiment, "faults", [])
+    span.set_attribute(ATTR_CHAOS_FAULT_COUNT, len(faults))
+
+    events = getattr(experiment, "injection_events", [])
+    span.set_attribute(ATTR_CHAOS_INJECTION_COUNT, len(events))
+
+    resilience = getattr(experiment, "resilience", None)
+    if resilience:
+        span.set_attribute(ATTR_CHAOS_RESILIENCE_SCORE, resilience.overall)
+        span.set_attribute(ATTR_CHAOS_RESILIENCE_PASSED, resilience.passed)
+
+    abort_reason = getattr(experiment, "abort_reason", None)
+    if abort_reason:
+        span.set_attribute(ATTR_CHAOS_ABORT_REASON, abort_reason)
+        span.set_status(StatusCode.ERROR, abort_reason)
+    elif action == "complete":
+        span.set_status(StatusCode.OK)
+
+    # Add fault types as events
+    for fault in faults:
+        span.add_event(
+            "fault_definition",
+            attributes={
+                "fault_type": fault.fault_type.value,
+                "target": fault.target,
+                "rate": fault.rate,
+            },
+        )
+
+
+def set_error_budget_span_attributes(span, budget, good, version, environment, application_name):
+    """Set attributes for error budget record_event spans."""
+    _set_common_attributes(span, version, environment, application_name)
+
+    span.set_attribute(ATTR_BUDGET_EVENT_GOOD, good)
+    span.set_attribute(ATTR_ERROR_BUDGET_TOTAL, budget.total)
+    span.set_attribute(ATTR_ERROR_BUDGET_CONSUMED, budget.consumed)
+    span.set_attribute(ATTR_ERROR_BUDGET_REMAINING, budget.remaining_percent)
+    span.set_attribute(ATTR_IS_EXHAUSTED, budget.is_exhausted)
+
+    if budget.is_exhausted:
+        span.set_status(StatusCode.ERROR, "Error budget exhausted")
+    elif not good:
+        span.set_status(StatusCode.OK, "Bad event recorded against budget")
+    else:
+        span.set_status(StatusCode.OK)
+
+
+def set_sli_span_attributes(span, sli, args, version, environment, application_name):
+    """Set attributes for SLI record spans."""
+    _set_common_attributes(span, version, environment, application_name)
+
+    span.set_attribute(ATTR_SLI_NAME, getattr(sli, "name", "unknown"))
+    span.set_attribute(ATTR_SLI_TARGET, getattr(sli, "target", 0.0))
+
+    window = getattr(sli, "window", None)
+    if window and hasattr(window, "value"):
+        span.set_attribute(ATTR_SLI_WINDOW, window.value)
+
+    current = sli.current_value() if hasattr(sli, "current_value") else None
+    if current is not None:
+        span.set_attribute(ATTR_SLI_VALUE, current)
+
+    span.set_status(StatusCode.OK)
+
+
+def record_sre_metrics(metrics, operation, instance, response, duration):
+    """Record Agent SRE metrics to OpenLit's metric instruments.
+
+    Args:
+        metrics: OpenLit metrics dictionary
+        operation: Operation type string
+        instance: The agent-sre object (SLO, ChaosExperiment, etc.)
+        response: Operation response/result
+        duration: Operation duration in seconds
+    """
+    if not metrics:
+        return
+
+    try:
+        counter = metrics.get("gen_ai_client_operation_duration")
+        if counter and duration > 0:
+            counter.record(
+                duration,
+                attributes={
+                    "gen_ai.system": AGENT_SRE_SYSTEM,
+                    "gen_ai.operation.name": operation,
+                },
+            )
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

Adds auto-instrumentation for [Agent SRE](https://github.com/imran-siddique/agent-sre), an AI-native SRE framework (1,071+ tests) that provides SLI/SLO tracking, chaos testing, canary deployments, and incident response for AI agent systems.

Follows up on #1003 where @amanagarwal042 invited a PR.

## What's Instrumented

| Operation | Span Name | Key Attributes |
|-----------|-----------|----------------|
| \\SLO.evaluate()\\ | \\slo.evaluate {name}\\ | status, error_budget_remaining, burn_rate, is_exhausted |
| \\ErrorBudget.record_event()\\ | \\rror_budget.record {good\|bad}\\ | total, consumed, remaining_percent |
| \\ChaosExperiment.start()\\ | \\chaos.start {name}\\ | target_agent, fault_count, blast_radius |
| \\ChaosExperiment.complete()\\ | \\chaos.complete {name}\\ | resilience_score, resilience_passed, duration |
| \\ChaosExperiment.abort()\\ | \\chaos.abort {name}\\ | abort_reason, injection_count |
| \\SLI.record()\\ (detailed) | \\sli.record {name}\\ | value, target, window |

## How It Works

Since Agent SRE already exports native OTel metrics and traces, the instrumentation wraps the core methods using \\wrapt\\ (same pattern as CrewAI, LangChain, etc.) to automatically capture SRE telemetry when \\openlit.init()\\ is called.

No OpenLit-specific code needed in agent-sre — the instrumentation monkey-patches at import time.

## Files Changed

- \\sdk/python/src/openlit/instrumentation/agent_sre/__init__.py\\ — \\AgentSREInstrumentor\\ class
- \\sdk/python/src/openlit/instrumentation/agent_sre/agent_sre.py\\ — Sync wrappers for all operations
- \\sdk/python/src/openlit/instrumentation/agent_sre/utils.py\\ — Span attribute helpers + metrics recording
- \\sdk/python/src/openlit/_instrumentors.py\\ — Registered \\gent-sre\\ in both maps

## Use Case

With this instrumentation, OpenLit users running agent-sre can see:
- **SLO health dashboards** — real-time error budget burn rate, SLI compliance
- **Chaos experiment traces** — fault injection events, resilience scores, abort conditions
- **Error budget consumption** — track good/bad events against budget

Closes #1003

## Summary by Sourcery

Add OpenTelemetry-based instrumentation for the Agent SRE framework to capture SLO, SLI, chaos experiments, and error budget operations in OpenLit.

New Features:
- Introduce AgentSREInstrumentor to auto-instrument agent-sre SLOs, SLIs, chaos experiments, and error budget events via OpenTelemetry spans and metrics.

Enhancements:
- Register agent-sre as a first-class instrumentation target in the global OpenLit instrumentor registry.