### PR TITLE
fix: remove hardcoded temperature=0.0 from eval LLM calls

### DIFF
--- a/sdk/python/src/openlit/evals/utils.py
+++ b/sdk/python/src/openlit/evals/utils.py
@@ -151,7 +151,6 @@ def llm_response_openai(prompt: str, model: str, base_url: str) -> str:
         messages=[
             {"role": "user", "content": prompt},
         ],
-        temperature=0.0,
         response_format={"type": "json_object"},
     )
     return response.choices[0].message.content
@@ -207,7 +206,6 @@ def llm_response_anthropic(prompt: str, model: str) -> str:
         model=model,
         messages=[{"role": "user", "content": prompt}],
         max_tokens=2000,
-        temperature=0.0,
         tools=tools,
         stream=False,
     )


### PR DESCRIPTION
**Issue number**: #1068

### Change description:

Removed the hardcoded `temperature=0.0` from both `llm_response_openai()` and `llm_response_anthropic()` in `evals/utils.py`. The gpt-5 family rejects `temperature=0.0` with a 400 error, and the structured output / JSON mode already constrains the response format without needing explicit temperature control.

### Checklist

* [x] PR name follows conventional commit format: `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Remove hardcoded temperature settings from evaluation LLM helper functions to rely on provider defaults and avoid incompatibilities with newer models.

Bug Fixes:
- Prevent 400 errors from gpt-5 family models by no longer forcing temperature=0.0 in OpenAI evaluation calls.

Enhancements:
- Align Anthropic evaluation helper with provider defaults by omitting an explicit temperature parameter in LLM requests.