### PR TITLE
fix: handle content=None and non-dict messages in format_content()

### DIFF
--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -59,12 +59,26 @@ def format_content(messages):
 
     for message in messages:
         try:
-            role = message.get("role", "user") or message.role
-            content = message.get("content", "") or message.content
-
-        except:
+            if isinstance(message, dict):
+                role = message.get("role", "user") or "user"
+                content = message.get("content")
+                if content is None:
+                    # content=None is normal for tool-call assistant turns;
+                    # fall back to tool_calls summary or empty string
+                    tool_calls = message.get("tool_calls")
+                    if tool_calls:
+                        content = f"[{len(tool_calls)} tool call(s)]"
+                    else:
+                        content = ""
+            else:
+                # Handle message objects (e.g., Pydantic models)
+                role = getattr(message, "role", "user") or "user"
+                content = getattr(message, "content", None)
+                if content is None:
+                    content = ""
+        except Exception:
             role = "user"
-            content = str(messages)
+            content = str(message)
 
         if isinstance(content, list):
             content_str_list = []


### PR DESCRIPTION
**Issue number**: #1059

### Change description:

`format_content()` serialized the **entire messages list** into a single `user:` span entry when `content` was `None` or messages were non-dict objects. This caused O(n²) prompt explosion in observability backends.

**Root cause:** `message.get("content", "") or message.content` returns `None` when the key exists with value `None` (`.get()` returns `None`, not `""`), then `None or message.content` raises `AttributeError` on dicts. The bare `except:` catches this and falls back to `str(messages)` — the entire list.

**Fix:**
- Check `isinstance(message, dict)` before using `.get()`
- Handle `content is None` explicitly — normal for tool-call assistant turns, now summarized as `[N tool call(s)]`
- Use `getattr()` for non-dict message objects (Pydantic models, LangChain messages)
- Replace bare `except:` with `except Exception:`
- Fallback stringifies the single failing `message`, not the entire `messages` list

### Checklist

* [x] PR name follows conventional commit format: `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Fix formatting of OpenAI messages when content is missing or messages are non-dict objects to prevent incorrect serialization and excessive prompts.

Bug Fixes:
- Correct message role and content extraction in format_content() for dict and non-dict message types, including cases where content is None.
- Avoid serializing the entire messages list when a single message fails to parse, limiting fallback to the offending message only.