### PR TITLE
fix: enhance entrypoint.sh for environment variable handling

### DIFF
--- a/src/client/scripts/entrypoint.sh
+++ b/src/client/scripts/entrypoint.sh
@@ -8,7 +8,7 @@ if [ -f "$NEXTAUTH_SECRET_FILE" ]; then
     # Load existing secret from persistent volume
     export NEXTAUTH_SECRET=$(cat "$NEXTAUTH_SECRET_FILE")
     echo "✅ Loaded existing NextAuth secret from persistent storage"
-else if [ -n "$NEXTAUTH_SECRET" ]; then
+elif [ -n "$NEXTAUTH_SECRET" ]; then
     echo "Using provided NEXTAUTH_SECRET environment variable"
 else
     # Generate new secret and save it to persistent volume

--- a/src/client/scripts/entrypoint.sh
+++ b/src/client/scripts/entrypoint.sh
@@ -8,6 +8,8 @@ if [ -f "$NEXTAUTH_SECRET_FILE" ]; then
     # Load existing secret from persistent volume
     export NEXTAUTH_SECRET=$(cat "$NEXTAUTH_SECRET_FILE")
     echo "✅ Loaded existing NextAuth secret from persistent storage"
+else if [ -n "$NEXTAUTH_SECRET" ]; then
+    echo "Using provided NEXTAUTH_SECRET environment variable"
 else
     # Generate new secret and save it to persistent volume
     export NEXTAUTH_SECRET=$(openssl rand -base64 32)
@@ -25,7 +27,19 @@ else
     echo "WARNING: /etc/environment is not writable; NEXTAUTH_SECRET will not be persisted there." >&2
 fi
 
-echo "NEXTAUTH_URL=http://localhost:${DOCKER_PORT:-3000}" >> /etc/environment
+if [ -n "$NEXTAUTH_URL" ]; then
+  echo "Using provided NEXTAUTH_URL=$NEXTAUTH_URL"
+else
+  echo "NEXTAUTH_URL=http://localhost:${DOCKER_PORT:-3000}" >> /etc/environment
+fi
+
+if [ -w /etc/environment ]; then
+    sed -i '/^NEXTAUTH_URL=/d' /etc/environment
+    echo "NEXTAUTH_URL=$NEXTAUTH_URL" >> /etc/environment
+else
+    echo "WARNING: /etc/environment is not writable; NEXTAUTH_URL will not be persisted there." >&2
+fi
+
 echo "SQLITE_DATABASE_URL=${SQLITE_DATABASE_URL:-file:../data/data.db}" >> /etc/environment
 echo "PATH=./node_modules/.bin:$PATH" >> /etc/environment
 

--- a/src/client/scripts/entrypoint.sh
+++ b/src/client/scripts/entrypoint.sh
@@ -29,13 +29,9 @@ fi
 
 if [ -n "$NEXTAUTH_URL" ]; then
   echo "Using provided NEXTAUTH_URL=$NEXTAUTH_URL"
-else
-  echo "NEXTAUTH_URL=http://localhost:${DOCKER_PORT:-3000}" >> /etc/environment
-fi
-
-if [ -w /etc/environment ]; then
+elif [ -w /etc/environment ]; then
     sed -i '/^NEXTAUTH_URL=/d' /etc/environment
-    echo "NEXTAUTH_URL=$NEXTAUTH_URL" >> /etc/environment
+    echo "NEXTAUTH_URL=http://localhost:${DOCKER_PORT:-3000}" >> /etc/environment
 else
     echo "WARNING: /etc/environment is not writable; NEXTAUTH_URL will not be persisted there." >&2
 fi


### PR DESCRIPTION
**Issue number**: #1080 

### Change description:
This PR enhance the entrypoint.sh to handling enviroment variable instead only add a value in `/etc/environment` and ignore the previous env vars.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [X] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [X] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Improve environment variable handling in the client entrypoint script to respect provided values and handle persistence more safely.

Bug Fixes:
- Respect an existing NEXTAUTH_SECRET environment variable when no secret file is present.
- Avoid overwriting a user-provided NEXTAUTH_URL and only write a default value to /etc/environment when appropriate, with warnings if the file is not writable.

Enhancements:
- Remove stale NEXTAUTH_URL entries from /etc/environment before writing a default value to ensure consistent configuration.