### PR TITLE
fix: Broken Omit attrbutes in OpenAI Agents sdk

### DIFF
--- a/sdk/python/src/openlit/_instrumentors.py
+++ b/sdk/python/src/openlit/_instrumentors.py
@@ -173,7 +173,7 @@ def get_instrumentor_class(name):
     try:
         module = importlib.import_module(module_path)
         return getattr(module, class_name)
-    except (ImportError, AttributeError):
+    except Exception:
         return None
 
 

--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -33,9 +33,10 @@ logger = logging.getLogger(__name__)
 
 def handle_not_given(value, default=None):
     """
-    Handle OpenAI's NotGiven values and None values by converting them to appropriate defaults.
+    Handle OpenAI's NotGiven/Omit sentinel values and None by converting them to defaults.
+    The Responses API uses 'Omit' while the Chat Completions API uses 'NotGiven'.
     """
-    if hasattr(value, "__class__") and value.__class__.__name__ == "NotGiven":
+    if hasattr(value, "__class__") and value.__class__.__name__ in ("NotGiven", "Omit"):
         return default
     if value is None:
         return default

--- a/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
+++ b/sdk/python/src/openlit/instrumentation/openai_agents/processor.py
@@ -36,7 +36,7 @@ try:
     if TYPE_CHECKING:
         from agents import Trace, Span
     TRACING_AVAILABLE = True
-except ImportError:
+except Exception:
 
     class TracingProcessor:
         """Dummy TracingProcessor for when agents is not available."""


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Handle additional OpenAI sentinel values and make instrumentation initialization more robust against unexpected import errors.

Bug Fixes:
- Normalize OpenAI request parameters by treating both NotGiven and Omit sentinels as defaultable values.
- Prevent instrumentation and agent tracing setup from failing when unexpected exceptions occur during dynamic imports.