### PR TITLE
fix(agno): respect yield_run_output in Team arun stream wrapper

### DIFF
--- a/sdk/python/src/openlit/instrumentation/agno/async_agno.py
+++ b/sdk/python/src/openlit/instrumentation/agno/async_agno.py
@@ -333,14 +333,16 @@ async def _team_arun_stream_wrapper(
             except Exception:
                 TeamRunOutput = None
 
-            yield_run_response = kwargs.get("yield_run_response", None)
+            yield_run_output = kwargs.get("yield_run_output", None) or kwargs.get(
+                "yield_run_response", None
+            )
             new_kwargs = dict(kwargs)
-            new_kwargs["yield_run_response"] = True
+            new_kwargs["yield_run_output"] = True
 
             async for response in wrapped(*args, **new_kwargs):
                 if TeamRunOutput and isinstance(response, TeamRunOutput):
                     final_response = response
-                    if yield_run_response:
+                    if yield_run_output:
                         yield response
                 else:
                     yield response


### PR DESCRIPTION
**Issue:** resolves #1100 

## Summary

`_team_arun_stream_wrapper` only considered `yield_run_response`, while Agno uses `yield_run_output` for `Team.arun(stream=True)`. That caused the final `TeamRunOutput` not to be forwarded when callers passed only `yield_run_output=True`, so completion-style events could be missing on the instrumented path.

This change mirrors `_arun_stream_wrapper`: resolve `yield_run_output` (with fallback to `yield_run_response`), pass `yield_run_output=True` into the wrapped call, and forward `TeamRunOutput` only when the caller requested it.

## Checklist

- [x] PR name follows conventional commit format (`fix:` …)
- [x] I have reviewed the contributing guidelines
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented *(check if you added changelog/docs; tick if yes)*

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

## Summary by Sourcery

Bug Fixes:
- Respect the `yield_run_output` flag in the Team async stream wrapper so that final `TeamRunOutput` events are emitted when callers request them.