### PR TITLE
fix: remove langchain dependency

### DIFF
--- a/docs/latest/sdk/integrations/langchain.mdx
+++ b/docs/latest/sdk/integrations/langchain.mdx
@@ -9,8 +9,18 @@ OpenLIT uses OpenTelemetry Auto-Instrumentation to help you monitor LLM applicat
 
 Auto-instrumentation means you don't have to set up monitoring manually for different LLMs, frameworks, or databases. By simply adding OpenLIT in your application, all the necessary monitoring configurations are automatically set up.
 
-The integration is compatible with  
-- LangChain Python SDK client `>= 0.1.20` 
+The integration is compatible with:
+- `langchain-core >= 0.1.20`
+- modern `langchain` releases that expose `langchain_core`
+- modern `langgraph` releases when installed alongside LangChain
+
+Minimal requirement:
+- `langchain-core`
+
+Common installation patterns:
+- LangChain applications: `pip install langchain`
+- LangChain Core only: `pip install langchain-core`
+- LangGraph applications: `pip install langgraph`
 
 ## Get started 
 
@@ -19,6 +29,16 @@ The integration is compatible with
     Open your command line or terminal and run:
     ```shell
     pip install openlit
+    ```
+  </Step>
+  <Step title="Install LangChain or LangChain Core">
+    Install the framework package your application uses:
+    ```shell
+    pip install langchain
+    # or
+    pip install langchain-core
+    # or
+    pip install langgraph
     ```
   </Step>
   <IntegrationMethods />

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -46,7 +46,6 @@ opentelemetry-instrumentation-system-metrics = {version = ">=0.52b0,<1.0.0", opt
 openai = "^1.1.1"
 anthropic = ">=0.42.0,<1.0.0"
 openai-agents = ">=0.0.3"
-langchain = "^0.3.15"
 
 [tool.poetry.scripts]
 openlit-instrument = "openlit.cli.main:run"

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -687,8 +687,9 @@ def get_agent_name() -> Optional[str]:
     return _current_agent_name.get()
 
 
-def record_agent_duration(metrics, agent_name, duration, operation="chat",
-                          system=None, error_type=None):
+def record_agent_duration(
+    metrics, agent_name, duration, operation="chat", system=None, error_type=None
+):
     """
     Record gen_ai.agent.operation.duration for an agent request.
     """

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -497,8 +497,9 @@ def log_agent_tool_error(agent_name, tool_name, system=None, model=None):
     try:
         metrics = OpenlitConfig.metrics_dict
         if metrics:
-            record_agent_tool_error(metrics, agent_name, tool_name,
-                                    system=system, model=model)
+            record_agent_tool_error(
+                metrics, agent_name, tool_name, system=system, model=model
+            )
     except Exception as e:
         logger.debug("Failed to record agent tool error: %s", e)
 

--- a/sdk/python/src/openlit/otel/metrics.py
+++ b/sdk/python/src/openlit/otel/metrics.py
@@ -350,7 +350,16 @@ def setup_meter(application_name, environment, meter, otlp_endpoint, otlp_header
                 description="Total duration of an agent handling a request, including all LLM calls and tool executions",
                 unit="s",
                 explicit_bucket_boundaries_advisory=[
-                    0.1, 0.5, 1, 2, 5, 10, 30, 60, 120, 300,
+                    0.1,
+                    0.5,
+                    1,
+                    2,
+                    5,
+                    10,
+                    30,
+                    60,
+                    120,
+                    300,
                 ],
             ),
             "genai_agent_invocations": meter.create_counter(

--- a/sdk/python/tests/requirements.txt
+++ b/sdk/python/tests/requirements.txt
@@ -6,6 +6,11 @@ schedule
 pylint
 
 # Gen AI
+langchain-core>=0.1.20
+langchain>=0.3.15,<1.0.0; python_version < "3.10"
+langchain>=1.0.0,<2.0.0; python_version >= "3.10"
+langgraph>=0.0.1,<1.0.0; python_version < "3.10"
+langgraph>=1.0.0,<2.0.0; python_version >= "3.10"
 cohere
 openai
 anthropic

--- a/sdk/python/tests/test_langchain_compat.py
+++ b/sdk/python/tests/test_langchain_compat.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-class-docstring, missing-function-docstring, duplicate-code
+# pylint: disable=missing-class-docstring, missing-function-docstring, duplicate-code, too-few-public-methods
 """Compatibility tests for LangChain instrumentation."""
 
 import pytest

--- a/sdk/python/tests/test_langchain_compat.py
+++ b/sdk/python/tests/test_langchain_compat.py
@@ -1,0 +1,85 @@
+# pylint: disable=missing-class-docstring, missing-function-docstring, duplicate-code
+"""Compatibility tests for LangChain instrumentation."""
+
+import pytest
+
+try:
+    from langchain_core.callbacks.manager import BaseCallbackManager
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    LANGCHAIN_CORE_AVAILABLE = True
+except ImportError:
+    LANGCHAIN_CORE_AVAILABLE = False
+    BaseCallbackManager = None
+    HumanMessage = None
+    SystemMessage = None
+
+try:
+    from langchain.chat_models.base import init_chat_model
+
+    LANGCHAIN_AVAILABLE = True
+except ImportError:
+    LANGCHAIN_AVAILABLE = False
+    init_chat_model = None
+
+from openlit.instrumentation.langchain import _BaseCallbackManagerInitWrapper
+from openlit.instrumentation.langchain.utils import build_input_messages
+
+
+pytestmark = pytest.mark.skipif(
+    not LANGCHAIN_CORE_AVAILABLE, reason="langchain-core not installed"
+)
+
+
+class TestLangChainCompatibility:
+    def test_callback_manager_wrapper_injects_handler_once(self):
+        class TestHandler:
+            pass
+
+        manager = BaseCallbackManager([], None, None)
+        wrapper = _BaseCallbackManagerInitWrapper(TestHandler())
+
+        wrapper(lambda *_args, **_kwargs: None, manager, (), {})
+        wrapper(lambda *_args, **_kwargs: None, manager, (), {})
+
+        matching_handlers = [
+            handler
+            for handler in getattr(manager, "inheritable_handlers", []) or []
+            if isinstance(handler, TestHandler)
+        ]
+
+        assert len(matching_handlers) == 1
+
+    def test_callback_manager_wrapper_respects_existing_handler(self):
+        class TestHandler:
+            pass
+
+        existing_handler = TestHandler()
+        manager = BaseCallbackManager([], None, None)
+        manager.inheritable_handlers = [existing_handler]
+        wrapper = _BaseCallbackManagerInitWrapper(TestHandler())
+
+        wrapper(lambda *_args, **_kwargs: None, manager, (), {})
+
+        matching_handlers = [
+            handler
+            for handler in getattr(manager, "inheritable_handlers", []) or []
+            if isinstance(handler, TestHandler)
+        ]
+
+        assert len(matching_handlers) == 1
+        assert matching_handlers[0] is existing_handler
+
+    def test_build_input_messages_handles_langchain_core_messages(self):
+        messages = [[SystemMessage(content="system"), HumanMessage(content="hello")]]
+
+        structured_messages = build_input_messages(messages)
+
+        assert structured_messages == [
+            {"role": "system", "parts": [{"type": "text", "content": "system"}]},
+            {"role": "user", "parts": [{"type": "text", "content": "hello"}]},
+        ]
+
+    @pytest.mark.skipif(not LANGCHAIN_AVAILABLE, reason="langchain not installed")
+    def test_langchain_chat_model_helper_import_is_available(self):
+        assert callable(init_chat_model)


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:
Issue 949
https://github.com/openlit/openlit/issues/949

### Change description:
Remove langchain as an OpenLit dependency. Currently, OpenLit will always install langchain regardless if the Python application uses langchain. Additionally, OpenLit currently requires an old version of langchain. This leads to issues as older versions of OpenLit do not have this restriction. Users running langchain >1.0.0 will by default get an old buggy version of OpenLit when they pip install openlit. The fix is to remove the dependency entirely. OpenLit should not force users to install langchain, especially if they are not using langchain in their application. I've added some basic tests to validate that OpenLit works with recent versions of langchain so that removing the restriction won't lead to issues.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x ] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Remove LangChain as a mandatory Python SDK dependency while ensuring compatibility with modern LangChain and LangGraph releases.

Enhancements:
- Clarify LangChain integration docs to describe compatibility with langchain-core, recent LangChain, and LangGraph versions and to require users to install LangChain explicitly.
- Add compatibility tests to validate OpenLit’s LangChain instrumentation with langchain-core messages and modern LangChain helpers.

Build:
- Update Python SDK project dependencies to drop the direct langchain requirement and move specific LangChain/LangGraph pins into test requirements.