### PR TITLE
fix: Add aliases for disable instrumentations

### DIFF
--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -32,7 +32,11 @@ from openlit.__helpers import (
     record_agent_tool_error,
 )
 from openlit._config import OpenlitConfig  # noqa: F401 — re-exported for public API
-from openlit._instrumentors import MODULE_NAME_MAP, INSTRUMENTOR_ALIASES, get_all_instrumentors
+from openlit._instrumentors import (
+    MODULE_NAME_MAP,
+    get_all_instrumentors,
+    normalize_instrumentor_names,
+)
 
 # Import GPU instrumentor separately as it doesn't follow the standard pattern
 from openlit.instrumentation.gpu import GPUInstrumentor
@@ -166,10 +170,7 @@ def init(
                                        span. Values must be valid OTel attribute types (str, int,
                                        float, bool, or sequences thereof). Optional.
     """
-    disabled_instrumentors = disabled_instrumentors if disabled_instrumentors else []
-    disabled_instrumentors = [
-        INSTRUMENTOR_ALIASES.get(name, name) for name in disabled_instrumentors
-    ]
+    disabled_instrumentors = normalize_instrumentor_names(disabled_instrumentors)
     logger.info("Starting openLIT initialization...")
 
     # Handle service_name/application_name migration
@@ -209,10 +210,9 @@ def init(
         if capture_message_content is True and "capture_message_content" in env_config:
             capture_message_content = env_config["capture_message_content"]
         if not disabled_instrumentors and "disabled_instrumentors" in env_config:
-            disabled_instrumentors = [
-                INSTRUMENTOR_ALIASES.get(name, name)
-                for name in env_config["disabled_instrumentors"]
-            ]
+            disabled_instrumentors = normalize_instrumentor_names(
+                env_config["disabled_instrumentors"]
+            )
         if disable_metrics is False and "disable_metrics" in env_config:
             disable_metrics = env_config["disable_metrics"]
         if disable_events is False and "disable_events" in env_config:
@@ -241,8 +241,9 @@ def init(
         name for name in disabled_instrumentors if name not in MODULE_NAME_MAP
     ]
     for invalid_name in invalid_instrumentors:
+        lower_name = invalid_name.lower()
         suggestions = [
-            k for k in MODULE_NAME_MAP if invalid_name in k or k in invalid_name
+            k for k in MODULE_NAME_MAP if lower_name in k or k in lower_name
         ]
         if suggestions:
             logger.warning(

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -32,7 +32,7 @@ from openlit.__helpers import (
     record_agent_tool_error,
 )
 from openlit._config import OpenlitConfig  # noqa: F401 — re-exported for public API
-from openlit._instrumentors import MODULE_NAME_MAP, get_all_instrumentors
+from openlit._instrumentors import MODULE_NAME_MAP, INSTRUMENTOR_ALIASES, get_all_instrumentors
 
 # Import GPU instrumentor separately as it doesn't follow the standard pattern
 from openlit.instrumentation.gpu import GPUInstrumentor
@@ -149,6 +149,10 @@ def init(
         disable_batch (bool): Flag to disable batch span processing (Optional).
         capture_message_content (bool): Flag to trace content (Optional).
         disabled_instrumentors (List[str]): Optional. List of instrumentor names to disable.
+                                          Common aliases are resolved automatically (e.g. "aiohttp"
+                                          maps to "aiohttp-client"). Note: "urllib3" must be disabled
+                                          separately from "requests" since requests uses urllib3
+                                          internally.
         disable_metrics (bool): Flag to disable metrics (Optional).
         disable_events (bool): Flag to disable OTel Logger event emission (Optional).
         pricing_json(str): File path or url to the pricing json (Optional).
@@ -163,6 +167,9 @@ def init(
                                        float, bool, or sequences thereof). Optional.
     """
     disabled_instrumentors = disabled_instrumentors if disabled_instrumentors else []
+    disabled_instrumentors = [
+        INSTRUMENTOR_ALIASES.get(name, name) for name in disabled_instrumentors
+    ]
     logger.info("Starting openLIT initialization...")
 
     # Handle service_name/application_name migration
@@ -202,7 +209,10 @@ def init(
         if capture_message_content is True and "capture_message_content" in env_config:
             capture_message_content = env_config["capture_message_content"]
         if not disabled_instrumentors and "disabled_instrumentors" in env_config:
-            disabled_instrumentors = env_config["disabled_instrumentors"]
+            disabled_instrumentors = [
+                INSTRUMENTOR_ALIASES.get(name, name)
+                for name in env_config["disabled_instrumentors"]
+            ]
         if disable_metrics is False and "disable_metrics" in env_config:
             disable_metrics = env_config["disable_metrics"]
         if disable_events is False and "disable_events" in env_config:
@@ -231,9 +241,20 @@ def init(
         name for name in disabled_instrumentors if name not in MODULE_NAME_MAP
     ]
     for invalid_name in invalid_instrumentors:
-        logger.warning(
-            "Invalid instrumentor name detected and ignored: '%s'", invalid_name
-        )
+        suggestions = [
+            k for k in MODULE_NAME_MAP if invalid_name in k or k in invalid_name
+        ]
+        if suggestions:
+            logger.warning(
+                "Invalid instrumentor name '%s'. Did you mean: %s?",
+                invalid_name,
+                ", ".join(suggestions),
+            )
+        else:
+            logger.warning(
+                "Invalid instrumentor name detected and ignored: '%s'",
+                invalid_name,
+            )
 
     try:
         # Retrieve or create the single configuration instance.

--- a/sdk/python/src/openlit/_instrumentors.py
+++ b/sdk/python/src/openlit/_instrumentors.py
@@ -79,6 +79,22 @@ MODULE_NAME_MAP = {
     "urllib3": "urllib3",
 }
 
+# Common aliases so users can pass intuitive names (e.g. "aiohttp") that
+# differ from the canonical hyphenated keys used in MODULE_NAME_MAP.
+INSTRUMENTOR_ALIASES = {
+    "aiohttp": "aiohttp-client",
+    "openai_agents": "openai-agents",
+    "google_ai_studio": "google-ai-studio",
+    "azure_ai_inference": "azure-ai-inference",
+    "reka": "reka-api",
+    "browser_use": "browser-use",
+    "google_adk": "google-adk",
+    "claude_agent_sdk": "claude-agent-sdk",
+    "agent_framework": "agent-framework",
+    "psycopg_pool": "psycopg-pool",
+    "http": "httpx",
+}
+
 # Dictionary mapping instrumentor names to their full module paths
 INSTRUMENTOR_MAP = {
     # OpenLIT AI/ML instrumentations

--- a/sdk/python/src/openlit/_instrumentors.py
+++ b/sdk/python/src/openlit/_instrumentors.py
@@ -95,6 +95,31 @@ INSTRUMENTOR_ALIASES = {
     "http": "httpx",
 }
 
+
+def normalize_instrumentor_name(name):
+    """Normalize a user-provided instrumentor name for lookup.
+
+    Lowercases the input for case-insensitive matching and resolves any
+    configured alias from INSTRUMENTOR_ALIASES.  Returns the canonical key
+    used in MODULE_NAME_MAP / INSTRUMENTOR_MAP.
+    """
+    if not isinstance(name, str):
+        return name
+    lowered = name.lower()
+    return INSTRUMENTOR_ALIASES.get(lowered, lowered)
+
+
+def normalize_instrumentor_names(names):
+    """Normalize a list of user-provided instrumentor names.
+
+    Single entry point for alias resolution + case folding so every code
+    path (init kwarg, env var, config file, etc.) stays consistent.
+    """
+    if not names:
+        return []
+    return [normalize_instrumentor_name(n) for n in names]
+
+
 # Dictionary mapping instrumentor names to their full module paths
 INSTRUMENTOR_MAP = {
     # OpenLIT AI/ML instrumentations


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: resolves #1095 

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add support for intuitive aliases when disabling Python SDK instrumentations and improve validation feedback for invalid instrumentor names.

New Features:
- Allow disabling instrumentations via common alias names that are automatically mapped to canonical instrumentor keys.

Enhancements:
- Resolve disabled instrumentor aliases from both function parameters and environment configuration before initialization.
- Provide helpful suggestions in log messages when an invalid instrumentor name resembles a known instrumentor.