### PR TITLE
Fix: Langchain and langraph instrumentation to follow GenAI semconv

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openlit"
-version = "1.39.0"
+version = "1.39.1"
 description = "OpenTelemetry-native Auto instrumentation library for monitoring LLM Applications and GPUs, facilitating the integration of observability into your GenAI-driven projects"
 authors = ["OpenLIT"]
 license = "Apache-2.0"

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -30,6 +30,95 @@ _current_agent_name: ContextVar[Optional[str]] = ContextVar(
     "openlit_agent_name", default=None
 )
 
+# When True, a framework instrumentor (LangChain, LiteLLM, etc.) owns the LLM
+# chat span.  Provider-level instrumentors (OpenAI, Anthropic, ...) should skip
+# creating their own span and instead let the framework span be the single
+# source of truth.
+_framework_llm_span_active: ContextVar[bool] = ContextVar(
+    "openlit_framework_llm_span_active", default=False
+)
+
+# Set by the LangGraph wrapper before calling wrapped() so the LangChain
+# callback handler knows to skip its own top-level graph invocation span
+# (which would duplicate the LangGraph wrapper span).
+_langgraph_wrapper_active: ContextVar[bool] = ContextVar(
+    "openlit_langgraph_wrapper_active", default=False
+)
+
+
+def set_framework_llm_active():
+    """Set by framework LLM callbacks; returns a token to reset later."""
+    return _framework_llm_span_active.set(True)
+
+
+def reset_framework_llm_active(token):
+    """Reset the framework LLM flag using the token from set_framework_llm_active."""
+    _framework_llm_span_active.reset(token)
+
+
+def is_framework_llm_active() -> bool:
+    """Check if a framework instrumentor is currently handling the LLM span."""
+    return _framework_llm_span_active.get()
+
+
+def set_langgraph_wrapper_active():
+    """Set by LangGraph wrapper; returns a token to reset later."""
+    return _langgraph_wrapper_active.set(True)
+
+
+def reset_langgraph_wrapper_active(token):
+    """Reset the LangGraph wrapper flag."""
+    _langgraph_wrapper_active.reset(token)
+
+
+def is_langgraph_wrapper_active() -> bool:
+    """Check if a LangGraph wrapper span is active (to suppress duplicate callback span)."""
+    return _langgraph_wrapper_active.get()
+
+
+_langgraph_conversation_id: ContextVar[str] = ContextVar(
+    "openlit_langgraph_conversation_id", default=""
+)
+
+
+def set_langgraph_conversation_id(conv_id):
+    """Propagate the conversation ID from invoke_workflow to child node spans."""
+    return _langgraph_conversation_id.set(conv_id)
+
+
+def reset_langgraph_conversation_id(token):
+    """Reset the conversation ID."""
+    _langgraph_conversation_id.reset(token)
+
+
+def get_langgraph_conversation_id() -> str:
+    """Get the current conversation ID set by the workflow span."""
+    return _langgraph_conversation_id.get()
+
+
+# Set by _wrap_create_agent (LangChain instrumentor) so that
+# wrap_compile (LangGraph instrumentor) does not emit a duplicate
+# create_agent span when compile() is called internally.
+_create_agent_active: ContextVar[bool] = ContextVar(
+    "openlit_create_agent_active", default=False
+)
+
+
+def set_create_agent_active():
+    """Set by create_agent wrapper; returns a token to reset later."""
+    return _create_agent_active.set(True)
+
+
+def reset_create_agent_active(token):
+    """Reset the create_agent flag."""
+    _create_agent_active.reset(token)
+
+
+def is_create_agent_active() -> bool:
+    """Check if a create_agent span is already being handled."""
+    return _create_agent_active.get()
+
+
 # Set up logging
 logger = logging.getLogger(__name__)
 

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -481,6 +481,41 @@ def set_server_address_and_port(
     return server_address, server_port
 
 
+PROVIDER_DEFAULT_ENDPOINTS = {
+    "openai": ("api.openai.com", 443),
+    "anthropic": ("api.anthropic.com", 443),
+    "google": ("generativelanguage.googleapis.com", 443),
+    "gcp.gemini": ("generativelanguage.googleapis.com", 443),
+    "gcp.vertex_ai": ("aiplatform.googleapis.com", 443),
+    "gcp.gen_ai": ("generativelanguage.googleapis.com", 443),
+    "mistral_ai": ("api.mistral.ai", 443),
+    "groq": ("api.groq.com", 443),
+    "together": ("api.together.xyz", 443),
+    "fireworks": ("api.fireworks.ai", 443),
+    "perplexity": ("api.perplexity.ai", 443),
+    "deepinfra": ("api.deepinfra.com", 443),
+    "aws.bedrock": ("bedrock-runtime.amazonaws.com", 443),
+    "azure": ("openai.azure.com", 443),
+    "azure.ai.openai": ("openai.azure.com", 443),
+    "azure.ai.inference": ("inference.ai.azure.com", 443),
+    "cohere": ("api.cohere.ai", 443),
+    "ollama": ("localhost", 11434),
+    "deepseek": ("api.deepseek.com", 443),
+    "x_ai": ("api.x.ai", 443),
+    "huggingface": ("api-inference.huggingface.co", 443),
+    "ibm.watsonx.ai": ("us-south.ml.cloud.ibm.com", 443),
+}
+
+
+def get_server_address_for_provider(provider_name: str) -> Tuple[str, int]:
+    """Return (server_address, server_port) for a provider name.
+
+    Universal helper usable by any framework instrumentor (LangChain,
+    LangGraph, CrewAI, etc.).  Returns ("", 0) for unknown providers.
+    """
+    return PROVIDER_DEFAULT_ENDPOINTS.get(provider_name, ("", 0))
+
+
 def otel_event(name, attributes, body):
     """
     Returns an OpenTelemetry LogRecord representing an event.

--- a/sdk/python/src/openlit/instrumentation/agno/utils.py
+++ b/sdk/python/src/openlit/instrumentation/agno/utils.py
@@ -308,7 +308,7 @@ def process_tool_request(
         if capture_message_content:
             if hasattr(response, "result") and response.result:
                 span.set_attribute(
-                    SemanticConvention.GEN_AI_TOOL_OUTPUT,
+                    SemanticConvention.GEN_AI_TOOL_CALL_RESULT,
                     truncate_content(response.result),
                 )
         if hasattr(response, "error") and response.error:

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -1566,8 +1566,6 @@ def _create_callback_handler_class(
                 if hasattr(output, "tool_call_id"):
                     tool_call_id = output.tool_call_id
                 elif isinstance(output, str) and "tool_call_id" in output:
-                    import re
-
                     match = re.search(r"tool_call_id=['\"]([^'\"]+)['\"]", output)
                     if match:
                         tool_call_id = match.group(1)
@@ -1843,10 +1841,32 @@ def _create_callback_handler_class(
                     holder = self.spans.get(run_id)
                 if holder is not None:
                     attempt = getattr(retry_state, "attempt_number", 0)
-                    holder.span.add_event(
-                        "retry",
-                        attributes={"retry.attempt": attempt},
+                    attributes: Dict[str, Any] = {"retry.attempt": attempt}
+
+                    next_action = getattr(retry_state, "next_action", None)
+                    sleep = getattr(next_action, "sleep", None) if next_action else None
+                    if isinstance(sleep, (int, float)):
+                        attributes["retry.delay_ms"] = int(sleep * 1000)
+
+                    outcome = getattr(retry_state, "outcome", None)
+                    if outcome is not None:
+                        try:
+                            exc = outcome.exception()
+                        except Exception:
+                            exc = None
+                        if exc is not None:
+                            attributes["retry.error.type"] = type(exc).__name__
+                            attributes["retry.error.message"] = str(exc)[:256]
+
+                    retry_object = getattr(retry_state, "retry_object", None)
+                    stop_policy = (
+                        getattr(retry_object, "stop", None) if retry_object else None
                     )
+                    max_attempts = getattr(stop_policy, "max_attempt_number", None)
+                    if isinstance(max_attempts, int):
+                        attributes["retry.max_attempts"] = max_attempts
+
+                    holder.span.add_event("retry", attributes=attributes)
             except Exception as e:
                 logger.debug("Error in on_retry: %s", e)
 
@@ -1904,7 +1924,6 @@ def _wrap_create_agent(tracer, version, environment, application_name):
     )
 
     def wrapper(wrapped, instance, args, kwargs):
-        import json
         from urllib.parse import urlparse
 
         llm = args[0] if args else kwargs.get("model")
@@ -1994,6 +2013,161 @@ def _wrap_create_agent(tracer, version, environment, application_name):
     return wrapper
 
 
+def _embed_common(
+    span,
+    instance,
+    args,
+    kwargs,
+    result,
+    start_time,
+    end_time,
+    model_name,
+    provider,
+    server_address,
+    server_port,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+    environment,
+    application_name,
+    version,
+):
+    """Shared post-call attribute/metric logic for sync and async embed wrappers."""
+    from openlit.semcov import SemanticConvention
+    from openlit.__helpers import (
+        general_tokens,
+        get_embed_model_cost,
+        record_embedding_metrics,
+    )
+
+    span.set_attribute(
+        SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, end_time - start_time
+    )
+    span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, model_name)
+
+    encoding_format = getattr(instance, "encoding_format", None)
+    if encoding_format:
+        span.set_attribute(
+            SemanticConvention.GEN_AI_REQUEST_ENCODING_FORMATS, [encoding_format]
+        )
+
+    req_dimensions = getattr(instance, "dimensions", None)
+    if req_dimensions is not None:
+        try:
+            span.set_attribute(
+                SemanticConvention.GEN_AI_REQUEST_EMBEDDING_DIMENSION,
+                int(req_dimensions),
+            )
+        except (TypeError, ValueError):
+            pass
+
+    input_tokens = 0
+    input_data = args[0] if args else None
+    if input_data is not None:
+        if isinstance(input_data, list):
+            input_tokens = sum(general_tokens(t) for t in input_data)
+        elif isinstance(input_data, str):
+            input_tokens = general_tokens(input_data)
+    if input_tokens > 0:
+        span.set_attribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
+
+    dimension_count = None
+    if result is not None and isinstance(result, list) and result:
+        first = result[0]
+        if isinstance(first, list) and first:
+            dimension_count = len(first)
+        elif isinstance(first, (int, float)):
+            dimension_count = len(result)
+    if req_dimensions is None and dimension_count is not None:
+        span.set_attribute(
+            SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT, dimension_count
+        )
+
+    cost = get_embed_model_cost(model_name, pricing_info, input_tokens)
+    if cost > 0:
+        span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
+
+    if capture_message_content and input_data is not None:
+        if isinstance(input_data, list):
+            input_msgs = [
+                {"role": "user", "parts": [{"type": "text", "content": str(item)}]}
+                for item in input_data
+            ]
+        else:
+            input_msgs = [
+                {
+                    "role": "user",
+                    "parts": [{"type": "text", "content": str(input_data)}],
+                }
+            ]
+        span.set_attribute(
+            SemanticConvention.GEN_AI_INPUT_MESSAGES, json.dumps(input_msgs)
+        )
+
+    span.set_status(Status(StatusCode.OK))
+
+    if not disable_metrics and metrics:
+        record_embedding_metrics(
+            metrics=metrics,
+            gen_ai_operation=SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+            GEN_AI_PROVIDER_NAME=provider,
+            server_address=server_address,
+            server_port=server_port,
+            request_model=model_name,
+            response_model=model_name,
+            environment=environment,
+            application_name=application_name,
+            start_time=start_time,
+            end_time=end_time,
+            input_tokens=input_tokens,
+            cost=cost,
+        )
+
+
+def _resolve_embed_provider_and_server(instance):
+    """Resolve provider name and server address/port from an Embeddings instance."""
+    from openlit.__helpers import get_server_address_for_provider
+
+    model_name = (
+        getattr(instance, "model", None)
+        or getattr(instance, "model_name", None)
+        or getattr(instance, "model_id", None)
+        or "unknown"
+    )
+
+    provider = "langchain"
+    class_name = instance.__class__.__name__.lower()
+    class_module = (
+        instance.__class__.__module__.lower()
+        if hasattr(instance.__class__, "__module__")
+        else ""
+    )
+    class_path = f"{class_module}.{class_name}"
+    for prov_key, prov_val in PROVIDER_MAP.items():
+        if prov_key in class_path:
+            provider = prov_val
+            break
+
+    server_address, server_port = "", 0
+    try:
+        from urllib.parse import urlparse
+
+        base_url = getattr(instance, "base_url", None) or getattr(
+            getattr(instance, "client", None), "base_url", None
+        )
+        if base_url:
+            parsed = urlparse(str(base_url))
+            server_address = parsed.hostname or ""
+            server_port = parsed.port or 443
+    except Exception:
+        pass
+    if not server_address:
+        server_address, server_port = get_server_address_for_provider(provider)
+
+    return model_name, provider, server_address, server_port
+
+
 def _wrap_embed(
     tracer,
     version,
@@ -2006,11 +2180,7 @@ def _wrap_embed(
 ):
     """Wraps langchain_core.embeddings.Embeddings methods to produce embeddings spans."""
     from openlit.semcov import SemanticConvention
-    from openlit.__helpers import (
-        handle_exception,
-        general_tokens,
-        get_server_address_for_provider,
-    )
+    from openlit.__helpers import handle_exception
 
     def wrapper(wrapped, instance, args, kwargs):
         from opentelemetry import context as context_api
@@ -2018,48 +2188,13 @@ def _wrap_embed(
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        model_name = (
-            getattr(instance, "model", None)
-            or getattr(instance, "model_name", None)
-            or getattr(instance, "model_id", None)
-            or "unknown"
+        model_name, provider, server_address, server_port = (
+            _resolve_embed_provider_and_server(instance)
         )
-
-        provider = "langchain"
-        class_name = instance.__class__.__name__.lower()
-        class_module = (
-            instance.__class__.__module__.lower()
-            if hasattr(instance.__class__, "__module__")
-            else ""
-        )
-        class_path = f"{class_module}.{class_name}"
-        for prov_key, prov_val in PROVIDER_MAP.items():
-            if prov_key in class_path:
-                provider = prov_val
-                break
-
         span_name = f"embeddings {model_name}"
 
-        server_address, server_port = "", 0
-        try:
-            from urllib.parse import urlparse
-
-            base_url = getattr(instance, "base_url", None) or getattr(
-                getattr(instance, "client", None), "base_url", None
-            )
-            if base_url:
-                parsed = urlparse(str(base_url))
-                server_address = parsed.hostname or ""
-                server_port = parsed.port or 443
-        except Exception:
-            pass
-        if not server_address:
-            server_address, server_port = get_server_address_for_provider(provider)
-
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-            import time as _time
-
-            start_time = _time.time()
+            start_time = time.time()
 
             span.set_attribute(
                 SemanticConvention.GEN_AI_OPERATION,
@@ -2078,46 +2213,51 @@ def _wrap_embed(
 
             try:
                 result = wrapped(*args, **kwargs)
+                end_time = time.time()
 
-                end_time = _time.time()
-                span.set_attribute(
-                    SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION,
-                    end_time - start_time,
+                _embed_common(
+                    span,
+                    instance,
+                    args,
+                    kwargs,
+                    result,
+                    start_time,
+                    end_time,
+                    model_name,
+                    provider,
+                    server_address,
+                    server_port,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    environment,
+                    application_name,
+                    version,
                 )
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, model_name)
-
-                if args:
-                    input_data = args[0]
-                    if isinstance(input_data, list):
-                        input_tokens = sum(general_tokens(t) for t in input_data)
-                    elif isinstance(input_data, str):
-                        input_tokens = general_tokens(input_data)
-                    else:
-                        input_tokens = 0
-                    if input_tokens > 0:
-                        span.set_attribute(
-                            SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens
-                        )
-
-                if result is not None:
-                    if isinstance(result, list) and result:
-                        first = result[0]
-                        if isinstance(first, list) and first:
-                            span.set_attribute(
-                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
-                                len(first),
-                            )
-                        elif isinstance(first, (int, float)):
-                            span.set_attribute(
-                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
-                                len(result),
-                            )
-
-                span.set_status(Status(StatusCode.OK))
                 return result
 
             except Exception as e:
                 handle_exception(span, e)
+                if not disable_metrics and metrics:
+                    from openlit.__helpers import record_embedding_metrics
+
+                    record_embedding_metrics(
+                        metrics,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                        provider,
+                        server_address,
+                        server_port,
+                        model_name,
+                        "unknown",
+                        environment,
+                        application_name,
+                        start_time,
+                        time.time(),
+                        0,
+                        0,
+                        error_type=type(e).__name__ or "_OTHER",
+                    )
                 raise
 
     return wrapper
@@ -2135,11 +2275,7 @@ def _wrap_embed_async(
 ):
     """Wraps async langchain_core.embeddings.Embeddings methods."""
     from openlit.semcov import SemanticConvention
-    from openlit.__helpers import (
-        handle_exception,
-        general_tokens,
-        get_server_address_for_provider,
-    )
+    from openlit.__helpers import handle_exception
 
     async def wrapper(wrapped, instance, args, kwargs):
         from opentelemetry import context as context_api
@@ -2147,48 +2283,13 @@ def _wrap_embed_async(
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return await wrapped(*args, **kwargs)
 
-        model_name = (
-            getattr(instance, "model", None)
-            or getattr(instance, "model_name", None)
-            or getattr(instance, "model_id", None)
-            or "unknown"
+        model_name, provider, server_address, server_port = (
+            _resolve_embed_provider_and_server(instance)
         )
-
-        provider = "langchain"
-        class_name = instance.__class__.__name__.lower()
-        class_module = (
-            instance.__class__.__module__.lower()
-            if hasattr(instance.__class__, "__module__")
-            else ""
-        )
-        class_path = f"{class_module}.{class_name}"
-        for prov_key, prov_val in PROVIDER_MAP.items():
-            if prov_key in class_path:
-                provider = prov_val
-                break
-
         span_name = f"embeddings {model_name}"
 
-        server_address, server_port = "", 0
-        try:
-            from urllib.parse import urlparse
-
-            base_url = getattr(instance, "base_url", None) or getattr(
-                getattr(instance, "client", None), "base_url", None
-            )
-            if base_url:
-                parsed = urlparse(str(base_url))
-                server_address = parsed.hostname or ""
-                server_port = parsed.port or 443
-        except Exception:
-            pass
-        if not server_address:
-            server_address, server_port = get_server_address_for_provider(provider)
-
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
-            import time as _time
-
-            start_time = _time.time()
+            start_time = time.time()
 
             span.set_attribute(
                 SemanticConvention.GEN_AI_OPERATION,
@@ -2207,46 +2308,51 @@ def _wrap_embed_async(
 
             try:
                 result = await wrapped(*args, **kwargs)
+                end_time = time.time()
 
-                end_time = _time.time()
-                span.set_attribute(
-                    SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION,
-                    end_time - start_time,
+                _embed_common(
+                    span,
+                    instance,
+                    args,
+                    kwargs,
+                    result,
+                    start_time,
+                    end_time,
+                    model_name,
+                    provider,
+                    server_address,
+                    server_port,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    environment,
+                    application_name,
+                    version,
                 )
-                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, model_name)
-
-                if args:
-                    input_data = args[0]
-                    if isinstance(input_data, list):
-                        input_tokens = sum(general_tokens(t) for t in input_data)
-                    elif isinstance(input_data, str):
-                        input_tokens = general_tokens(input_data)
-                    else:
-                        input_tokens = 0
-                    if input_tokens > 0:
-                        span.set_attribute(
-                            SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens
-                        )
-
-                if result is not None:
-                    if isinstance(result, list) and result:
-                        first = result[0]
-                        if isinstance(first, list) and first:
-                            span.set_attribute(
-                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
-                                len(first),
-                            )
-                        elif isinstance(first, (int, float)):
-                            span.set_attribute(
-                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
-                                len(result),
-                            )
-
-                span.set_status(Status(StatusCode.OK))
                 return result
 
             except Exception as e:
                 handle_exception(span, e)
+                if not disable_metrics and metrics:
+                    from openlit.__helpers import record_embedding_metrics
+
+                    record_embedding_metrics(
+                        metrics,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                        provider,
+                        server_address,
+                        server_port,
+                        model_name,
+                        "unknown",
+                        environment,
+                        application_name,
+                        start_time,
+                        time.time(),
+                        0,
+                        0,
+                        error_type=type(e).__name__ or "_OTHER",
+                    )
                 raise
 
     return wrapper
@@ -2321,16 +2427,16 @@ class LangChainInstrumentor(BaseInstrumentor):
         except Exception:
             logger.debug("langchain.agents.create_agent not available, skipping")
 
-        embed_kwargs = dict(
-            tracer=tracer,
-            version=version,
-            environment=environment,
-            application_name=application_name,
-            pricing_info=pricing_info,
-            capture_message_content=capture_message_content,
-            metrics=metrics,
-            disable_metrics=disable_metrics,
-        )
+        embed_kwargs = {
+            "tracer": tracer,
+            "version": version,
+            "environment": environment,
+            "application_name": application_name,
+            "pricing_info": pricing_info,
+            "capture_message_content": capture_message_content,
+            "metrics": metrics,
+            "disable_metrics": disable_metrics,
+        }
         for method_name in ("embed_documents", "embed_query"):
             try:
                 wrap_function_wrapper(
@@ -2359,6 +2465,10 @@ class LangChainInstrumentor(BaseInstrumentor):
             from opentelemetry.instrumentation.utils import unwrap
 
             unwrap("langchain_core.callbacks.manager", "BaseCallbackManager.__init__")
+            try:
+                unwrap("langchain.agents", "create_agent")
+            except Exception:
+                pass
             for method_name in (
                 "embed_documents",
                 "embed_query",

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -50,6 +50,13 @@ class SpanHolder:
         "cache_creation_input_tokens",
         "input_messages_raw",
         "prompts",
+        "system_instructions",
+        "tool_definitions",
+        "provider",
+        "server_address",
+        "server_port",
+        "tool_calls",
+        "finish_reason",
     )
 
     def __init__(self, span, token=None, start_time=None):
@@ -71,6 +78,13 @@ class SpanHolder:
         self.cache_creation_input_tokens = 0
         self.input_messages_raw: Any = None
         self.prompts: List[Any] = []
+        self.system_instructions: Optional[List[Dict[str, Any]]] = None
+        self.tool_definitions: Optional[List[Dict[str, Any]]] = None
+        self.provider: str = ""
+        self.server_address: str = ""
+        self.server_port: int = 0
+        self.tool_calls: Optional[List[Dict[str, Any]]] = None
+        self.finish_reason: str = "stop"
 
     def get_duration(self) -> float:
         """Calculate duration from start time to now."""
@@ -294,6 +308,23 @@ PROVIDER_MAP = {
 }
 
 
+PROVIDER_DEFAULT_ENDPOINTS = {
+    "openai": ("api.openai.com", 443),
+    "anthropic": ("api.anthropic.com", 443),
+    "google": ("generativelanguage.googleapis.com", 443),
+    "mistral_ai": ("api.mistral.ai", 443),
+    "groq": ("api.groq.com", 443),
+    "together": ("api.together.xyz", 443),
+    "fireworks": ("api.fireworks.ai", 443),
+    "perplexity": ("api.perplexity.ai", 443),
+    "deepinfra": ("api.deepinfra.com", 443),
+    "aws.bedrock": ("bedrock-runtime.amazonaws.com", 443),
+    "azure": ("openai.azure.com", 443),
+    "cohere": ("api.cohere.ai", 443),
+    "ollama": ("localhost", 11434),
+}
+
+
 def detect_provider(serialized: Optional[Dict[str, Any]]) -> str:
     """Detect the LLM provider from serialized class info."""
     from openlit.semcov import SemanticConvention
@@ -309,6 +340,49 @@ def detect_provider(serialized: Optional[Dict[str, Any]]) -> str:
                 return system
 
     return SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN
+
+
+_SKIP_CHAIN_CLASS_PREFIXES = frozenset(
+    {
+        "RunnableSequence",
+        "RunnableParallel",
+        "RunnableLambda",
+        "RunnablePassthrough",
+        "RunnableAssign",
+        "RunnablePick",
+        "RunnableBranch",
+        "RunnableEach",
+        "Prompt",
+        "PromptTemplate",
+        "ChatPromptTemplate",
+        "MessagesPlaceholder",
+        "SystemMessagePromptTemplate",
+        "HumanMessagePromptTemplate",
+        "AIMessagePromptTemplate",
+        "BasePromptTemplate",
+        "StrOutputParser",
+        "JsonOutputParser",
+        "PydanticOutputParser",
+    }
+)
+
+
+def _is_internal_chain(serialized: Optional[Dict[str, Any]], name: str) -> bool:
+    """Return True if this chain is internal LCEL / LangGraph plumbing that
+    should NOT produce a user-visible span."""
+    if serialized and "id" in serialized:
+        class_path = serialized["id"]
+        if isinstance(class_path, list) and class_path:
+            class_name = str(class_path[-1])
+            if class_name in _SKIP_CHAIN_CLASS_PREFIXES:
+                return True
+            if class_name.startswith("Runnable"):
+                return True
+
+    if name in _SKIP_CHAIN_CLASS_PREFIXES:
+        return True
+
+    return False
 
 
 def detect_observation_type(
@@ -338,6 +412,27 @@ def detect_observation_type(
         return "chain"
 
     return "span"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _resolve_conversation_id(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+    """Extract conversation/thread ID from LangChain callback metadata."""
+    if not metadata:
+        return None
+    for key in ("thread_id", "conversation_id", "session_id"):
+        val = metadata.get(key)
+        if val:
+            return str(val)
+    configurable = metadata.get("configurable", {})
+    for key in ("thread_id", "conversation_id"):
+        val = configurable.get(key)
+        if val:
+            return str(val)
+    return None
 
 
 # =============================================================================
@@ -373,6 +468,9 @@ def _create_callback_handler_class(
         calculate_ttft,
         calculate_tbt,
         truncate_content,
+        is_langgraph_wrapper_active,
+        set_framework_llm_active,
+        reset_framework_llm_active,
     )
     from openlit.semcov import SemanticConvention
 
@@ -394,6 +492,9 @@ def _create_callback_handler_class(
             self._event_provider = event_provider
             self.spans: Dict[UUID, SpanHolder] = {}
             self.run_inline = True
+            # Tracks skipped chain run_ids -> their parent_run_id so children
+            # can walk up to find a real (non-skipped) parent span.
+            self._skipped_runs: Dict[UUID, Optional[UUID]] = {}
 
         def _get_name_from_callback(
             self,
@@ -414,6 +515,19 @@ def _create_callback_handler_class(
                         return class_id[-1]
             return "unknown"
 
+        def _resolve_parent_run_id(
+            self, parent_run_id: Optional[UUID]
+        ) -> Optional[UUID]:
+            """Walk up through skipped runs to find the nearest real parent."""
+            visited = set()
+            current = parent_run_id
+            while current is not None and current in self._skipped_runs:
+                if current in visited:
+                    break
+                visited.add(current)
+                current = self._skipped_runs[current]
+            return current
+
         def _create_span(
             self,
             run_id: UUID,
@@ -426,6 +540,7 @@ def _create_callback_handler_class(
             # via the parent_context parameter, not via context attachment.
             # This avoids "Failed to detach context" errors in streaming scenarios
             # where callbacks may execute in different execution contexts.
+            parent_run_id = self._resolve_parent_run_id(parent_run_id)
             parent_context = None
             if parent_run_id is not None and parent_run_id in self.spans:
                 parent_span = self.spans[parent_run_id].span
@@ -718,13 +833,34 @@ def _create_callback_handler_class(
                 name = self._get_name_from_callback(serialized, **kwargs)
                 obs_type = detect_observation_type(serialized, "chain", name=name)
 
-                # Use different operation type for agents vs chains
+                if obs_type != "agent" and _is_internal_chain(serialized, name):
+                    self._skipped_runs[run_id] = parent_run_id
+                    return
+
+                # Suppress the top-level graph callback span when LangGraph wrapper
+                # already created the root span.
+                if (
+                    obs_type != "agent"
+                    and is_langgraph_wrapper_active()
+                    and parent_run_id is None
+                ):
+                    self._skipped_runs[run_id] = parent_run_id
+                    return
+
+                # Skip all non-agent intermediate chains (graph-node wrappers
+                # like call_model, should_continue). They don't map to any OTel
+                # semantic convention and their parent hierarchy is unreliable.
+                # Children are re-parented via _resolve_parent_run_id.
+                if obs_type != "agent" and parent_run_id is not None:
+                    self._skipped_runs[run_id] = parent_run_id
+                    return
+
                 if obs_type == "agent":
                     operation_type = SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT
-                    span_name = f"agent {name}"
+                    span_name = f"invoke_agent {name}"
                 else:
                     operation_type = SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK
-                    span_name = f"workflow {name}"
+                    span_name = f"invoke_workflow {name}"
 
                 span = self._create_span(run_id, parent_run_id, span_name)
 
@@ -733,7 +869,17 @@ def _create_callback_handler_class(
                     SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
                 )
                 self._set_common_attributes(span, operation_type)
-                span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_TYPE, name)
+
+                if obs_type == "agent":
+                    span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, name)
+                else:
+                    span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, name)
+
+                conv_id = _resolve_conversation_id(metadata)
+                if conv_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id
+                    )
 
                 if self._capture_message_content and inputs:
                     try:
@@ -757,6 +903,7 @@ def _create_callback_handler_class(
         ) -> None:
             """Run when chain ends."""
             try:
+                self._skipped_runs.pop(run_id, None)
                 if run_id not in self.spans:
                     return
 
@@ -809,6 +956,7 @@ def _create_callback_handler_class(
         ) -> None:
             """Run when chain errors."""
             try:
+                self._skipped_runs.pop(run_id, None)
                 if run_id in self.spans:
                     span = self.spans[run_id].span
                     span.set_attribute(
@@ -845,6 +993,13 @@ def _create_callback_handler_class(
                     run_id, parent_run_id, span_name, SpanKind.CLIENT
                 )
 
+                # Suppress duplicate provider spans while framework owns the LLM span
+                fw_token = set_framework_llm_active()
+                from opentelemetry import context as otel_context
+
+                ctx_token = otel_context.attach(set_span_in_context(span))
+                self.spans[run_id].token = (fw_token, ctx_token)
+
                 span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, provider)
                 self._set_common_attributes(
                     span, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT
@@ -852,10 +1007,39 @@ def _create_callback_handler_class(
                 span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
                 self._set_model_parameters(span, model_params)
 
+                conv_id = _resolve_conversation_id(metadata)
+                if conv_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id
+                    )
+
                 # Store model info for later
                 self.spans[run_id].model_name = model_name
                 self.spans[run_id].model_parameters = model_params
                 self.spans[run_id].prompts = prompts if prompts else []
+                self.spans[run_id].provider = provider
+
+                # Resolve server address from invocation_params or provider defaults
+                invocation_params = kwargs.get("invocation_params", {})
+                api_base = invocation_params.get("api_base") or invocation_params.get(
+                    "base_url"
+                )
+                if api_base:
+                    try:
+                        from urllib.parse import urlparse
+
+                        parsed = urlparse(api_base)
+                        self.spans[run_id].server_address = parsed.hostname or ""
+                        self.spans[run_id].server_port = parsed.port or 443
+                    except Exception:
+                        pass
+                if (
+                    not self.spans[run_id].server_address
+                    and provider in PROVIDER_DEFAULT_ENDPOINTS
+                ):
+                    default_host, default_port = PROVIDER_DEFAULT_ENDPOINTS[provider]
+                    self.spans[run_id].server_address = default_host
+                    self.spans[run_id].server_port = default_port
 
                 if self._capture_message_content and prompts:
                     prompt_str = truncate_content("\n".join(prompts))
@@ -898,6 +1082,15 @@ def _create_callback_handler_class(
                     run_id, parent_run_id, span_name, SpanKind.CLIENT
                 )
 
+                # Suppress duplicate OpenAI/provider spans while framework owns the LLM span
+                fw_token = set_framework_llm_active()
+
+                # Attach our span to OTel context so HTTP client spans nest under it
+                from opentelemetry import context as otel_context
+
+                ctx_token = otel_context.attach(set_span_in_context(span))
+                self.spans[run_id].token = (fw_token, ctx_token)
+
                 span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, provider)
                 self._set_common_attributes(
                     span, SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT
@@ -905,9 +1098,38 @@ def _create_callback_handler_class(
                 span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
                 self._set_model_parameters(span, model_params)
 
-                # Store model info
+                conv_id = _resolve_conversation_id(metadata)
+                if conv_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id
+                    )
+
+                # Store model info and provider/server details
                 self.spans[run_id].model_name = model_name
                 self.spans[run_id].model_parameters = model_params
+                self.spans[run_id].provider = provider
+
+                # Resolve server address from invocation_params or provider defaults
+                invocation_params = kwargs.get("invocation_params", {})
+                api_base = invocation_params.get("api_base") or invocation_params.get(
+                    "base_url"
+                )
+                if api_base:
+                    try:
+                        from urllib.parse import urlparse
+
+                        parsed = urlparse(api_base)
+                        self.spans[run_id].server_address = parsed.hostname or ""
+                        self.spans[run_id].server_port = parsed.port or 443
+                    except Exception:
+                        pass
+                if (
+                    not self.spans[run_id].server_address
+                    and provider in PROVIDER_DEFAULT_ENDPOINTS
+                ):
+                    default_host, default_port = PROVIDER_DEFAULT_ENDPOINTS[provider]
+                    self.spans[run_id].server_address = default_host
+                    self.spans[run_id].server_port = default_port
 
                 # Always calculate prompt content for token estimation
                 if messages:
@@ -923,6 +1145,35 @@ def _create_callback_handler_class(
                     self.spans[run_id].prompt_content = prompt_str
                     self.spans[run_id].input_tokens = general_tokens(prompt_str)
                     self.spans[run_id].input_messages_raw = messages
+
+                    # Extract system instructions from messages
+                    if self._capture_message_content:
+                        sys_instructions = []
+                        for msg_list in messages:
+                            for msg in msg_list:
+                                role = getattr(msg, "type", "")
+                                if role == "system":
+                                    content = getattr(msg, "content", "")
+                                    if content:
+                                        sys_instructions.append(str(content))
+                        if sys_instructions:
+                            self.spans[run_id].system_instructions = sys_instructions
+                            span.set_attribute(
+                                SemanticConvention.GEN_AI_SYSTEM_INSTRUCTIONS,
+                                json.dumps(sys_instructions),
+                            )
+
+                    # Extract tool definitions from invocation params
+                    invocation_params = kwargs.get("invocation_params", {})
+                    tools = invocation_params.get("tools") or invocation_params.get(
+                        "functions"
+                    )
+                    if tools and isinstance(tools, list):
+                        self.spans[run_id].tool_definitions = tools
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_TOOL_DEFINITIONS,
+                            json.dumps(tools, default=str),
+                        )
 
                     # Set prompt attribute if capturing content
                     if self._capture_message_content:
@@ -1056,6 +1307,61 @@ def _create_callback_handler_class(
                     )
                 )
 
+                # Extract tool_calls and finish_reason from generations
+                if response.generations:
+                    for gen_list in response.generations:
+                        for gen in gen_list:
+                            msg = getattr(gen, "message", None)
+                            if msg:
+                                tc = getattr(msg, "tool_calls", None)
+                                if tc:
+                                    formatted_tools = []
+                                    for call in tc:
+                                        if isinstance(call, dict):
+                                            formatted_tools.append(
+                                                {
+                                                    "id": call.get("id", ""),
+                                                    "function": {
+                                                        "name": call.get("name", ""),
+                                                        "arguments": json.dumps(
+                                                            call.get("args", {})
+                                                        )
+                                                        if isinstance(
+                                                            call.get("args"), dict
+                                                        )
+                                                        else str(call.get("args", "")),
+                                                    },
+                                                }
+                                            )
+                                        else:
+                                            formatted_tools.append(
+                                                {
+                                                    "id": getattr(call, "id", ""),
+                                                    "function": {
+                                                        "name": getattr(
+                                                            call, "name", ""
+                                                        ),
+                                                        "arguments": json.dumps(
+                                                            getattr(call, "args", {})
+                                                        )
+                                                        if isinstance(
+                                                            getattr(call, "args", None),
+                                                            dict,
+                                                        )
+                                                        else str(
+                                                            getattr(call, "args", "")
+                                                        ),
+                                                    },
+                                                }
+                                            )
+                                    if formatted_tools:
+                                        holder.tool_calls = formatted_tools
+                                resp_meta = getattr(msg, "response_metadata", {})
+                                if isinstance(resp_meta, dict):
+                                    fr = resp_meta.get("finish_reason")
+                                    if fr:
+                                        holder.finish_reason = fr
+
                 # Handle token usage including reasoning tokens and cached tokens
                 if response.llm_output:
                     token_usage = response.llm_output.get(
@@ -1112,6 +1418,15 @@ def _create_callback_handler_class(
                         "model_name"
                     ) or response.llm_output.get("model", model_name)
 
+                # For non-streaming calls, TTFT equals the full duration since the
+                # entire response arrives at once.
+                if not is_streaming:
+                    ttft = duration
+
+                # Resolve server address/port: prefer holder values, fall back to defaults
+                scope_server_address = holder.server_address or "localhost"
+                scope_server_port = holder.server_port or 443
+
                 # Build scope and run common_chat_logic (OTel span/event/metrics)
                 scope = type("Scope", (), {})()
                 scope._span = span
@@ -1119,13 +1434,13 @@ def _create_callback_handler_class(
                 scope._model_parameters = holder.model_parameters or {}
                 scope._start_time = holder.start_time
                 scope._end_time = end_time
-                scope._server_address = "localhost"
-                scope._server_port = 8080
+                scope._server_address = scope_server_address
+                scope._server_port = scope_server_port
                 scope._response_model = response_model
                 scope._response_id = (response.llm_output or {}).get("id") or None
                 scope._llmresponse = completion_content or ""
-                scope._finish_reason = "stop"
-                scope._tools = None
+                scope._finish_reason = holder.finish_reason
+                scope._tools = holder.tool_calls
                 scope._input_tokens = input_tokens
                 scope._output_tokens = output_tokens
                 scope._cache_read_input_tokens = getattr(
@@ -1140,6 +1455,11 @@ def _create_callback_handler_class(
                 scope._request_model = model_name
                 scope._input_messages_raw = getattr(holder, "input_messages_raw", None)
                 scope._prompts = getattr(holder, "prompts", [])
+                scope._system_instructions = getattr(
+                    holder, "system_instructions", None
+                )
+                scope._tool_definitions = getattr(holder, "tool_definitions", None)
+                scope._provider = holder.provider or None
 
                 common_chat_logic(
                     scope,
@@ -1153,6 +1473,17 @@ def _create_callback_handler_class(
                     is_streaming,
                     self._event_provider,
                 )
+
+                # Reset the framework LLM flag and detach OTel context
+                if holder.token and isinstance(holder.token, tuple):
+                    fw_token, ctx_token = holder.token
+                    try:
+                        from opentelemetry import context as otel_context
+
+                        otel_context.detach(ctx_token)
+                    except Exception:
+                        pass
+                    reset_framework_llm_active(fw_token)
 
                 self._end_span(run_id)
 
@@ -1170,11 +1501,20 @@ def _create_callback_handler_class(
             """Run when LLM errors."""
             try:
                 if run_id in self.spans:
-                    span = self.spans[run_id].span
-                    span.set_attribute(
+                    holder = self.spans[run_id]
+                    holder.span.set_attribute(
                         SemanticConvention.GEN_AI_FRAMEWORK_ERROR_MESSAGE,
                         truncate_content(error),
                     )
+                    if holder.token and isinstance(holder.token, tuple):
+                        fw_token, ctx_token = holder.token
+                        try:
+                            from opentelemetry import context as otel_context
+
+                            otel_context.detach(ctx_token)
+                        except Exception:
+                            pass
+                        reset_framework_llm_active(fw_token)
                 self._end_span(run_id, str(error))
             except Exception as e:
                 logger.debug("Error in on_llm_error: %s", e)
@@ -1197,7 +1537,7 @@ def _create_callback_handler_class(
             """Run when tool starts."""
             try:
                 name = self._get_name_from_callback(serialized, **kwargs)
-                span_name = f"tool {name}"
+                span_name = f"execute_tool {name}"
 
                 span = self._create_span(run_id, parent_run_id, span_name)
 
@@ -1209,10 +1549,23 @@ def _create_callback_handler_class(
                     span, SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS
                 )
                 span.set_attribute(SemanticConvention.GEN_AI_TOOL_NAME, name)
+                span.set_attribute(SemanticConvention.GEN_AI_TOOL_TYPE, "function")
+
+                description = (serialized or {}).get("description")
+                if description:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_TOOL_DESCRIPTION, str(description)
+                    )
+
+                conv_id = _resolve_conversation_id(metadata)
+                if conv_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id
+                    )
 
                 if self._capture_message_content and input_str:
                     span.set_attribute(
-                        SemanticConvention.GEN_AI_TOOL_INPUT,
+                        SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS,
                         truncate_content(input_str),
                     )
 
@@ -1240,9 +1593,25 @@ def _create_callback_handler_class(
                     SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, duration
                 )
 
+                tool_call_id = None
+                if hasattr(output, "tool_call_id"):
+                    tool_call_id = output.tool_call_id
+                elif isinstance(output, str) and "tool_call_id" in output:
+                    import re
+
+                    match = re.search(r"tool_call_id=['\"]([^'\"]+)['\"]", output)
+                    if match:
+                        tool_call_id = match.group(1)
+
+                if tool_call_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_TOOL_CALL_ID, tool_call_id
+                    )
+
                 if self._capture_message_content and output:
                     span.set_attribute(
-                        SemanticConvention.GEN_AI_TOOL_OUTPUT, truncate_content(output)
+                        SemanticConvention.GEN_AI_TOOL_CALL_RESULT,
+                        truncate_content(output),
                     )
 
                 # Record metrics
@@ -1307,7 +1676,9 @@ def _create_callback_handler_class(
                 name = self._get_name_from_callback(serialized, **kwargs)
                 span_name = f"retrieval {name}"
 
-                span = self._create_span(run_id, parent_run_id, span_name)
+                span = self._create_span(
+                    run_id, parent_run_id, span_name, SpanKind.CLIENT
+                )
 
                 span.set_attribute(
                     SemanticConvention.GEN_AI_PROVIDER_NAME,
@@ -1316,10 +1687,17 @@ def _create_callback_handler_class(
                 self._set_common_attributes(
                     span, SemanticConvention.GEN_AI_OPERATION_TYPE_RETRIEVE
                 )
+                span.set_attribute(SemanticConvention.GEN_AI_DATA_SOURCE_ID, name)
+
+                conv_id = _resolve_conversation_id(metadata)
+                if conv_id:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id
+                    )
 
                 if self._capture_message_content and query:
                     span.set_attribute(
-                        SemanticConvention.GEN_AI_RETRIEVAL_QUERY,
+                        SemanticConvention.GEN_AI_RETRIEVAL_QUERY_TEXT,
                         truncate_content(query),
                     )
 
@@ -1352,13 +1730,19 @@ def _create_callback_handler_class(
                 )
 
                 if self._capture_message_content and documents:
-                    sample_docs = []
+                    structured_docs = []
                     for doc in documents[:3]:
                         content = getattr(doc, "page_content", str(doc))
-                        sample_docs.append(truncate_content(content))
+                        doc_entry = {"content": truncate_content(content)}
+                        doc_meta = getattr(doc, "metadata", None)
+                        if doc_meta and isinstance(doc_meta, dict):
+                            doc_id = doc_meta.get("id") or doc_meta.get("source")
+                            if doc_id:
+                                doc_entry["id"] = str(doc_id)
+                        structured_docs.append(doc_entry)
                     span.set_attribute(
                         SemanticConvention.GEN_AI_RETRIEVAL_DOCUMENTS,
-                        "; ".join(sample_docs),
+                        json.dumps(structured_docs),
                     )
 
                 # Record metrics
@@ -1515,6 +1899,92 @@ class _BaseCallbackManagerInitWrapper:
 # =============================================================================
 
 
+def _wrap_create_agent(tracer, version, environment, application_name):
+    """Wraps langchain.agents.create_agent to produce a create_agent span."""
+    from openlit.semcov import SemanticConvention
+    from openlit.__helpers import (
+        handle_exception,
+        set_create_agent_active,
+        reset_create_agent_active,
+    )
+
+    def wrapper(wrapped, instance, args, kwargs):
+        import json
+        from urllib.parse import urlparse
+
+        llm = args[0] if args else kwargs.get("model")
+        model_name = "unknown"
+        if llm is not None:
+            model_name = (
+                getattr(llm, "model_name", None)
+                or getattr(llm, "model", None)
+                or "unknown"
+            )
+
+        agent_name = kwargs.get("name", "default")
+        span_name = f"create_agent {agent_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            span.set_attribute(SemanticConvention.GEN_AI_OPERATION, "create_agent")
+            span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, "langchain")
+            span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
+            span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
+            span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
+            span.set_attribute(
+                SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+
+            server_address = "localhost"
+            server_port = 443
+            try:
+                base_url = getattr(llm, "base_url", None) or getattr(
+                    llm, "openai_api_base", None
+                )
+                if base_url:
+                    parsed = urlparse(str(base_url))
+                    if parsed.hostname:
+                        server_address = parsed.hostname
+                    if parsed.port:
+                        server_port = parsed.port
+                    elif parsed.scheme == "https":
+                        server_port = 443
+                    elif parsed.scheme == "http":
+                        server_port = 80
+            except Exception:
+                pass
+            span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+            span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+
+            tools = args[1] if len(args) > 1 else kwargs.get("tools", [])
+            tool_names = []
+            if tools:
+                for t in tools:
+                    name = getattr(t, "name", None) or str(t)
+                    tool_names.append(name)
+                span.set_attribute("gen_ai.agent.tools", json.dumps(tool_names))
+
+            if tool_names:
+                description = f"Agent with tools: {', '.join(tool_names)}"
+            else:
+                description = "LangChain agent"
+            span.set_attribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, description)
+
+            ca_token = set_create_agent_active()
+            try:
+                result = wrapped(*args, **kwargs)
+                result._openlit_creation_context = span.get_span_context()
+                span.set_status(Status(StatusCode.OK))
+                return result
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+            finally:
+                reset_create_agent_active(ca_token)
+
+    return wrapper
+
+
 class LangChainInstrumentor(BaseInstrumentor):
     """
     OpenLIT LangChain instrumentor with comprehensive features.
@@ -1571,6 +2041,18 @@ class LangChainInstrumentor(BaseInstrumentor):
             logger.debug("Successfully wrapped BaseCallbackManager.__init__")
         except Exception as e:
             logger.debug("Failed to wrap BaseCallbackManager.__init__: %s", e)
+
+        try:
+            wrap_function_wrapper(
+                module="langchain.agents",
+                name="create_agent",
+                wrapper=_wrap_create_agent(
+                    tracer, version, environment, application_name
+                ),
+            )
+            logger.debug("Successfully wrapped langchain.agents.create_agent")
+        except Exception:
+            logger.debug("langchain.agents.create_agent not available, skipping")
 
     def _uninstrument(self, **kwargs):
         """Remove instrumentation."""

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -6,6 +6,7 @@ import logging
 import json
 import re
 import time
+import threading
 from typing import Any, Collection, Dict, List, Optional, Literal, cast
 from uuid import UUID
 import importlib.metadata
@@ -308,23 +309,6 @@ PROVIDER_MAP = {
 }
 
 
-PROVIDER_DEFAULT_ENDPOINTS = {
-    "openai": ("api.openai.com", 443),
-    "anthropic": ("api.anthropic.com", 443),
-    "google": ("generativelanguage.googleapis.com", 443),
-    "mistral_ai": ("api.mistral.ai", 443),
-    "groq": ("api.groq.com", 443),
-    "together": ("api.together.xyz", 443),
-    "fireworks": ("api.fireworks.ai", 443),
-    "perplexity": ("api.perplexity.ai", 443),
-    "deepinfra": ("api.deepinfra.com", 443),
-    "aws.bedrock": ("bedrock-runtime.amazonaws.com", 443),
-    "azure": ("openai.azure.com", 443),
-    "cohere": ("api.cohere.ai", 443),
-    "ollama": ("localhost", 11434),
-}
-
-
 def detect_provider(serialized: Optional[Dict[str, Any]]) -> str:
     """Detect the LLM provider from serialized class info."""
     from openlit.semcov import SemanticConvention
@@ -471,6 +455,7 @@ def _create_callback_handler_class(
         is_langgraph_wrapper_active,
         set_framework_llm_active,
         reset_framework_llm_active,
+        get_server_address_for_provider,
     )
     from openlit.semcov import SemanticConvention
 
@@ -492,8 +477,7 @@ def _create_callback_handler_class(
             self._event_provider = event_provider
             self.spans: Dict[UUID, SpanHolder] = {}
             self.run_inline = True
-            # Tracks skipped chain run_ids -> their parent_run_id so children
-            # can walk up to find a real (non-skipped) parent span.
+            self._lock = threading.RLock()
             self._skipped_runs: Dict[UUID, Optional[UUID]] = {}
 
         def _get_name_from_callback(
@@ -519,14 +503,15 @@ def _create_callback_handler_class(
             self, parent_run_id: Optional[UUID]
         ) -> Optional[UUID]:
             """Walk up through skipped runs to find the nearest real parent."""
-            visited = set()
-            current = parent_run_id
-            while current is not None and current in self._skipped_runs:
-                if current in visited:
-                    break
-                visited.add(current)
-                current = self._skipped_runs[current]
-            return current
+            with self._lock:
+                visited = set()
+                current = parent_run_id
+                while current is not None and current in self._skipped_runs:
+                    if current in visited:
+                        break
+                    visited.add(current)
+                    current = self._skipped_runs[current]
+                return current
 
         def _create_span(
             self,
@@ -536,54 +521,50 @@ def _create_callback_handler_class(
             kind: SpanKind = SpanKind.INTERNAL,
         ) -> Any:
             """Create a new span with proper parent relationship."""
-            # For callback-based instrumentation, we manage parent-child relationships
-            # via the parent_context parameter, not via context attachment.
-            # This avoids "Failed to detach context" errors in streaming scenarios
-            # where callbacks may execute in different execution contexts.
-            parent_run_id = self._resolve_parent_run_id(parent_run_id)
-            parent_context = None
-            if parent_run_id is not None and parent_run_id in self.spans:
-                parent_span = self.spans[parent_run_id].span
-                parent_context = set_span_in_context(parent_span)
+            with self._lock:
+                parent_run_id = self._resolve_parent_run_id(parent_run_id)
+                parent_context = None
+                if parent_run_id is not None and parent_run_id in self.spans:
+                    parent_span = self.spans[parent_run_id].span
+                    parent_context = set_span_in_context(parent_span)
 
-            span = self._tracer.start_span(
-                span_name,
-                context=parent_context,
-                kind=kind,
-            )
+                span = self._tracer.start_span(
+                    span_name,
+                    context=parent_context,
+                    kind=kind,
+                )
 
-            # Don't attach to context - callbacks can execute in different contexts
-            holder = SpanHolder(span, token=None)
-            self.spans[run_id] = holder
+                holder = SpanHolder(span, token=None)
+                self.spans[run_id] = holder
 
-            if parent_run_id is not None and parent_run_id in self.spans:
-                self.spans[parent_run_id].children.append(run_id)
+                if parent_run_id is not None and parent_run_id in self.spans:
+                    self.spans[parent_run_id].children.append(run_id)
 
-            return span
+                return span
 
         def _end_span(self, run_id: UUID, error: Optional[str] = None) -> None:
             """End a span and clean up."""
-            if run_id not in self.spans:
-                return
+            with self._lock:
+                if run_id not in self.spans:
+                    return
 
-            holder = self.spans[run_id]
-            span = holder.span
+                holder = self.spans[run_id]
+                span = holder.span
 
-            # End any child spans that are still open
-            for child_id in holder.children:
-                if child_id in self.spans:
-                    child_holder = self.spans[child_id]
-                    if child_holder.span.end_time is None:
-                        child_holder.span.end()
+                for child_id in holder.children:
+                    if child_id in self.spans:
+                        child_holder = self.spans[child_id]
+                        if child_holder.span.end_time is None:
+                            child_holder.span.end()
 
-            if error:
-                span.set_status(Status(StatusCode.ERROR, error))
-            else:
-                span.set_status(Status(StatusCode.OK))
+                if error:
+                    span.set_status(Status(StatusCode.ERROR, error))
+                else:
+                    span.set_status(Status(StatusCode.OK))
 
-            span.end()
+                span.end()
 
-            del self.spans[run_id]
+                del self.spans[run_id]
 
         def _set_common_attributes(self, span, operation_type: str) -> None:
             """Set common attributes on a span."""
@@ -834,25 +815,22 @@ def _create_callback_handler_class(
                 obs_type = detect_observation_type(serialized, "chain", name=name)
 
                 if obs_type != "agent" and _is_internal_chain(serialized, name):
-                    self._skipped_runs[run_id] = parent_run_id
+                    with self._lock:
+                        self._skipped_runs[run_id] = parent_run_id
                     return
 
-                # Suppress the top-level graph callback span when LangGraph wrapper
-                # already created the root span.
                 if (
                     obs_type != "agent"
                     and is_langgraph_wrapper_active()
                     and parent_run_id is None
                 ):
-                    self._skipped_runs[run_id] = parent_run_id
+                    with self._lock:
+                        self._skipped_runs[run_id] = parent_run_id
                     return
 
-                # Skip all non-agent intermediate chains (graph-node wrappers
-                # like call_model, should_continue). They don't map to any OTel
-                # semantic convention and their parent hierarchy is unreliable.
-                # Children are re-parented via _resolve_parent_run_id.
                 if obs_type != "agent" and parent_run_id is not None:
-                    self._skipped_runs[run_id] = parent_run_id
+                    with self._lock:
+                        self._skipped_runs[run_id] = parent_run_id
                     return
 
                 if obs_type == "agent":
@@ -903,7 +881,8 @@ def _create_callback_handler_class(
         ) -> None:
             """Run when chain ends."""
             try:
-                self._skipped_runs.pop(run_id, None)
+                with self._lock:
+                    self._skipped_runs.pop(run_id, None)
                 if run_id not in self.spans:
                     return
 
@@ -931,8 +910,8 @@ def _create_callback_handler_class(
                             metrics=self._metrics,
                             gen_ai_operation=SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
                             GEN_AI_PROVIDER_NAME=SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
-                            server_address="localhost",
-                            server_port=8080,
+                            server_address="",
+                            server_port=0,
                             environment=self._environment,
                             application_name=self._application_name,
                             start_time=holder.start_time,
@@ -956,7 +935,8 @@ def _create_callback_handler_class(
         ) -> None:
             """Run when chain errors."""
             try:
-                self._skipped_runs.pop(run_id, None)
+                with self._lock:
+                    self._skipped_runs.pop(run_id, None)
                 if run_id in self.spans:
                     span = self.spans[run_id].span
                     span.set_attribute(
@@ -1033,29 +1013,26 @@ def _create_callback_handler_class(
                         self.spans[run_id].server_port = parsed.port or 443
                     except Exception:
                         pass
-                if (
-                    not self.spans[run_id].server_address
-                    and provider in PROVIDER_DEFAULT_ENDPOINTS
-                ):
-                    default_host, default_port = PROVIDER_DEFAULT_ENDPOINTS[provider]
-                    self.spans[run_id].server_address = default_host
-                    self.spans[run_id].server_port = default_port
-
-                if self._capture_message_content and prompts:
-                    prompt_str = truncate_content("\n".join(prompts))
-                    span.set_attribute(
-                        SemanticConvention.GEN_AI_INPUT_MESSAGES, prompt_str
+                if not self.spans[run_id].server_address:
+                    default_host, default_port = get_server_address_for_provider(
+                        provider
                     )
+                    if default_host:
+                        self.spans[run_id].server_address = default_host
+                        self.spans[run_id].server_port = default_port
+
+                if prompts:
+                    prompt_str = truncate_content("\n".join(prompts))
                     self.spans[run_id].input_tokens = general_tokens(prompt_str)
 
-                    # Store structured prompts for event emission
-                    try:
-                        structured_prompts = build_input_messages(prompts)
-                        self.spans[run_id].input_messages = structured_prompts
-                    except Exception as prompt_err:
-                        logger.debug(
-                            "Error building structured prompts: %s", prompt_err
-                        )
+                    if self._capture_message_content:
+                        try:
+                            structured_prompts = build_input_messages(prompts)
+                            self.spans[run_id].input_messages = structured_prompts
+                        except Exception as prompt_err:
+                            logger.debug(
+                                "Error building structured prompts: %s", prompt_err
+                            )
 
             except Exception as e:
                 logger.debug("Error in on_llm_start: %s", e)
@@ -1123,13 +1100,13 @@ def _create_callback_handler_class(
                         self.spans[run_id].server_port = parsed.port or 443
                     except Exception:
                         pass
-                if (
-                    not self.spans[run_id].server_address
-                    and provider in PROVIDER_DEFAULT_ENDPOINTS
-                ):
-                    default_host, default_port = PROVIDER_DEFAULT_ENDPOINTS[provider]
-                    self.spans[run_id].server_address = default_host
-                    self.spans[run_id].server_port = default_port
+                if not self.spans[run_id].server_address:
+                    default_host, default_port = get_server_address_for_provider(
+                        provider
+                    )
+                    if default_host:
+                        self.spans[run_id].server_address = default_host
+                        self.spans[run_id].server_port = default_port
 
                 # Always calculate prompt content for token estimation
                 if messages:
@@ -1155,7 +1132,9 @@ def _create_callback_handler_class(
                                 if role == "system":
                                     content = getattr(msg, "content", "")
                                     if content:
-                                        sys_instructions.append(str(content))
+                                        sys_instructions.append(
+                                            {"type": "text", "content": str(content)}
+                                        )
                         if sys_instructions:
                             self.spans[run_id].system_instructions = sys_instructions
                             span.set_attribute(
@@ -1173,12 +1152,6 @@ def _create_callback_handler_class(
                         span.set_attribute(
                             SemanticConvention.GEN_AI_TOOL_DEFINITIONS,
                             json.dumps(tools, default=str),
-                        )
-
-                    # Set prompt attribute if capturing content
-                    if self._capture_message_content:
-                        span.set_attribute(
-                            SemanticConvention.GEN_AI_INPUT_MESSAGES, prompt_str
                         )
 
                     # Store structured messages for event emission
@@ -1541,10 +1514,6 @@ def _create_callback_handler_class(
 
                 span = self._create_span(run_id, parent_run_id, span_name)
 
-                span.set_attribute(
-                    SemanticConvention.GEN_AI_PROVIDER_NAME,
-                    SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
-                )
                 self._set_common_attributes(
                     span, SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS
                 )
@@ -1621,8 +1590,8 @@ def _create_callback_handler_class(
                             metrics=self._metrics,
                             gen_ai_operation=SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS,
                             GEN_AI_PROVIDER_NAME=SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
-                            server_address="localhost",
-                            server_port=8080,
+                            server_address="",
+                            server_port=0,
                             environment=self._environment,
                             application_name=self._application_name,
                             start_time=holder.start_time,
@@ -1752,8 +1721,8 @@ def _create_callback_handler_class(
                             metrics=self._metrics,
                             gen_ai_operation=SemanticConvention.GEN_AI_OPERATION_TYPE_RETRIEVE,
                             GEN_AI_PROVIDER_NAME=SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
-                            server_address="localhost",
-                            server_port=8080,
+                            server_address="",
+                            server_port=0,
                             environment=self._environment,
                             application_name=self._application_name,
                             start_time=holder.start_time,
@@ -1856,6 +1825,31 @@ def _create_callback_handler_class(
             except Exception as e:
                 logger.debug("Error in on_agent_finish: %s", e)
 
+        # =================================================================
+        # Retry Callback
+        # =================================================================
+
+        def on_retry(
+            self,
+            retry_state: Any,
+            *,
+            run_id: UUID,
+            parent_run_id: Optional[UUID] = None,
+            **kwargs: Any,
+        ) -> None:
+            """Log a span event when LangChain retries an operation."""
+            try:
+                with self._lock:
+                    holder = self.spans.get(run_id)
+                if holder is not None:
+                    attempt = getattr(retry_state, "attempt_number", 0)
+                    holder.span.add_event(
+                        "retry",
+                        attributes={"retry.attempt": attempt},
+                    )
+            except Exception as e:
+                logger.debug("Error in on_retry: %s", e)
+
     return OpenLITCallbackHandler
 
 
@@ -1906,6 +1900,7 @@ def _wrap_create_agent(tracer, version, environment, application_name):
         handle_exception,
         set_create_agent_active,
         reset_create_agent_active,
+        get_server_address_for_provider,
     )
 
     def wrapper(wrapped, instance, args, kwargs):
@@ -1914,19 +1909,31 @@ def _wrap_create_agent(tracer, version, environment, application_name):
 
         llm = args[0] if args else kwargs.get("model")
         model_name = "unknown"
+        provider = "langchain"
         if llm is not None:
             model_name = (
                 getattr(llm, "model_name", None)
                 or getattr(llm, "model", None)
                 or "unknown"
             )
+            class_name = llm.__class__.__name__.lower()
+            class_module = (
+                llm.__class__.__module__.lower()
+                if hasattr(llm.__class__, "__module__")
+                else ""
+            )
+            class_path = f"{class_module}.{class_name}"
+            for prov_key, prov_val in PROVIDER_MAP.items():
+                if prov_key in class_path:
+                    provider = prov_val
+                    break
 
         agent_name = kwargs.get("name", "default")
         span_name = f"create_agent {agent_name}"
 
         with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             span.set_attribute(SemanticConvention.GEN_AI_OPERATION, "create_agent")
-            span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, "langchain")
+            span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, provider)
             span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
             span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
             span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
@@ -1935,8 +1942,7 @@ def _wrap_create_agent(tracer, version, environment, application_name):
             )
             span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
 
-            server_address = "localhost"
-            server_port = 443
+            server_address, server_port = "", 0
             try:
                 base_url = getattr(llm, "base_url", None) or getattr(
                     llm, "openai_api_base", None
@@ -1953,8 +1959,11 @@ def _wrap_create_agent(tracer, version, environment, application_name):
                         server_port = 80
             except Exception:
                 pass
-            span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
-            span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+            if not server_address:
+                server_address, server_port = get_server_address_for_provider(provider)
+            if server_address:
+                span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+                span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
 
             tools = args[1] if len(args) > 1 else kwargs.get("tools", [])
             tool_names = []
@@ -1981,6 +1990,264 @@ def _wrap_create_agent(tracer, version, environment, application_name):
                 raise
             finally:
                 reset_create_agent_active(ca_token)
+
+    return wrapper
+
+
+def _wrap_embed(
+    tracer,
+    version,
+    environment,
+    application_name,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wraps langchain_core.embeddings.Embeddings methods to produce embeddings spans."""
+    from openlit.semcov import SemanticConvention
+    from openlit.__helpers import (
+        handle_exception,
+        general_tokens,
+        get_server_address_for_provider,
+    )
+
+    def wrapper(wrapped, instance, args, kwargs):
+        from opentelemetry import context as context_api
+
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return wrapped(*args, **kwargs)
+
+        model_name = (
+            getattr(instance, "model", None)
+            or getattr(instance, "model_name", None)
+            or getattr(instance, "model_id", None)
+            or "unknown"
+        )
+
+        provider = "langchain"
+        class_name = instance.__class__.__name__.lower()
+        class_module = (
+            instance.__class__.__module__.lower()
+            if hasattr(instance.__class__, "__module__")
+            else ""
+        )
+        class_path = f"{class_module}.{class_name}"
+        for prov_key, prov_val in PROVIDER_MAP.items():
+            if prov_key in class_path:
+                provider = prov_val
+                break
+
+        span_name = f"embeddings {model_name}"
+
+        server_address, server_port = "", 0
+        try:
+            from urllib.parse import urlparse
+
+            base_url = getattr(instance, "base_url", None) or getattr(
+                getattr(instance, "client", None), "base_url", None
+            )
+            if base_url:
+                parsed = urlparse(str(base_url))
+                server_address = parsed.hostname or ""
+                server_port = parsed.port or 443
+        except Exception:
+            pass
+        if not server_address:
+            server_address, server_port = get_server_address_for_provider(provider)
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            import time as _time
+
+            start_time = _time.time()
+
+            span.set_attribute(
+                SemanticConvention.GEN_AI_OPERATION,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, provider)
+            span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
+            span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
+            span.set_attribute(
+                SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+            if server_address:
+                span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+                span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+
+            try:
+                result = wrapped(*args, **kwargs)
+
+                end_time = _time.time()
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION,
+                    end_time - start_time,
+                )
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, model_name)
+
+                if args:
+                    input_data = args[0]
+                    if isinstance(input_data, list):
+                        input_tokens = sum(general_tokens(t) for t in input_data)
+                    elif isinstance(input_data, str):
+                        input_tokens = general_tokens(input_data)
+                    else:
+                        input_tokens = 0
+                    if input_tokens > 0:
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens
+                        )
+
+                if result is not None:
+                    if isinstance(result, list) and result:
+                        first = result[0]
+                        if isinstance(first, list) and first:
+                            span.set_attribute(
+                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
+                                len(first),
+                            )
+                        elif isinstance(first, (int, float)):
+                            span.set_attribute(
+                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
+                                len(result),
+                            )
+
+                span.set_status(Status(StatusCode.OK))
+                return result
+
+            except Exception as e:
+                handle_exception(span, e)
+                raise
+
+    return wrapper
+
+
+def _wrap_embed_async(
+    tracer,
+    version,
+    environment,
+    application_name,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """Wraps async langchain_core.embeddings.Embeddings methods."""
+    from openlit.semcov import SemanticConvention
+    from openlit.__helpers import (
+        handle_exception,
+        general_tokens,
+        get_server_address_for_provider,
+    )
+
+    async def wrapper(wrapped, instance, args, kwargs):
+        from opentelemetry import context as context_api
+
+        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            return await wrapped(*args, **kwargs)
+
+        model_name = (
+            getattr(instance, "model", None)
+            or getattr(instance, "model_name", None)
+            or getattr(instance, "model_id", None)
+            or "unknown"
+        )
+
+        provider = "langchain"
+        class_name = instance.__class__.__name__.lower()
+        class_module = (
+            instance.__class__.__module__.lower()
+            if hasattr(instance.__class__, "__module__")
+            else ""
+        )
+        class_path = f"{class_module}.{class_name}"
+        for prov_key, prov_val in PROVIDER_MAP.items():
+            if prov_key in class_path:
+                provider = prov_val
+                break
+
+        span_name = f"embeddings {model_name}"
+
+        server_address, server_port = "", 0
+        try:
+            from urllib.parse import urlparse
+
+            base_url = getattr(instance, "base_url", None) or getattr(
+                getattr(instance, "client", None), "base_url", None
+            )
+            if base_url:
+                parsed = urlparse(str(base_url))
+                server_address = parsed.hostname or ""
+                server_port = parsed.port or 443
+        except Exception:
+            pass
+        if not server_address:
+            server_address, server_port = get_server_address_for_provider(provider)
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            import time as _time
+
+            start_time = _time.time()
+
+            span.set_attribute(
+                SemanticConvention.GEN_AI_OPERATION,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_PROVIDER_NAME, provider)
+            span.set_attribute(SemanticConvention.GEN_AI_REQUEST_MODEL, model_name)
+            span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
+            span.set_attribute(
+                SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+            )
+            span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+            if server_address:
+                span.set_attribute(SemanticConvention.SERVER_ADDRESS, server_address)
+                span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
+
+            try:
+                result = await wrapped(*args, **kwargs)
+
+                end_time = _time.time()
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION,
+                    end_time - start_time,
+                )
+                span.set_attribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, model_name)
+
+                if args:
+                    input_data = args[0]
+                    if isinstance(input_data, list):
+                        input_tokens = sum(general_tokens(t) for t in input_data)
+                    elif isinstance(input_data, str):
+                        input_tokens = general_tokens(input_data)
+                    else:
+                        input_tokens = 0
+                    if input_tokens > 0:
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens
+                        )
+
+                if result is not None:
+                    if isinstance(result, list) and result:
+                        first = result[0]
+                        if isinstance(first, list) and first:
+                            span.set_attribute(
+                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
+                                len(first),
+                            )
+                        elif isinstance(first, (int, float)):
+                            span.set_attribute(
+                                SemanticConvention.GEN_AI_EMBEDDINGS_DIMENSION_COUNT,
+                                len(result),
+                            )
+
+                span.set_status(Status(StatusCode.OK))
+                return result
+
+            except Exception as e:
+                handle_exception(span, e)
+                raise
 
     return wrapper
 
@@ -2054,11 +2321,53 @@ class LangChainInstrumentor(BaseInstrumentor):
         except Exception:
             logger.debug("langchain.agents.create_agent not available, skipping")
 
+        embed_kwargs = dict(
+            tracer=tracer,
+            version=version,
+            environment=environment,
+            application_name=application_name,
+            pricing_info=pricing_info,
+            capture_message_content=capture_message_content,
+            metrics=metrics,
+            disable_metrics=disable_metrics,
+        )
+        for method_name in ("embed_documents", "embed_query"):
+            try:
+                wrap_function_wrapper(
+                    module="langchain_core.embeddings",
+                    name=f"Embeddings.{method_name}",
+                    wrapper=_wrap_embed(**embed_kwargs),
+                )
+                logger.debug("Successfully wrapped Embeddings.%s", method_name)
+            except Exception:
+                logger.debug("Embeddings.%s not available, skipping", method_name)
+
+        for method_name in ("aembed_documents", "aembed_query"):
+            try:
+                wrap_function_wrapper(
+                    module="langchain_core.embeddings",
+                    name=f"Embeddings.{method_name}",
+                    wrapper=_wrap_embed_async(**embed_kwargs),
+                )
+                logger.debug("Successfully wrapped Embeddings.%s", method_name)
+            except Exception:
+                logger.debug("Embeddings.%s not available, skipping", method_name)
+
     def _uninstrument(self, **kwargs):
         """Remove instrumentation."""
         try:
             from opentelemetry.instrumentation.utils import unwrap
 
             unwrap("langchain_core.callbacks.manager", "BaseCallbackManager.__init__")
+            for method_name in (
+                "embed_documents",
+                "embed_query",
+                "aembed_documents",
+                "aembed_query",
+            ):
+                try:
+                    unwrap("langchain_core.embeddings", f"Embeddings.{method_name}")
+                except Exception:
+                    pass
         except Exception as e:
             logger.debug("Error during uninstrumentation: %s", e)

--- a/sdk/python/src/openlit/instrumentation/langchain/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/utils.py
@@ -47,28 +47,62 @@ def format_content(messages_or_prompts: Any) -> str:
     return "\n".join(parts) if parts else ""
 
 
+def _build_parts(content) -> list:
+    """Build OTel message parts from LangChain message content.
+
+    Handles plain strings, multimodal list-of-dicts (text, image_url, etc.),
+    and falls back gracefully.
+    """
+    if isinstance(content, str):
+        return [{"type": "text", "content": content}]
+
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict):
+                ptype = part.get("type", "text")
+                if ptype == "text":
+                    parts.append({"type": "text", "content": part.get("text", "")})
+                elif ptype == "image_url":
+                    url = part.get("image_url", {})
+                    if isinstance(url, str):
+                        parts.append({"type": "image", "url": url})
+                    elif isinstance(url, dict):
+                        parts.append({"type": "image", "url": url.get("url", "")})
+                else:
+                    parts.append({"type": ptype, "content": str(part)})
+            elif isinstance(part, str):
+                parts.append({"type": "text", "content": part})
+            else:
+                parts.append({"type": "text", "content": str(part)})
+        return parts if parts else [{"type": "text", "content": ""}]
+
+    return [{"type": "text", "content": str(content)}]
+
+
 def build_input_messages_from_langchain(messages: List) -> List[dict]:
     """
     Convert LangChain messages (list-of-lists of BaseMessage) to OTel input message structure.
+    Supports multimodal content (text, image_url, etc.).
     """
     try:
         structured = []
+        role_mapping = {
+            "system": "system",
+            "human": "user",
+            "ai": "assistant",
+            "tool": "tool",
+            "function": "tool",
+        }
         for msg_list in messages:
             for msg in msg_list:
                 role = getattr(msg, "type", "user")
                 content = getattr(msg, "content", str(msg))
-                role_mapping = {
-                    "system": "system",
-                    "human": "user",
-                    "ai": "assistant",
-                    "tool": "tool",
-                    "function": "tool",
-                }
                 otel_role = role_mapping.get(role, "user")
                 structured.append(
                     {
                         "role": otel_role,
-                        "parts": [{"type": "text", "content": str(content)}],
+                        "parts": _build_parts(content),
                     }
                 )
         return structured
@@ -361,38 +395,36 @@ def common_chat_logic(
         version,
     )
 
-    # Span Attributes for Request parameters
+    # Span Attributes for Request parameters (only set when actually present)
     params = _get_scope_params(scope)
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_TEMPERATURE,
-        params.get("temperature", 1.0),
-    )
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS,
-        params.get("max_tokens", params.get("max_completion_tokens", -1)),
-    )
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_TOP_P,
-        params.get("top_p", 1.0),
-    )
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY,
-        params.get("frequency_penalty", 0.0),
-    )
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY,
-        params.get("presence_penalty", 0.0),
-    )
-    stop = params.get("stop", params.get("stop_sequences", []))
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
-        stop if isinstance(stop, list) else [stop] if stop else [],
-    )
-    seed_val = params.get("seed")
-    scope._span.set_attribute(
-        SemanticConvention.GEN_AI_REQUEST_SEED,
-        int(seed_val) if seed_val is not None else 0,
-    )
+    for _param_key, _param_attr in [
+        ("temperature", SemanticConvention.GEN_AI_REQUEST_TEMPERATURE),
+        ("top_p", SemanticConvention.GEN_AI_REQUEST_TOP_P),
+        ("frequency_penalty", SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY),
+        ("presence_penalty", SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY),
+    ]:
+        _val = params.get(_param_key)
+        if _val is not None:
+            scope._span.set_attribute(_param_attr, _val)
+
+    _max_tokens = params.get("max_tokens") or params.get("max_completion_tokens")
+    if _max_tokens is not None:
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, _max_tokens
+        )
+
+    _seed_val = params.get("seed")
+    if _seed_val is not None:
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_REQUEST_SEED, int(_seed_val)
+        )
+
+    _stop = params.get("stop") or params.get("stop_sequences")
+    if _stop:
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
+            _stop if isinstance(_stop, list) else [_stop],
+        )
 
     # Span Attributes for Response parameters
     if getattr(scope, "_response_id", None):

--- a/sdk/python/src/openlit/instrumentation/langchain/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/utils.py
@@ -340,11 +340,15 @@ def common_chat_logic(
 
     cost = get_chat_model_cost(request_model, pricing_info, input_tokens, output_tokens)
 
+    provider = (
+        getattr(scope, "_provider", None) or SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN
+    )
+
     # Common Span Attributes
     common_span_attributes(
         scope,
         SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-        SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
+        provider,
         scope._server_address,
         scope._server_port,
         request_model,
@@ -433,7 +437,7 @@ def common_chat_logic(
             SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
+            SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS, ", ".join(filter(None, args))
         )
 
     # Span Attributes for Cost and Tokens
@@ -521,6 +525,7 @@ def common_chat_logic(
                     and scope._system_instructions
                 ):
                     extra["system_instructions"] = scope._system_instructions
+                tool_defs = getattr(scope, "_tool_definitions", None)
                 emit_inference_event(
                     event_provider=event_provider,
                     operation_name=SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
@@ -528,7 +533,7 @@ def common_chat_logic(
                     response_model=scope._response_model,
                     input_messages=input_msgs,
                     output_messages=output_msgs,
-                    tool_definitions=None,
+                    tool_definitions=tool_defs,
                     server_address=scope._server_address,
                     server_port=scope._server_port,
                     **extra,
@@ -544,7 +549,7 @@ def common_chat_logic(
             record_completion_metrics(
                 metrics,
                 SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-                SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN,
+                provider,
                 scope._server_address,
                 scope._server_port,
                 request_model,

--- a/sdk/python/src/openlit/instrumentation/langgraph/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/__init__.py
@@ -50,10 +50,10 @@ EXECUTION_OPERATIONS_ALT = [
 ]
 
 # === GRAPH CONSTRUCTION OPERATIONS (Detailed tracing only) ===
+# graph_init and graph_add_edge are excluded: they produce orphaned spans
+# during graph building that add no monitoring value.
 CONSTRUCTION_OPERATIONS = [
-    ("langgraph.graph.state", "StateGraph.__init__", "graph_init", "sync"),
     ("langgraph.graph.state", "StateGraph.add_node", "graph_add_node", "special"),
-    ("langgraph.graph.state", "StateGraph.add_edge", "graph_add_edge", "sync"),
     ("langgraph.graph.state", "StateGraph.compile", "graph_compile", "special"),
 ]
 

--- a/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/async_langgraph.py
@@ -6,7 +6,14 @@ import time
 import json
 from opentelemetry.trace import SpanKind, Status, StatusCode
 from opentelemetry import context as context_api
-from openlit.__helpers import handle_exception, truncate_content
+from openlit.__helpers import (
+    handle_exception,
+    truncate_content,
+    set_langgraph_wrapper_active,
+    reset_langgraph_wrapper_active,
+    set_langgraph_conversation_id,
+    reset_langgraph_conversation_id,
+)
 from openlit.instrumentation.langgraph.utils import (
     process_langgraph_response,
     OPERATION_MAP,
@@ -16,8 +23,10 @@ from openlit.instrumentation.langgraph.utils import (
     get_message_content,
     get_message_role,
     extract_config_info,
+    _get_graph_name,
     SemanticConvention,
 )
+from openlit.instrumentation.langgraph.langgraph import _LANGGRAPH_SUPPRESS_KEY
 
 
 def async_general_wrap(
@@ -56,8 +65,9 @@ def async_general_wrap(
             """
             Wraps the astream method - returns an async generator wrapper.
             """
-            # Check for suppression
-            if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+            if context_api.get_value(
+                context_api._SUPPRESS_INSTRUMENTATION_KEY
+            ) or context_api.get_value(_LANGGRAPH_SUPPRESS_KEY):
                 return wrapped(*args, **kwargs)
 
             # Get server address and port
@@ -100,8 +110,10 @@ def async_general_wrap(
         """
         Wraps the async LangGraph operation with telemetry.
         """
-        # Check for suppression
-        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+        # Check for OTel-level or LangGraph-level suppression
+        if context_api.get_value(
+            context_api._SUPPRESS_INSTRUMENTATION_KEY
+        ) or context_api.get_value(_LANGGRAPH_SUPPRESS_KEY):
             return await wrapped(*args, **kwargs)
 
         # Get server address and port
@@ -117,12 +129,45 @@ def async_general_wrap(
             operation_type, gen_ai_endpoint, instance, args, kwargs
         )
 
-        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        _WORKFLOW_ENDPOINTS = {
+            "graph_invoke",
+            "graph_ainvoke",
+            "graph_stream",
+            "graph_astream",
+        }
+        span_kind = (
+            SpanKind.INTERNAL
+            if gen_ai_endpoint in _WORKFLOW_ENDPOINTS
+            else SpanKind.CLIENT
+        )
+
+        with tracer.start_as_current_span(span_name, kind=span_kind) as span:
+            if gen_ai_endpoint in _WORKFLOW_ENDPOINTS:
+                graph_name = _get_graph_name(instance)
+                span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, graph_name)
+
             start_time = time.time()
 
+            conv_id_token = None
+            config = kwargs.get("config") or (args[1] if len(args) > 1 else None)
+            if isinstance(config, dict):
+                thread_id = config.get("configurable", {}).get("thread_id")
+                if thread_id:
+                    conv_id_token = set_langgraph_conversation_id(str(thread_id))
+
             try:
-                # Execute the wrapped async function
-                response = await wrapped(*args, **kwargs)
+                # Suppress child LangGraph Pregel wrappers to avoid duplicates
+                suppress_token = context_api.attach(
+                    context_api.set_value(_LANGGRAPH_SUPPRESS_KEY, True)
+                )
+                lg_token = set_langgraph_wrapper_active()
+                try:
+                    response = await wrapped(*args, **kwargs)
+                finally:
+                    reset_langgraph_wrapper_active(lg_token)
+                    context_api.detach(suppress_token)
+                    if conv_id_token is not None:
+                        reset_langgraph_conversation_id(conv_id_token)
 
                 # Process response
                 response = process_langgraph_response(
@@ -174,7 +219,10 @@ async def _create_async_stream_wrapper(
     """
     Creates an async generator wrapper for astream.
     """
-    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+    with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+        graph_name = _get_graph_name(instance)
+        span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, graph_name)
+
         start_time = time.time()
 
         # Set basic attributes
@@ -190,12 +238,12 @@ async def _create_async_stream_wrapper(
         span.set_attribute(SemanticConvention.SERVER_PORT, server_port)
         span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
         span.set_attribute(SemanticConvention.GEN_AI_APPLICATION_NAME, application_name)
-        span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
+        span.set_attribute(SemanticConvention.GEN_AI_EXECUTION_MODE, "stream")
         span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, True)
 
         # Extract stream mode from kwargs
         stream_mode = kwargs.get("stream_mode", "values")
-        span.set_attribute(SemanticConvention.LANGGRAPH_STREAM_MODE, str(stream_mode))
+        span.set_attribute(SemanticConvention.GEN_AI_STREAM_MODE, str(stream_mode))
 
         # Track execution state
         execution_state = {
@@ -227,11 +275,11 @@ async def _create_async_stream_wrapper(
             config_info = extract_config_info(config)
             if config_info.get("thread_id"):
                 span.set_attribute(
-                    SemanticConvention.LANGGRAPH_THREAD_ID, config_info["thread_id"]
+                    SemanticConvention.GEN_AI_CONVERSATION_ID, config_info["thread_id"]
                 )
             if config_info.get("checkpoint_id"):
                 span.set_attribute(
-                    SemanticConvention.LANGGRAPH_CHECKPOINT_ID,
+                    SemanticConvention.GEN_AI_CHECKPOINT_ID,
                     config_info["checkpoint_id"],
                 )
 
@@ -349,23 +397,23 @@ def _finalize_async_stream_span(
 
     # Set execution attributes
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_EXECUTED_NODES,
+        SemanticConvention.GEN_AI_GRAPH_EXECUTED_NODES,
         json.dumps(execution_state["executed_nodes"]),
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_NODE_EXECUTION_COUNT,
+        SemanticConvention.GEN_AI_GRAPH_NODE_EXECUTION_COUNT,
         len(execution_state["executed_nodes"]),
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_MESSAGE_COUNT, execution_state["message_count"]
+        SemanticConvention.GEN_AI_GRAPH_MESSAGE_COUNT, execution_state["message_count"]
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_CHUNK_COUNT, execution_state["chunk_count"]
+        SemanticConvention.GEN_AI_GRAPH_TOTAL_CHUNKS, execution_state["chunk_count"]
     )
 
     if execution_state["final_response"] and capture_message_content:
         span.set_attribute(
-            SemanticConvention.LANGGRAPH_FINAL_RESPONSE,
+            SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
             truncate_content(execution_state["final_response"]),
         )
         span.set_attribute(
@@ -373,7 +421,7 @@ def _finalize_async_stream_span(
             truncate_content(execution_state["final_response"]),
         )
 
-    span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_STATUS, "success")
+    span.set_attribute(SemanticConvention.GEN_AI_GRAPH_STATUS, "success")
     span.set_attribute(
         SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, end_time - start_time
     )
@@ -456,7 +504,7 @@ def async_checkpoint_wrap(
                         config_info = extract_config_info(config)
                         if config_info.get("thread_id"):
                             span.set_attribute(
-                                SemanticConvention.LANGGRAPH_THREAD_ID,
+                                SemanticConvention.GEN_AI_CONVERSATION_ID,
                                 config_info["thread_id"],
                             )
 
@@ -466,7 +514,7 @@ def async_checkpoint_wrap(
                         config_info = extract_config_info(config)
                         if config_info.get("thread_id"):
                             span.set_attribute(
-                                SemanticConvention.LANGGRAPH_THREAD_ID,
+                                SemanticConvention.GEN_AI_CONVERSATION_ID,
                                 config_info["thread_id"],
                             )
 
@@ -475,11 +523,11 @@ def async_checkpoint_wrap(
                         checkpoint = result.checkpoint
                         if checkpoint and hasattr(checkpoint, "id"):
                             span.set_attribute(
-                                SemanticConvention.LANGGRAPH_CHECKPOINT_ID,
+                                SemanticConvention.GEN_AI_CHECKPOINT_ID,
                                 str(checkpoint.id),
                             )
 
-                span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_STATUS, "success")
+                span.set_attribute(SemanticConvention.GEN_AI_GRAPH_STATUS, "success")
                 span.set_status(Status(StatusCode.OK))
 
                 # Record metrics

--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -548,6 +548,9 @@ def wrap_add_node(
 
         # Create wrapped node function for instrumentation
         def create_wrapped_node(original_func, node_name):
+            if getattr(original_func, "_openlit_wrapped", False):
+                return original_func
+
             if inspect.iscoroutinefunction(original_func):
 
                 @wraps(original_func)
@@ -610,6 +613,7 @@ def wrap_add_node(
                             handle_exception(span, e)
                             raise
 
+                wrapped_node_async._openlit_wrapped = True
                 return wrapped_node_async
             else:
 
@@ -671,6 +675,7 @@ def wrap_add_node(
                             handle_exception(span, e)
                             raise
 
+                wrapped_node_sync._openlit_wrapped = True
                 return wrapped_node_sync
 
         # Wrap the action function

--- a/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/langgraph.py
@@ -3,9 +3,17 @@ LangGraph sync wrapper for instrumentation
 """
 
 import time
-from opentelemetry.trace import SpanKind
+from opentelemetry.trace import SpanKind, Link
 from opentelemetry import context as context_api
-from openlit.__helpers import handle_exception, truncate_content
+from openlit.__helpers import (
+    handle_exception,
+    truncate_content,
+    set_langgraph_wrapper_active,
+    reset_langgraph_wrapper_active,
+    set_langgraph_conversation_id,
+    reset_langgraph_conversation_id,
+    get_langgraph_conversation_id,
+)
 from openlit.instrumentation.langgraph.utils import (
     process_langgraph_response,
     OPERATION_MAP,
@@ -15,8 +23,35 @@ from openlit.instrumentation.langgraph.utils import (
     extract_messages_from_input,
     get_message_content,
     get_message_role,
+    _get_graph_name,
     SemanticConvention,
 )
+
+_LANGGRAPH_SUPPRESS_KEY = context_api.create_key("openlit-langgraph-suppress")
+
+
+def _is_tool_node(node_name, action):
+    """Return True if this node is a tool-dispatching node that should NOT
+    be wrapped as invoke_agent. Tool execution is already captured by the
+    LangChain callback handler's execute_tool spans."""
+    if "ToolNode" in type(action).__name__:
+        return True
+    if (
+        hasattr(action, "func")
+        and "ToolNode" in type(getattr(action, "func", None)).__name__
+    ):
+        return True
+    name_lower = node_name.lower()
+    if "tool" in name_lower and "agent" not in name_lower:
+        return True
+    return False
+
+
+def _set_node_conv_id(span):
+    """Set gen_ai.conversation.id from the ContextVar propagated by invoke_workflow."""
+    conv_id = get_langgraph_conversation_id()
+    if conv_id:
+        span.set_attribute(SemanticConvention.GEN_AI_CONVERSATION_ID, conv_id)
 
 
 def general_wrap(
@@ -52,8 +87,10 @@ def general_wrap(
         """
         Wraps the LangGraph operation with telemetry.
         """
-        # Check for suppression
-        if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
+        # Check for OTel-level or LangGraph-level suppression
+        if context_api.get_value(
+            context_api._SUPPRESS_INSTRUMENTATION_KEY
+        ) or context_api.get_value(_LANGGRAPH_SUPPRESS_KEY):
             return wrapped(*args, **kwargs)
 
         # Get server address and port
@@ -90,12 +127,51 @@ def general_wrap(
                 gen_ai_endpoint,
             )
 
-        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        links = []
+        creation_ctx = getattr(instance, "_openlit_creation_context", None)
+        if creation_ctx:
+            links.append(Link(creation_ctx))
+
+        _WORKFLOW_ENDPOINTS = {
+            "graph_invoke",
+            "graph_ainvoke",
+            "graph_stream",
+            "graph_astream",
+        }
+        span_kind = (
+            SpanKind.INTERNAL
+            if gen_ai_endpoint in _WORKFLOW_ENDPOINTS
+            else SpanKind.CLIENT
+        )
+
+        with tracer.start_as_current_span(
+            span_name, kind=span_kind, links=links
+        ) as span:
+            if gen_ai_endpoint in _WORKFLOW_ENDPOINTS:
+                graph_name = _get_graph_name(instance)
+                span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, graph_name)
+
             start_time = time.time()
 
+            conv_id_token = None
+            config = kwargs.get("config") or (args[1] if len(args) > 1 else None)
+            if isinstance(config, dict):
+                thread_id = config.get("configurable", {}).get("thread_id")
+                if thread_id:
+                    conv_id_token = set_langgraph_conversation_id(str(thread_id))
+
             try:
-                # Execute the wrapped function
-                response = wrapped(*args, **kwargs)
+                suppress_token = context_api.attach(
+                    context_api.set_value(_LANGGRAPH_SUPPRESS_KEY, True)
+                )
+                lg_token = set_langgraph_wrapper_active()
+                try:
+                    response = wrapped(*args, **kwargs)
+                finally:
+                    reset_langgraph_wrapper_active(lg_token)
+                    context_api.detach(suppress_token)
+                    if conv_id_token is not None:
+                        reset_langgraph_conversation_id(conv_id_token)
 
                 # Process response
                 response = process_langgraph_response(
@@ -152,7 +228,17 @@ def _handle_stream(
     """
 
     def stream_wrapper():
-        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        links = []
+        creation_ctx = getattr(instance, "_openlit_creation_context", None)
+        if creation_ctx:
+            links.append(Link(creation_ctx))
+
+        with tracer.start_as_current_span(
+            span_name, kind=SpanKind.INTERNAL, links=links
+        ) as span:
+            graph_name = _get_graph_name(instance)
+            span.set_attribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, graph_name)
+
             start_time = time.time()
 
             span.set_attribute("telemetry.sdk.name", "openlit")
@@ -169,7 +255,7 @@ def _handle_stream(
                 SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
             )
             span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_type)
-            span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
+            span.set_attribute(SemanticConvention.GEN_AI_EXECUTION_MODE, "stream")
             span.set_attribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, True)
 
             # Track execution state
@@ -293,23 +379,23 @@ def _finalize_stream_span(span, execution_state, capture_message_content, start_
 
     # Set execution attributes
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_EXECUTED_NODES,
+        SemanticConvention.GEN_AI_GRAPH_EXECUTED_NODES,
         json.dumps(execution_state["executed_nodes"]),
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_NODE_EXECUTION_COUNT,
+        SemanticConvention.GEN_AI_GRAPH_NODE_EXECUTION_COUNT,
         len(execution_state["executed_nodes"]),
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_MESSAGE_COUNT, execution_state["message_count"]
+        SemanticConvention.GEN_AI_GRAPH_MESSAGE_COUNT, execution_state["message_count"]
     )
     span.set_attribute(
-        SemanticConvention.LANGGRAPH_CHUNK_COUNT, execution_state["chunk_count"]
+        SemanticConvention.GEN_AI_GRAPH_TOTAL_CHUNKS, execution_state["chunk_count"]
     )
 
     if execution_state["final_response"] and capture_message_content:
         span.set_attribute(
-            SemanticConvention.LANGGRAPH_FINAL_RESPONSE,
+            SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
             truncate_content(execution_state["final_response"]),
         )
         span.set_attribute(
@@ -317,7 +403,7 @@ def _finalize_stream_span(span, execution_state, capture_message_content, start_
             truncate_content(execution_state["final_response"]),
         )
 
-    span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_STATUS, "success")
+    span.set_attribute(SemanticConvention.GEN_AI_GRAPH_STATUS, "success")
     span.set_attribute(
         SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, end_time - start_time
     )
@@ -336,29 +422,35 @@ def wrap_compile(
     disable_metrics,
 ):
     """
-    Special wrapper for StateGraph.compile that captures graph structure.
+    Special wrapper for StateGraph.compile that emits a create_agent span.
+
+    If a create_agent span is already active (e.g. from _wrap_create_agent in
+    the LangChain instrumentor), compile is passed through without a span to
+    avoid duplication.
     """
+    import json
+    from openlit.__helpers import is_create_agent_active
 
     def wrapper(wrapped, instance, args, kwargs):
         if context_api.get_value(context_api._SUPPRESS_INSTRUMENTATION_KEY):
             return wrapped(*args, **kwargs)
 
-        server_address, server_port = set_server_address_and_port(instance)
-        operation_type = OPERATION_MAP.get(
-            gen_ai_endpoint, SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK
-        )
-        span_name = generate_span_name(
-            operation_type, gen_ai_endpoint, instance, args, kwargs
-        )
+        if is_create_agent_active():
+            return wrapped(*args, **kwargs)
 
-        with tracer.start_as_current_span(span_name, kind=SpanKind.INTERNAL) as span:
+        # Derive agent name from the graph instance
+        graph_name = _get_graph_name(instance)
+        agent_name = "default" if graph_name in ("graph", "LangGraph") else graph_name
+
+        span_name = f"create_agent {agent_name}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
             start_time = time.time()
 
             try:
-                # Execute compile
                 result = wrapped(*args, **kwargs)
 
-                # Extract graph structure from instance (StateGraph)
+                # Extract graph structure for agent attributes
                 nodes = []
                 edges = []
 
@@ -376,35 +468,42 @@ def wrap_compile(
                             if isinstance(edge, tuple) and len(edge) >= 2:
                                 edges.append(f"{edge[0]}->{edge[1]}")
 
-                # Set graph attributes
                 set_graph_attributes(span, nodes, edges)
 
-                # Set common attributes
-                from openlit.__helpers import common_framework_span_attributes
-
-                scope = type("GenericScope", (), {})()
-                scope._span = span
-                scope._start_time = start_time
-                scope._end_time = time.time()
-
-                common_framework_span_attributes(
-                    scope,
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_OPERATION,
+                    SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+                )
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_PROVIDER_NAME,
                     SemanticConvention.GEN_AI_SYSTEM_LANGGRAPH,
-                    server_address,
-                    server_port,
-                    environment,
-                    application_name,
-                    version,
-                    gen_ai_endpoint,
-                    instance,
+                )
+                span.set_attribute(SemanticConvention.GEN_AI_AGENT_NAME, agent_name)
+                span.set_attribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment)
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+                )
+                span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, version)
+
+                if nodes:
+                    span.set_attribute("gen_ai.agent.tools", json.dumps(nodes))
+                    description = f"Agent with nodes: {', '.join(nodes)}"
+                else:
+                    description = "LangGraph agent"
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_AGENT_DESCRIPTION, description
                 )
 
-                span.set_attribute(SemanticConvention.GEN_AI_OPERATION, operation_type)
-                span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_STATUS, "success")
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION,
+                    time.time() - start_time,
+                )
 
                 from opentelemetry.trace import Status, StatusCode
 
                 span.set_status(Status(StatusCode.OK))
+
+                result._openlit_creation_context = span.get_span_context()
 
                 return result
 
@@ -470,13 +569,20 @@ def wrap_add_node(
                             SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
                         )
                         span.set_attribute(
-                            SemanticConvention.LANGGRAPH_NODE_NAME, node_name
+                            SemanticConvention.GEN_AI_AGENT_NAME, node_name
                         )
                         span.set_attribute(
                             SemanticConvention.GEN_AI_ENVIRONMENT, environment
                         )
                         span.set_attribute(
                             SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+                        )
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_SDK_VERSION, version
+                        )
+                        _set_node_conv_id(span)
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_OUTPUT_TYPE, "text"
                         )
 
                         try:
@@ -526,13 +632,20 @@ def wrap_add_node(
                             SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
                         )
                         span.set_attribute(
-                            SemanticConvention.LANGGRAPH_NODE_NAME, node_name
+                            SemanticConvention.GEN_AI_AGENT_NAME, node_name
                         )
                         span.set_attribute(
                             SemanticConvention.GEN_AI_ENVIRONMENT, environment
                         )
                         span.set_attribute(
                             SemanticConvention.GEN_AI_APPLICATION_NAME, application_name
+                        )
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_SDK_VERSION, version
+                        )
+                        _set_node_conv_id(span)
+                        span.set_attribute(
+                            SemanticConvention.GEN_AI_OUTPUT_TYPE, "text"
                         )
 
                         try:
@@ -563,10 +676,19 @@ def wrap_add_node(
         # Wrap the action function
         node_name = str(node_key) if not isinstance(node_key, str) else node_key
 
-        # FIX: Check if action is a function/routine.
-        # If it is a class instance (like ToolNode), do NOT wrap it.
-        if inspect.isroutine(action):
+        if _is_tool_node(node_name, action):
+            wrapped_action = action
+        elif inspect.isroutine(action):
             wrapped_action = create_wrapped_node(action, node_name)
+        elif hasattr(action, "func") and inspect.isroutine(
+            getattr(action, "func", None)
+        ):
+            action.func = create_wrapped_node(action.func, node_name)
+            if hasattr(action, "afunc") and inspect.isroutine(
+                getattr(action, "afunc", None)
+            ):
+                action.afunc = create_wrapped_node(action.afunc, node_name)
+            wrapped_action = action
         else:
             wrapped_action = action
 

--- a/sdk/python/src/openlit/instrumentation/langgraph/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/utils.py
@@ -15,7 +15,7 @@ OPERATION_MAP = {
     "graph_init": SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
     "graph_add_node": SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
     "graph_add_edge": SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
-    "graph_compile": SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
+    "graph_compile": SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
     # Graph Execution Operations
     "graph_invoke": SemanticConvention.GEN_AI_OPERATION_TYPE_GRAPH_EXECUTION,
     "graph_ainvoke": SemanticConvention.GEN_AI_OPERATION_TYPE_GRAPH_EXECUTION,
@@ -159,12 +159,12 @@ def set_graph_attributes(span, nodes=None, edges=None):
     """
     if nodes:
         span.set_attribute(
-            SemanticConvention.LANGGRAPH_GRAPH_NODES, json.dumps(list(nodes))
+            SemanticConvention.GEN_AI_GRAPH_NODES, json.dumps(list(nodes))
         )
-        span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_NODE_COUNT, len(nodes))
+        span.set_attribute(SemanticConvention.GEN_AI_GRAPH_NODE_COUNT, len(nodes))
         # Set individual node names
         for i, node in enumerate(list(nodes)[:10]):  # Limit to first 10
-            span.set_attribute(f"langgraph.node.{i}.name", str(node))
+            span.set_attribute(f"gen_ai.graph.node.{i}.name", str(node))
 
     if edges:
         edge_list = []
@@ -174,18 +174,14 @@ def set_graph_attributes(span, nodes=None, edges=None):
             elif isinstance(edge, str):
                 edge_list.append(edge)
 
-        span.set_attribute(
-            SemanticConvention.LANGGRAPH_GRAPH_EDGES, json.dumps(edge_list)
-        )
-        span.set_attribute(
-            SemanticConvention.LANGGRAPH_GRAPH_EDGE_COUNT, len(edge_list)
-        )
+        span.set_attribute(SemanticConvention.GEN_AI_GRAPH_EDGES, json.dumps(edge_list))
+        span.set_attribute(SemanticConvention.GEN_AI_GRAPH_EDGE_COUNT, len(edge_list))
         # Set individual edge info
         for i, edge in enumerate(edge_list[:10]):  # Limit to first 10
             parts = edge.split("->")
             if len(parts) == 2:
-                span.set_attribute(f"langgraph.edge.{i}.source", parts[0])
-                span.set_attribute(f"langgraph.edge.{i}.target", parts[1])
+                span.set_attribute(f"gen_ai.graph.edge.{i}.source", parts[0])
+                span.set_attribute(f"gen_ai.graph.edge.{i}.target", parts[1])
 
 
 def extract_llm_info_from_result(span, state, result):
@@ -198,18 +194,25 @@ def extract_llm_info_from_result(span, state, result):
         result: Result from node execution
     """
     try:
-        # Extract messages from state for context
+        # Extract messages from state as OTel-compliant gen_ai.input.messages
         if isinstance(state, dict) and "messages" in state:
             messages = state["messages"]
-            # Set prompt content from last few messages
-            for i, msg in enumerate(messages[-3:]):
+            input_msgs = []
+            for msg in messages[-3:]:
                 content = get_message_content(msg)
                 role = get_message_role(msg)
                 if content:
-                    span.set_attribute(
-                        f"gen_ai.prompt.{i}.content", truncate_content(content)
+                    input_msgs.append(
+                        {
+                            "role": role,
+                            "content": truncate_content(content),
+                        }
                     )
-                    span.set_attribute(f"gen_ai.prompt.{i}.role", role)
+            if input_msgs:
+                span.set_attribute(
+                    SemanticConvention.GEN_AI_INPUT_MESSAGES,
+                    json.dumps(input_msgs),
+                )
 
         # Extract from result
         if isinstance(result, dict) and "messages" in result:
@@ -268,13 +271,16 @@ def extract_llm_info_from_result(span, state, result):
                                 SemanticConvention.GEN_AI_RESPONSE_ID, metadata["id"]
                             )
 
-                # Extract content
                 if hasattr(last_msg, "content"):
                     content = get_message_content(last_msg)
+                    role = get_message_role(last_msg)
                     if content:
+                        otel_msg = [
+                            {"role": role, "content": truncate_content(content)}
+                        ]
                         span.set_attribute(
                             SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
-                            truncate_content(content),
+                            json.dumps(otel_msg),
                         )
 
                 # Extract usage_metadata (alternative location)
@@ -390,14 +396,16 @@ def generate_span_name(operation_type, endpoint, instance=None, args=None, kwarg
 
     # State operations
     elif endpoint in ("graph_get_state", "graph_aget_state"):
-        return "retrieve graph_state"
+        return "retrieval graph_state"
 
     # Graph construction
     elif endpoint == "graph_init":
         return f"{operation_type} graph_init"
 
     elif endpoint == "graph_compile":
-        return f"{operation_type} graph_compile"
+        graph_name = _get_graph_name(instance)
+        agent_name = "default" if graph_name in ("graph", "LangGraph") else graph_name
+        return f"create_agent {agent_name}"
 
     elif endpoint == "graph_add_node":
         node_name = args[0] if args else "node"
@@ -419,7 +427,7 @@ def generate_span_name(operation_type, endpoint, instance=None, args=None, kwarg
         return f"{operation_type} checkpoint_write"
 
     elif endpoint == "checkpoint_read":
-        return "retrieve checkpoint"
+        return "retrieval checkpoint"
 
     # Default
     return f"{operation_type} {endpoint}"
@@ -521,9 +529,9 @@ def process_langgraph_response(
 
     # Set execution mode
     if endpoint in ("graph_invoke", "graph_ainvoke"):
-        span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "invoke")
+        span.set_attribute(SemanticConvention.GEN_AI_EXECUTION_MODE, "invoke")
     elif endpoint in ("graph_stream", "graph_astream"):
-        span.set_attribute(SemanticConvention.LANGGRAPH_EXECUTION_MODE, "stream")
+        span.set_attribute(SemanticConvention.GEN_AI_EXECUTION_MODE, "stream")
 
     # Extract config information
     config = kwargs.get("config") or (args[1] if len(args) > 1 else None)
@@ -531,11 +539,11 @@ def process_langgraph_response(
         config_info = extract_config_info(config)
         if config_info.get("thread_id"):
             span.set_attribute(
-                SemanticConvention.LANGGRAPH_THREAD_ID, config_info["thread_id"]
+                SemanticConvention.GEN_AI_CONVERSATION_ID, config_info["thread_id"]
             )
         if config_info.get("checkpoint_id"):
             span.set_attribute(
-                SemanticConvention.LANGGRAPH_CHECKPOINT_ID, config_info["checkpoint_id"]
+                SemanticConvention.GEN_AI_CHECKPOINT_ID, config_info["checkpoint_id"]
             )
 
     # Process response based on type
@@ -547,7 +555,7 @@ def process_langgraph_response(
         _process_compile_response(span, instance, response)
 
     # Set success status
-    span.set_attribute(SemanticConvention.LANGGRAPH_GRAPH_STATUS, "success")
+    span.set_attribute(SemanticConvention.GEN_AI_GRAPH_STATUS, "success")
     span.set_status(Status(StatusCode.OK))
 
     # Record metrics
@@ -567,28 +575,27 @@ def _process_invoke_response(span, response, capture_message_content):
     """Process invoke/ainvoke response."""
     try:
         if isinstance(response, dict):
-            # Extract messages
             messages = extract_messages_from_output(response)
             if messages:
                 span.set_attribute(
-                    SemanticConvention.LANGGRAPH_MESSAGE_COUNT, len(messages)
+                    SemanticConvention.GEN_AI_GRAPH_MESSAGE_COUNT, len(messages)
                 )
 
-                # Get final response content
-                if messages:
-                    last_msg = messages[-1] if isinstance(messages, list) else messages
-                    content = get_message_content(last_msg)
-                    if content and capture_message_content:
-                        span.set_attribute(
-                            SemanticConvention.LANGGRAPH_FINAL_RESPONSE,
-                            truncate_content(content),
-                        )
+                if capture_message_content:
+                    otel_msgs = []
+                    for msg in messages:
+                        content = get_message_content(msg)
+                        role = get_message_role(msg)
+                        entry = {"role": role}
+                        if content:
+                            entry["content"] = truncate_content(content)
+                        otel_msgs.append(entry)
+                    if otel_msgs:
                         span.set_attribute(
                             SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
-                            truncate_content(content),
+                            json.dumps(otel_msgs),
                         )
 
-            # Try to extract LLM info
             extract_llm_info_from_result(span, {}, response)
 
     except Exception:
@@ -602,14 +609,15 @@ def _process_state_response(span, response):
             values = response.values
             if isinstance(values, dict) and "messages" in values:
                 span.set_attribute(
-                    SemanticConvention.LANGGRAPH_MESSAGE_COUNT, len(values["messages"])
+                    SemanticConvention.GEN_AI_GRAPH_MESSAGE_COUNT,
+                    len(values["messages"]),
                 )
 
         if hasattr(response, "next"):
             next_nodes = response.next
             if next_nodes:
                 span.set_attribute(
-                    "langgraph.state.next_nodes", json.dumps(list(next_nodes))
+                    "gen_ai.graph.next_nodes", json.dumps(list(next_nodes))
                 )
 
     except Exception:

--- a/sdk/python/src/openlit/instrumentation/langgraph/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/utils.py
@@ -5,7 +5,11 @@ LangGraph utilities for comprehensive telemetry processing and business intellig
 import time
 import json
 from opentelemetry.trace import Status, StatusCode
-from openlit.__helpers import common_framework_span_attributes, truncate_content
+from openlit.__helpers import (
+    common_framework_span_attributes,
+    truncate_content,
+    get_server_address_for_provider,
+)
 from openlit.semcov import SemanticConvention
 
 
@@ -33,21 +37,23 @@ OPERATION_MAP = {
 }
 
 
-def set_server_address_and_port(instance):
+def set_server_address_and_port(instance, provider_name=None):
     """
     Extract server information from LangGraph instance.
 
+    Falls back to the universal provider-to-endpoint map when no instance-
+    level URL is found.
+
     Args:
         instance: LangGraph instance (StateGraph, CompiledGraph, etc.)
+        provider_name: Optional provider string for universal lookup
 
     Returns:
         tuple: (server_address, server_port)
     """
-    server_address = "localhost"
-    server_port = 8080
+    server_address = ""
+    server_port = 0
 
-    # LangGraph doesn't have a direct server, but we can try to
-    # extract checkpointer connection info if available
     try:
         if hasattr(instance, "checkpointer"):
             checkpointer = instance.checkpointer
@@ -55,10 +61,13 @@ def set_server_address_and_port(instance):
                 conn = checkpointer.conn
                 if hasattr(conn, "info"):
                     info = conn.info
-                    server_address = info.host or "localhost"
+                    server_address = info.host or ""
                     server_port = info.port or 5432
     except Exception:
         pass
+
+    if not server_address and provider_name:
+        server_address, server_port = get_server_address_for_provider(provider_name)
 
     return server_address, server_port
 

--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -9,6 +9,7 @@ from openlit.__helpers import (
     record_completion_metrics,
     record_embedding_metrics,
     set_server_address_and_port,
+    is_framework_llm_active,
 )
 from openlit.instrumentation.openai.utils import (
     process_chat_chunk,
@@ -115,6 +116,9 @@ def async_chat_completions(
         """
         Wraps the OpenAI async chat completions call.
         """
+
+        if is_framework_llm_active():
+            return await wrapped(*args, **kwargs)
 
         streaming = kwargs.get("stream", False)
         server_address, server_port = set_server_address_and_port(

--- a/sdk/python/src/openlit/instrumentation/openai/openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/openai.py
@@ -9,6 +9,7 @@ from openlit.__helpers import (
     set_server_address_and_port,
     record_completion_metrics,
     record_embedding_metrics,
+    is_framework_llm_active,
 )
 from openlit.instrumentation.openai.utils import (
     process_chat_chunk,
@@ -115,6 +116,9 @@ def chat_completions(
         """
         Wraps the OpenAI chat completions call.
         """
+
+        if is_framework_llm_active():
+            return wrapped(*args, **kwargs)
 
         streaming = kwargs.get("stream", False)
         server_address, server_port = set_server_address_and_port(

--- a/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
+++ b/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
@@ -198,8 +198,8 @@ class OpenLITTracingProcessor(TracingProcessor):
             return f"invoke_agent {target_agent}"
         if "workflow" in operation_name.lower():
             if workflow_name:
-                return f"workflow {workflow_name}"
-            return "workflow"
+                return f"invoke_workflow {workflow_name}"
+            return "invoke_workflow"
 
         # Default case
         return operation_name

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -131,6 +131,42 @@ class SemanticConvention:
     GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
     GEN_AI_TOOL_DEFINITIONS = "gen_ai.tool.definitions"
 
+    # GenAI Tool Attributes (OTel Semconv)
+    GEN_AI_TOOL_NAME = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_NAME", "gen_ai.tool.name"
+    )
+    GEN_AI_TOOL_TYPE = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_TYPE", "gen_ai.tool.type"
+    )
+    GEN_AI_TOOL_DESCRIPTION = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_DESCRIPTION", "gen_ai.tool.description"
+    )
+    GEN_AI_TOOL_CALL_ID = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_CALL_ID", "gen_ai.tool.call.id"
+    )
+    GEN_AI_TOOL_CALL_ARGUMENTS = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_CALL_ARGUMENTS", "gen_ai.tool.call.arguments"
+    )
+    GEN_AI_TOOL_CALL_RESULT = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_TOOL_CALL_RESULT", "gen_ai.tool.call.result"
+    )
+
+    # GenAI Retrieval Attributes (OTel Semconv)
+    GEN_AI_DATA_SOURCE_ID = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_DATA_SOURCE_ID", "gen_ai.data_source.id"
+    )
+    GEN_AI_RETRIEVAL_QUERY_TEXT = _get_otel_attr(
+        OTelGenAIAttributes,
+        "GEN_AI_RETRIEVAL_QUERY_TEXT",
+        "gen_ai.retrieval.query.text",
+    )
+    GEN_AI_RETRIEVAL_DOCUMENTS = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_RETRIEVAL_DOCUMENTS", "gen_ai.retrieval.documents"
+    )
+
+    # GenAI Workflow Attributes (OTel Semconv - not yet in Python library, but in spec)
+    GEN_AI_WORKFLOW_NAME = "gen_ai.workflow.name"
+
     # GenAI Request Attributes (OTel Semconv)
     GEN_AI_OPERATION = _get_otel_attr(
         OTelGenAIAttributes, "GEN_AI_OPERATION_NAME", "gen_ai.operation.name"
@@ -226,12 +262,12 @@ class SemanticConvention:
     GEN_AI_OPERATION_TYPE_LANGUAGE_IDENTIFICATION = "language_identification"
     GEN_AI_OPERATION_TYPE_SPEECH_TO_TEXT_TRANSLATE = "speech_to_text_translate"
     GEN_AI_OPERATION_TYPE_VECTORDB = "vectordb"
-    GEN_AI_OPERATION_TYPE_FRAMEWORK = "workflow"
+    GEN_AI_OPERATION_TYPE_FRAMEWORK = "invoke_workflow"
     GEN_AI_OPERATION_TYPE_AGENT = "invoke_agent"
     GEN_AI_OPERATION_TYPE_TEAM = "team"
     GEN_AI_OPERATION_TYPE_CREATE_AGENT = "create_agent"
     GEN_AI_OPERATION_TYPE_EXECUTE_AGENT_TASK = "execute_task"
-    GEN_AI_OPERATION_TYPE_GRAPH_EXECUTION = "graph_execution"
+    GEN_AI_OPERATION_TYPE_GRAPH_EXECUTION = "invoke_workflow"
     GEN_AI_OPERATION_TYPE_USER_PROMPT_PROCESSING = "user_prompt_processing"
     GEN_AI_OPERATION_TYPE_MODEL_REQUEST = "model_request"
     GEN_AI_OPERATION_TYPE_TOOL_COORDINATION = "tool_coordination"
@@ -249,7 +285,7 @@ class SemanticConvention:
     # Tool Processing Types
     GEN_AI_TOOL_PROCESSING_TYPE_EXECUTION = "execution"
     GEN_AI_TOOL_PROCESSING_TYPE_COORDINATION = "coordination"
-    GEN_AI_OPERATION_TYPE_RETRIEVE = "retrieve"
+    GEN_AI_OPERATION_TYPE_RETRIEVE = "retrieval"
 
     # GenAI Output Types (OTel Semconv)
     GEN_AI_OUTPUT_TYPE_IMAGE = "image"
@@ -322,22 +358,19 @@ class SemanticConvention:
     GEN_AI_SYSTEM_BROWSER_USE = "browser_use"
     GEN_AI_SYSTEM_LANGGRAPH = "langgraph"
 
-    # LangGraph-specific Attributes
-    LANGGRAPH_GRAPH_NODES = "langgraph.graph.nodes"
-    LANGGRAPH_GRAPH_NODE_COUNT = "langgraph.graph.node_count"
-    LANGGRAPH_GRAPH_EDGES = "langgraph.graph.edges"
-    LANGGRAPH_GRAPH_EDGE_COUNT = "langgraph.graph.edge_count"
-    LANGGRAPH_EXECUTION_MODE = "langgraph.execution.mode"
-    LANGGRAPH_EXECUTED_NODES = "langgraph.graph.executed_nodes"
-    LANGGRAPH_NODE_EXECUTION_COUNT = "langgraph.graph.node_execution_count"
-    LANGGRAPH_MESSAGE_COUNT = "langgraph.graph.message_count"
-    LANGGRAPH_CHUNK_COUNT = "langgraph.graph.total_chunks"
-    LANGGRAPH_FINAL_RESPONSE = "langgraph.graph.final_response"
-    LANGGRAPH_NODE_NAME = "langgraph.node.name"
-    LANGGRAPH_GRAPH_STATUS = "langgraph.graph.status"
-    LANGGRAPH_THREAD_ID = "langgraph.thread.id"
-    LANGGRAPH_CHECKPOINT_ID = "langgraph.checkpoint.id"
-    LANGGRAPH_STREAM_MODE = "langgraph.stream.mode"
+    # Graph Execution Attributes (framework-agnostic, usable across LangGraph, CrewAI, etc.)
+    GEN_AI_GRAPH_NODES = "gen_ai.graph.nodes"
+    GEN_AI_GRAPH_NODE_COUNT = "gen_ai.graph.node_count"
+    GEN_AI_GRAPH_EDGES = "gen_ai.graph.edges"
+    GEN_AI_GRAPH_EDGE_COUNT = "gen_ai.graph.edge_count"
+    GEN_AI_EXECUTION_MODE = "gen_ai.execution.mode"
+    GEN_AI_GRAPH_EXECUTED_NODES = "gen_ai.graph.executed_nodes"
+    GEN_AI_GRAPH_NODE_EXECUTION_COUNT = "gen_ai.graph.node_execution_count"
+    GEN_AI_GRAPH_MESSAGE_COUNT = "gen_ai.graph.message_count"
+    GEN_AI_GRAPH_TOTAL_CHUNKS = "gen_ai.graph.total_chunks"
+    GEN_AI_GRAPH_STATUS = "gen_ai.graph.status"
+    GEN_AI_CHECKPOINT_ID = "gen_ai.checkpoint.id"
+    GEN_AI_STREAM_MODE = "gen_ai.stream.mode"
 
     # GenAI Framework Component Attributes (Standard)
     GEN_AI_FRAMEWORK_COMPONENT_NAME = "gen_ai.framework.component.name"
@@ -488,22 +521,19 @@ class SemanticConvention:
     GEN_AI_CONTENT_REVISED_PROMPT = "gen_ai.content.revised_prompt"
     GEN_AI_CONTENT_REASONING = "gen_ai.content.reasoning"
 
-    # Tool Attributes (LangChain/Framework Support)
+    # Tool Attributes (Legacy aliases - use GEN_AI_TOOL_CALL_ARGUMENTS/RESULT from Tier 1 instead)
     GEN_AI_TOOL_INPUT = "gen_ai.tool.input"
     GEN_AI_TOOL_OUTPUT = "gen_ai.tool.output"
-    GEN_AI_TOOL_NAME = "gen_ai.tool.name"
-    GEN_AI_TOOL_CALL_ID = "gen_ai.tool.call.id"
     GEN_AI_TOOL_ARGS = "gen_ai.tool.args"
 
-    # Retrieval Attributes (LangChain Retriever Support)
+    # Retrieval Attributes (Legacy aliases - use GEN_AI_RETRIEVAL_QUERY_TEXT/GEN_AI_RETRIEVAL_DOCUMENTS from Tier 1)
     GEN_AI_RETRIEVAL_QUERY = "gen_ai.retrieval.query"
-    GEN_AI_RETRIEVAL_DOCUMENTS = "gen_ai.retrieval.documents"
     GEN_AI_RETRIEVAL_DOCUMENT_COUNT = "gen_ai.retrieval.document_count"
 
-    # Workflow Attributes (LangChain Chain Support)
+    # Workflow Attributes (LangChain Chain Support - legacy; use GEN_AI_WORKFLOW_NAME from Tier 1)
     GEN_AI_WORKFLOW_INPUT = "gen_ai.workflow.input"
     GEN_AI_WORKFLOW_OUTPUT = "gen_ai.workflow.output"
-    GEN_AI_WORKFLOW_TYPE = "gen_ai.workflow.type"
+    GEN_AI_WORKFLOW_TYPE = "gen_ai.workflow.type"  # Legacy: use GEN_AI_WORKFLOW_NAME
 
     # Framework Attributes (Enhanced Observability)
     GEN_AI_FRAMEWORK_TAGS = "gen_ai.framework.tags"
@@ -644,10 +674,19 @@ class SemanticConvention:
     DB_POSTGRESQL_ROWS_AFFECTED = "db.postgresql.rows_affected"
     DB_POSTGRESQL_PLAN = "db.postgresql.plan"
 
-    # GenAI Request Attributes (OTel Semconv)
-    GEN_AI_AGENT_ID = "gen_ai.agent.id"
-    GEN_AI_AGENT_NAME = "gen_ai.agent.name"
-    GEN_AI_AGENT_DESCRIPTION = "gen_ai.agent.description"
+    # GenAI Agent Attributes (OTel Semconv)
+    GEN_AI_AGENT_ID = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_AGENT_ID", "gen_ai.agent.id"
+    )
+    GEN_AI_AGENT_NAME = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_AGENT_NAME", "gen_ai.agent.name"
+    )
+    GEN_AI_AGENT_DESCRIPTION = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_AGENT_DESCRIPTION", "gen_ai.agent.description"
+    )
+    GEN_AI_AGENT_VERSION = _get_otel_attr(
+        OTelGenAIAttributes, "GEN_AI_AGENT_VERSION", "gen_ai.agent.version"
+    )
 
     GEN_AI_AGENT_TYPE = "gen_ai.agent.type"
     GEN_AI_AGENT_TASK_ID = "gen_ai.agent.task.id"
@@ -845,7 +884,6 @@ class SemanticConvention:
 
     # Browser-Use Agent Specific Attributes
     GEN_AI_AGENT_MAX_STEPS = "gen_ai.agent.max_steps"
-    GEN_AI_AGENT_ID = "gen_ai.agent.id"
     GEN_AI_AGENT_TASK_ID = "gen_ai.agent.task_id"
     GEN_AI_AGENT_SESSION_ID = "gen_ai.agent.session_id"
     GEN_AI_AGENT_USE_VISION = "gen_ai.agent.use_vision"
@@ -1012,25 +1050,11 @@ class SemanticConvention:
     GEN_AI_FRAMEWORK_ERROR_TYPE = "gen_ai.framework.error.type"
     GEN_AI_FRAMEWORK_ERROR_MESSAGE = "gen_ai.framework.error.message"
 
-    # Workflow attributes (general, reusable)
-    GEN_AI_WORKFLOW_TYPE = "gen_ai.workflow.type"
-    GEN_AI_WORKFLOW_INPUT = "gen_ai.workflow.input"
-    GEN_AI_WORKFLOW_OUTPUT = "gen_ai.workflow.output"
-
     # Serialized function information (general, reusable)
     GEN_AI_SERIALIZED_NAME = "gen_ai.serialized.name"
     GEN_AI_SERIALIZED_SIGNATURE = "gen_ai.serialized.signature"
     GEN_AI_SERIALIZED_DOC = "gen_ai.serialized.doc"
     GEN_AI_SERIALIZED_MODULE = "gen_ai.serialized.module"
-
-    # Tool operation attributes (general, reusable)
-    GEN_AI_TOOL_INPUT = "gen_ai.tool.input"
-    GEN_AI_TOOL_OUTPUT = "gen_ai.tool.output"
-
-    # Retrieval operation attributes (general, reusable)
-    GEN_AI_RETRIEVAL_QUERY = "gen_ai.retrieval.query"
-    GEN_AI_RETRIEVAL_DOCUMENT_COUNT = "gen_ai.retrieval.document_count"
-    GEN_AI_RETRIEVAL_DOCUMENTS = "gen_ai.retrieval.documents"
 
     # Provider information (general, reusable)
     GEN_AI_REQUEST_PROVIDER = "gen_ai.request.provider"
@@ -1053,7 +1077,6 @@ class SemanticConvention:
     # These are framework-agnostic and reusable across all agent frameworks
 
     # OpenAI Agent-specific Attributes (for any framework using OpenAI models)
-    GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
     GEN_AI_OPENAI_ASSISTANT_ID = "gen_ai.openai.assistant.id"
     GEN_AI_OPENAI_THREAD_ID = "gen_ai.openai.thread.id"
     GEN_AI_OPENAI_RUN_ID = "gen_ai.openai.run.id"
@@ -1064,11 +1087,7 @@ class SemanticConvention:
     )
 
     # Data Source Attributes (for RAG and knowledge retrieval)
-    GEN_AI_DATA_SOURCE_ID = "gen_ai.data_source.id"
     GEN_AI_DATA_SOURCE_TYPE = "gen_ai.data_source.type"
-
-    # Standard Tool Attributes (framework-agnostic)
-    GEN_AI_TOOL_TYPE = "gen_ai.tool.type"
 
     # Standard Workflow Attributes (framework-agnostic)
     GEN_AI_WORKFLOW_AGENT_COUNT = "gen_ai.workflow.agent_count"
@@ -1185,7 +1204,6 @@ class SemanticConvention:
     # Reuse existing: GEN_AI_REQUEST_USER, GEN_AI_SESSION_ID, GEN_AI_REQUEST_IS_STREAM
 
     # Tool execution attributes (only truly new ones)
-    GEN_AI_TOOL_DESCRIPTION = "gen_ai.tool.description"
     GEN_AI_TOOL_PARAMETERS = "gen_ai.tool.parameters"
     GEN_AI_TOOL_INPUT_KWARGS = "gen_ai.tool.input_kwargs"
     GEN_AI_TOOL_OUTPUT_TYPE = "gen_ai.tool.output_type"
@@ -1235,7 +1253,6 @@ class SemanticConvention:
     GEN_AI_KNOWLEDGE_OPERATION_SUCCESS = "gen_ai.knowledge.operation.success"
 
     # Workflow operation attributes (additional ones not already covered above)
-    GEN_AI_WORKFLOW_NAME = "gen_ai.workflow.name"
     GEN_AI_WORKFLOW_DESCRIPTION = "gen_ai.workflow.description"
     GEN_AI_WORKFLOW_EXECUTION_DURATION = "gen_ai.workflow.execution.duration"
     GEN_AI_WORKFLOW_OPERATION_SUCCESS = "gen_ai.workflow.operation.success"

--- a/sdk/typescript/src/instrumentation/langchain/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/langchain/wrapper.ts
@@ -277,7 +277,13 @@ class OpenLITCallbackHandler {
     try {
       const id: string[] = chain?.id || [];
       const name = id[id.length - 1] || 'chain';
-      const spanName = `workflow ${name}`;
+      const isAgent = id.some((part: string) => part.toLowerCase().includes('agent')) ||
+                      name.toLowerCase().includes('agent');
+
+      const operationType = isAgent
+        ? SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT
+        : SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK;
+      const spanName = isAgent ? `invoke_agent ${name}` : `invoke_workflow ${name}`;
 
       const parentCtx = this._getParentContext(parentRunId);
       const span = this.tracer.startSpan(
@@ -288,12 +294,18 @@ class OpenLITCallbackHandler {
 
       span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME, SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN);
       span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN);
-      span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK);
+      span.setAttribute(SemanticConvention.GEN_AI_OPERATION, operationType);
       span.setAttribute(SemanticConvention.GEN_AI_ENVIRONMENT, OpenlitConfig.environment || '');
       span.setAttribute(SemanticConvention.GEN_AI_APPLICATION_NAME, OpenlitConfig.applicationName || '');
 
+      if (isAgent) {
+        span.setAttribute(SemanticConvention.GEN_AI_AGENT_NAME, name);
+      } else {
+        span.setAttribute(SemanticConvention.GEN_AI_WORKFLOW_NAME, name);
+      }
+
       if (OpenlitConfig.traceContent && inputs) {
-        span.setAttribute(SemanticConvention.GEN_AI_INPUT_MESSAGES, JSON.stringify(inputs).slice(0, 2000));
+        span.setAttribute(SemanticConvention.GEN_AI_WORKFLOW_INPUT, JSON.stringify(inputs).slice(0, 2000));
       }
 
       this.spans.set(runId, {
@@ -316,7 +328,7 @@ class OpenLITCallbackHandler {
       const duration = (Date.now() - holder.startTime) / 1000;
       holder.span.setAttribute(SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, duration);
       if (OpenlitConfig.traceContent && outputs) {
-        holder.span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, JSON.stringify(outputs).slice(0, 2000));
+        holder.span.setAttribute(SemanticConvention.GEN_AI_WORKFLOW_OUTPUT, JSON.stringify(outputs).slice(0, 2000));
       }
       holder.span.setStatus({ code: 1 });
       holder.span.end();
@@ -325,6 +337,151 @@ class OpenLITCallbackHandler {
   }
 
   handleChainError(error: any, runId: string) {
+    try {
+      const holder = this.spans.get(runId);
+      if (!holder) return;
+      OpenLitHelper.handleException(holder.span, error);
+      holder.span.end();
+      this.spans.delete(runId);
+    } catch { /* non-blocking */ }
+  }
+
+  // ---- Tool callbacks --------------------------------------------------------
+
+  handleToolStart(tool: any, input: string, runId: string, parentRunId?: string) {
+    try {
+      const id: string[] = tool?.id || [];
+      const name = tool?.name || tool?.kwargs?.name || id[id.length - 1] || 'unknown';
+      const spanName = `execute_tool ${name}`;
+
+      const parentCtx = this._getParentContext(parentRunId);
+      const span = this.tracer.startSpan(
+        spanName,
+        { kind: SpanKind.INTERNAL },
+        parentCtx
+      );
+
+      span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME, SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN);
+      span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS);
+      span.setAttribute(SemanticConvention.GEN_AI_ENVIRONMENT, OpenlitConfig.environment || '');
+      span.setAttribute(SemanticConvention.GEN_AI_APPLICATION_NAME, OpenlitConfig.applicationName || '');
+      span.setAttribute(SemanticConvention.GEN_AI_TOOL_NAME, name);
+      span.setAttribute(SemanticConvention.GEN_AI_TOOL_TYPE_OTEL, 'function');
+
+      const description = tool?.description;
+      if (description) {
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_DESCRIPTION, String(description));
+      }
+
+      if (OpenlitConfig.traceContent && input) {
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS, String(input).slice(0, 2000));
+      }
+
+      this.spans.set(runId, {
+        span,
+        startTime: Date.now(),
+        modelName: name,
+        parentRunId,
+        streamingContent: [],
+        tokenTimestamps: [],
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+    } catch { /* non-blocking */ }
+  }
+
+  handleToolEnd(output: any, runId: string) {
+    try {
+      const holder = this.spans.get(runId);
+      if (!holder) return;
+      const duration = (Date.now() - holder.startTime) / 1000;
+      holder.span.setAttribute(SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, duration);
+      if (OpenlitConfig.traceContent && output) {
+        holder.span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_RESULT, String(output).slice(0, 2000));
+      }
+      holder.span.setStatus({ code: 1 });
+      holder.span.end();
+      this.spans.delete(runId);
+    } catch { /* non-blocking */ }
+  }
+
+  handleToolError(error: any, runId: string) {
+    try {
+      const holder = this.spans.get(runId);
+      if (!holder) return;
+      OpenLitHelper.handleException(holder.span, error);
+      holder.span.end();
+      this.spans.delete(runId);
+    } catch { /* non-blocking */ }
+  }
+
+  // ---- Retriever callbacks ---------------------------------------------------
+
+  handleRetrieverStart(retriever: any, query: string, runId: string, parentRunId?: string) {
+    try {
+      const id: string[] = retriever?.id || [];
+      const name = retriever?.name || retriever?.kwargs?.name || id[id.length - 1] || 'unknown';
+      const spanName = `retrieval ${name}`;
+
+      const parentCtx = this._getParentContext(parentRunId);
+      const span = this.tracer.startSpan(
+        spanName,
+        { kind: SpanKind.CLIENT },
+        parentCtx
+      );
+
+      span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME, SemanticConvention.GEN_AI_SYSTEM_LANGCHAIN);
+      span.setAttribute(SemanticConvention.GEN_AI_OPERATION, SemanticConvention.GEN_AI_OPERATION_TYPE_RETRIEVE);
+      span.setAttribute(SemanticConvention.GEN_AI_ENVIRONMENT, OpenlitConfig.environment || '');
+      span.setAttribute(SemanticConvention.GEN_AI_APPLICATION_NAME, OpenlitConfig.applicationName || '');
+      span.setAttribute(SemanticConvention.GEN_AI_DATA_SOURCE_ID, name);
+
+      if (OpenlitConfig.traceContent && query) {
+        span.setAttribute(SemanticConvention.GEN_AI_RETRIEVAL_QUERY_TEXT, String(query).slice(0, 2000));
+      }
+
+      this.spans.set(runId, {
+        span,
+        startTime: Date.now(),
+        modelName: name,
+        parentRunId,
+        streamingContent: [],
+        tokenTimestamps: [],
+        promptTokens: 0,
+        completionTokens: 0,
+      });
+    } catch { /* non-blocking */ }
+  }
+
+  handleRetrieverEnd(documents: any[], runId: string) {
+    try {
+      const holder = this.spans.get(runId);
+      if (!holder) return;
+      const duration = (Date.now() - holder.startTime) / 1000;
+      holder.span.setAttribute(SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, duration);
+      holder.span.setAttribute(SemanticConvention.GEN_AI_RETRIEVAL_DOCUMENT_COUNT, documents?.length || 0);
+
+      if (OpenlitConfig.traceContent && documents?.length > 0) {
+        const structured = documents.slice(0, 3).map((doc: any) => {
+          const content = doc?.pageContent || doc?.page_content || String(doc);
+          const entry: Record<string, string> = { content: content.slice(0, 2000) };
+          const meta = doc?.metadata;
+          if (meta) {
+            const docId = meta.id || meta.source;
+            if (docId) entry.id = String(docId);
+          }
+          return entry;
+        });
+        holder.span.setAttribute(SemanticConvention.GEN_AI_RETRIEVAL_DOCUMENTS, JSON.stringify(structured));
+      }
+
+      holder.span.setStatus({ code: 1 });
+      holder.span.end();
+      this.spans.delete(runId);
+    } catch { /* non-blocking */ }
+  }
+
+  handleRetrieverError(error: any, runId: string) {
     try {
       const holder = this.spans.get(runId);
       if (!holder) return;

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -149,13 +149,22 @@ export default class SemanticConvention {
 
   // Retrieval (framework / RAG)
   static GEN_AI_RETRIEVAL_QUERY = 'gen_ai.retrieval.query';
+  static GEN_AI_RETRIEVAL_QUERY_TEXT = 'gen_ai.retrieval.query.text';
   static GEN_AI_RETRIEVAL_DOCUMENTS = 'gen_ai.retrieval.documents';
   static GEN_AI_RETRIEVAL_DOCUMENT_COUNT = 'gen_ai.retrieval.document_count';
+  static GEN_AI_DATA_SOURCE_ID = 'gen_ai.data_source.id';
+
+  // Agent (OTel Semconv)
+  static GEN_AI_AGENT_NAME = 'gen_ai.agent.name';
+  static GEN_AI_AGENT_ID = 'gen_ai.agent.id';
+  static GEN_AI_AGENT_DESCRIPTION = 'gen_ai.agent.description';
+  static GEN_AI_AGENT_VERSION = 'gen_ai.agent.version';
 
   // Workflow / framework
   static GEN_AI_WORKFLOW_INPUT = 'gen_ai.workflow.input';
   static GEN_AI_WORKFLOW_OUTPUT = 'gen_ai.workflow.output';
   static GEN_AI_WORKFLOW_TYPE = 'gen_ai.workflow.type';
+  static GEN_AI_WORKFLOW_NAME = 'gen_ai.workflow.name';
   static GEN_AI_FRAMEWORK_ERROR_CLASS = 'gen_ai.framework.error.class';
   static GEN_AI_FRAMEWORK_ERROR_TYPE = 'gen_ai.framework.error.type';
   static GEN_AI_FRAMEWORK_ERROR_MESSAGE = 'gen_ai.framework.error.message';
@@ -173,7 +182,10 @@ export default class SemanticConvention {
   static GEN_AI_OPERATION_TYPE_AUDIO = 'audio';
   static GEN_AI_OPERATION_TYPE_FINETUNING = 'fine_tuning';
   static GEN_AI_OPERATION_TYPE_VECTORDB = 'vectordb';
-  static GEN_AI_OPERATION_TYPE_FRAMEWORK = 'workflow';
+  static GEN_AI_OPERATION_TYPE_FRAMEWORK = 'invoke_workflow';
+  static GEN_AI_OPERATION_TYPE_AGENT = 'invoke_agent';
+  static GEN_AI_OPERATION_TYPE_TOOLS = 'execute_tool';
+  static GEN_AI_OPERATION_TYPE_RETRIEVE = 'retrieval';
   
   // GenAI Output Types
   static GEN_AI_OUTPUT_TYPE_TEXT = 'text';


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Align LangChain and LangGraph instrumentation with GenAI semantic conventions, enrich captured telemetry for LLM, tool, retrieval, workflow, and agent operations, and prevent duplicate or noisy spans across framework and provider layers.

New Features:
- Capture additional GenAI span attributes for providers, workflows, agents, tools, retrievals, system instructions, tool calls, and conversation IDs in LangChain and LangGraph integrations.
- Instrument LangChain agent creation and embeddings (sync and async) to emit dedicated spans with model, provider, endpoint, and token usage metadata.
- Link LangGraph workflow execution spans to their agent creation context and propagate conversation/thread identifiers across node spans.

Bug Fixes:
- Avoid duplicate or orphaned spans between LangChain, LangGraph, and OpenAI instrumentations by coordinating suppression flags and parent-child span resolution.
- Correct operation names and attribute keys to follow the latest GenAI semantic conventions for workflows, agents, tools, and retrieval operations.
- Ensure server address/port and request parameter attributes are populated only when available, with sensible provider-specific defaults.

Enhancements:
- Improve LangChain callback handler robustness with thread-safe span bookkeeping, retry events, and richer extraction of prompts, tool definitions, tool calls, and finish reasons.
- Normalize LangGraph telemetry to use generic GenAI graph attributes instead of framework-specific keys and emit structured input/output message content.
- Refine common chat processing utilities to support multimodal message parts and to pass through framework/provider identifiers consistently to spans, events, and metrics.

Build:
- Bump Python SDK version to 1.39.1 to reflect the updated instrumentation behavior.