### PR TITLE
feat: add span name filter

### DIFF
--- a/src/client/src/components/(playground)/filter/traces-filter.tsx
+++ b/src/client/src/components/(playground)/filter/traces-filter.tsx
@@ -254,7 +254,9 @@ const DynamicFilters = ({
 			case "models":
 			case "providers":
 			case "traceTypes":
-			case "applicationNames":		case "spanNames":			case "environments":
+			case "applicationNames":
+			case "spanNames":
+			case "environments":
 				if (operationType === "add") {
 					setSelectedFilterValues((s) => {
 						const typeArray = s[type] || [];

--- a/src/client/src/components/(playground)/filter/traces-filter.tsx
+++ b/src/client/src/components/(playground)/filter/traces-filter.tsx
@@ -148,6 +148,7 @@ function configToParams(config: Partial<FilterConfig>, params: URLSearchParams) 
 	params.delete("providers");
 	params.delete("traceTypes");
 	params.delete("appNames");
+	params.delete("spanNames");
 	params.delete("envs");
 	params.delete("maxCost");
 	// remove all existing cf entries
@@ -157,6 +158,7 @@ function configToParams(config: Partial<FilterConfig>, params: URLSearchParams) 
 	if (config.providers?.length) params.set("providers", config.providers.join(","));
 	if (config.traceTypes?.length) params.set("traceTypes", config.traceTypes.join(","));
 	if (config.applicationNames?.length) params.set("appNames", config.applicationNames.join(","));
+	if (config.spanNames?.length) params.set("spanNames", config.spanNames.join(","));
 	if (config.environments?.length) params.set("envs", config.environments.join(","));
 	if (config.maxCost) params.set("maxCost", String(config.maxCost));
 	config.customFilters?.forEach(({ attributeType, key, value }) => {
@@ -176,6 +178,8 @@ function paramsToConfig(params: URLSearchParams): Partial<FilterConfig> {
 	if (traceTypes) config.traceTypes = traceTypes.split(",").filter(Boolean);
 	const appNames = params.get("appNames");
 	if (appNames) config.applicationNames = appNames.split(",").filter(Boolean);
+	const spanNames = params.get("spanNames");
+	if (spanNames) config.spanNames = spanNames.split(",").filter(Boolean);
 	const envs = params.get("envs");
 	if (envs) config.environments = envs.split(",").filter(Boolean);
 	const maxCost = params.get("maxCost");
@@ -250,8 +254,7 @@ const DynamicFilters = ({
 			case "models":
 			case "providers":
 			case "traceTypes":
-			case "applicationNames":
-			case "environments":
+			case "applicationNames":		case "spanNames":			case "environments":
 				if (operationType === "add") {
 					setSelectedFilterValues((s) => {
 						const typeArray = s[type] || [];
@@ -447,6 +450,19 @@ const DynamicFilters = ({
 							type="applicationNames"
 							updateSelectedValues={updateSelectedValues}
 							selectedValues={selectedFilterValues.applicationNames}
+							clearItem={clearFilter}
+						/>
+					) : null}
+					{filterConfig?.spanNames?.length ? (
+						<ComboDropdown
+							options={filterConfig?.spanNames.map((s) => ({
+								label: s,
+								value: s,
+							}))}
+							title="Span Names"
+							type="spanNames"
+							updateSelectedValues={updateSelectedValues}
+							selectedValues={selectedFilterValues.spanNames}
 							clearItem={clearFilter}
 						/>
 					) : null}

--- a/src/client/src/helpers/server/platform.ts
+++ b/src/client/src/helpers/server/platform.ts
@@ -233,6 +233,14 @@ export const getFilterWhereCondition = (
 				);
 			}
 
+			if (filter.selectedConfig.spanNames?.length) {
+				whereArray.push(
+					`SpanName IN (${filter.selectedConfig.spanNames
+						.map((spanName) => `'${spanName}'`)
+						.join(", ")})`
+				);
+			}
+
 			if (filter.selectedConfig.environments?.length) {
 				whereArray.push(
 					`ResourceAttributes['${getTraceMappingKeyFullPath(

--- a/src/client/src/lib/platform/request/index.ts
+++ b/src/client/src/lib/platform/request/index.ts
@@ -132,6 +132,10 @@ export async function getRequestsConfig(params: MetricParams) {
 	);
 
 	select.push(
+		`arrayFilter(x -> x != '', ARRAY_AGG(DISTINCT SpanName)) AS spanNames`
+	);
+
+	select.push(
 		`arrayFilter(x -> x != '', ARRAY_AGG(DISTINCT ResourceAttributes['${getTraceMappingKeyFullPath(
 			"environment"
 		)}'])) AS environments`

--- a/src/client/src/types/platform.ts
+++ b/src/client/src/types/platform.ts
@@ -14,6 +14,7 @@ export type FilterWhereConditionType = {
 		models: string[];
 		traceTypes: string[];
 		applicationNames: string[];
+		spanNames: string[];
 		environments: string[];
 		customFilters: { attributeType: string; key: string; value: string }[];
 	}>;

--- a/src/client/src/types/store/filter.ts
+++ b/src/client/src/types/store/filter.ts
@@ -34,6 +34,7 @@ export interface FilterConfig {
 	totalRows: number;
 	traceTypes: string[];
 	applicationNames: string[];
+	spanNames: string[];
 	environments: string[];
 	customFilters?: CustomFilter[];
 }


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.  
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`  

**Issue number**: #1064

---

### Change description:
This PR adds support for filtering traces by **span name**.

Currently, in the **Monitoring → Requests** view, only filtering by **application name** is available. This limitation makes it difficult to analyze traces with a large number of spans or to quickly locate specific operations.

With this change, users can filter results using the span name, enabling more granular trace exploration and improving the overall debugging and observability experience.

---

### Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

---

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add support for filtering traces by span name in the Monitoring → Requests view and propagate span name selection through the frontend filters, URL params, and backend query configuration.

New Features:
- Expose span name options in the requests filter UI and allow users to select span names as a filter criterion.
- Include span name selections in URL search parameters and client-side filter configuration for traces.
- Extend backend request configuration to return distinct span names and apply span name filters in the generated where conditions.

Enhancements:
- Update shared filter and platform types to include spanNames in the filter configuration model.