### PR TITLE
fix: Windows Docker compatibility, OTel token normalization, and model payload key

### DIFF
--- a/assets/otel-collector-config.yaml
+++ b/assets/otel-collector-config.yaml
@@ -7,6 +7,49 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  transform:
+      error_mode: ignore
+      trace_statements:
+        - context: span
+          statements:
+          # --- 1. MODEL NORMALIZATION ---
+          # Ensure OpenLIT sees the model ID for pricing lookups
+          - set(attributes["gen_ai.request.model"], attributes["model"]) 
+            where attributes["gen_ai.request.model"] == nil and attributes["model"] != nil
+
+          # --- 2. INPUT NORMALIZATION & CLAUDE CACHE MATH ---
+          # Identify the base input (Standard OTel key vs raw Claude/Copilot tag)
+          - set(attributes["tmp.base_input"], attributes["gen_ai.usage.input_tokens"]) 
+            where attributes["gen_ai.usage.input_tokens"] != nil
+          - set(attributes["tmp.base_input"], attributes["input_tokens"]) 
+            where attributes["tmp.base_input"] == nil and attributes["input_tokens"] != nil
+
+          # Initialize cache weights to 0 so the addition logic doesn't fail on nulls
+          - set(attributes["tmp.cache_weighted"], 0)
+          - set(attributes["tmp.cache_weighted"], attributes["cache_read_tokens"] * 0.1) 
+            where attributes["cache_read_tokens"] != nil
+          - set(attributes["tmp.cache_weighted"], attributes["tmp.cache_weighted"] + (attributes["cache_creation_tokens"] * 1.25)) 
+            where attributes["cache_creation_tokens"] != nil
+
+          # Set final Input Tokens: Base + Weighted Cache
+          - set(attributes["gen_ai.usage.input_tokens"], attributes["tmp.base_input"] + attributes["tmp.cache_weighted"]) 
+            where attributes["tmp.base_input"] != nil
+
+          # --- 3. OUTPUT NORMALIZATION ---
+          # Identify the base output (Standard OTel key vs raw Claude/Copilot tag)
+          - set(attributes["tmp.base_output"], attributes["gen_ai.usage.output_tokens"]) 
+            where attributes["gen_ai.usage.output_tokens"] != nil
+          - set(attributes["tmp.base_output"], attributes["output_tokens"]) 
+            where attributes["tmp.base_output"] == nil and attributes["output_tokens"] != nil
+
+          # Apply normalized output to the standard key
+          - set(attributes["gen_ai.usage.output_tokens"], attributes["tmp.base_output"]) 
+            where attributes["tmp.base_output"] != nil
+
+          # --- 4. TOTAL TOKENS CALCULATION ---
+          # Now that Input and Output are normalized, sum them for the Dashboard
+          - set(attributes["gen_ai.usage.total_tokens"], attributes["gen_ai.usage.input_tokens"] + attributes["gen_ai.usage.output_tokens"]) 
+            where attributes["gen_ai.usage.input_tokens"] != nil and attributes["gen_ai.usage.output_tokens"] != nil
   batch:
   memory_limiter:
     # 80% of maximum memory up to 2G
@@ -41,7 +84,7 @@ service:
       exporters: [clickhouse]
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [transform, memory_limiter, batch]
       exporters: [clickhouse]
     metrics:
       receivers: [otlp]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709 AS builder
 
 # Installing node and npm
-RUN apk add --no-cache nodejs npm
+RUN apk add --no-cache nodejs npm openssl
 
 # Installing extra packages
 RUN apk add --no-cache rust cargo build-base
@@ -116,6 +116,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends file && \
     echo "otelcontribcol:" && file /app/opamp/otelcontribcol && \
     echo "opampsupervisor:" && file /app/opamp/opampsupervisor && \
     rm -rf /var/lib/apt/lists/*
+
+# Fix Windows CRLF line endings in shell scripts (required for Windows Docker Desktop compatibility)
+RUN find /app -name "*.sh" -exec sed -i 's/\r$//' {} +
 
 # Execute entrypoint script to generate NextAuth.js secret and run commands
 RUN chmod +x ./scripts/entrypoint.sh /app/opamp/otelcontribcol /app/opamp/opampsupervisor /app/opamp/opamp-server /app/opamp/setup-supervisor.sh

--- a/src/client/src/components/(playground)/openground/model-editor-panel.tsx
+++ b/src/client/src/components/(playground)/openground/model-editor-panel.tsx
@@ -87,7 +87,7 @@ export default function ModelEditorPanel({
 		const payload = {
 			provider: provider,
 			model: {
-				model_id: formData.model_id,
+				id: formData.model_id,
 				displayName: formData.displayName,
 				contextWindow: formData.contextWindow || 4096,
 				inputPricePerMToken: formData.inputPricePerMToken || 0,


### PR DESCRIPTION
fixes https://github.com/openlit/openlit/issues/1107

## Docker / Windows compatibility (Dockerfile, clickhouse-init.sh)

Shell scripts checked out on Windows receive CRLF line endings due to Git's default core.autocrlf=true setting. When copied into a Linux container the shebang becomes `#!/bin/bash\r`, causing the kernel to reject the interpreter with an exec format error. The container would start, crash immediately, and spin in the restart loop defined by `restart: always`, making all directories inside the container invisible via `docker exec`.

- Dockerfile: add `RUN find /app -name "*.sh" -exec sed -i 's/\r$//' {} +` before the chmod commands to strip any trailing \r from every shell script copied into the image. This is idempotent on Linux/macOS (no-op when files already have LF endings).
- Dockerfile: add `openssl` to the builder stage's `apk add` call. The Next.js build (via Prisma) requires openssl at generation time; omitting it caused the `npx prisma generate` step to fail silently on clean builds.
- assets/clickhouse-init.sh: normalize line endings to LF so the file is consistent with the fix above and will not trigger the same issue when bind-mounted from a Windows host.

## OTel Collector token normalization (assets/otel-collector-config.yaml)

Different LLM SDKs emit token counts under inconsistent attribute names (e.g. `input_tokens` vs `gen_ai.usage.input_tokens`) and Claude's API returns cache-specific token buckets that require weighted pricing math before they can be summed. Without normalization, the OpenLIT dashboard shows blank or incorrect token/cost values for Claude and other providers that deviate from the standard OTel semantic conventions.

Added a `transform` processor (error_mode: ignore) to the traces pipeline with four ordered stages:

1. Model normalization — copies `model` → `gen_ai.request.model` when the standard key is absent, ensuring pricing lookups always have a model ID.
2. Input token normalization + Claude cache math — resolves the base input from either `gen_ai.usage.input_tokens` or the raw `input_tokens` tag, then computes a weighted cache adjustment:
     cache_read_tokens     × 0.10  (cache reads are 10 % of input price)
     cache_creation_tokens × 1.25  (cache writes are 125 % of input price)
   The weighted sum is added to the base input and written back to
   `gen_ai.usage.input_tokens`.

3. Output token normalization — mirrors input logic, resolving `gen_ai.usage.output_tokens` from either the standard key or `output_tokens`.

4. Total tokens — sums the now-normalized input and output into `gen_ai.usage.total_tokens` for the dashboard aggregation queries.

The `transform` processor is inserted at the front of the traces processor chain (`[transform, memory_limiter, batch]`) so downstream exporters always receive fully normalized attributes.

## Openground model payload key fix (model-editor-panel.tsx)

The model editor form was sending `model_id` as the key in the request payload, but the API and model schema expect `id`. This caused new models added via the UI to be saved without an ID, breaking model selection and provider lookups in the playground.

Changed `model_id: formData.model_id` → `id: formData.model_id` in the POST payload construction inside ModelEditorPanel.

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Normalize OpenTelemetry token and model attributes, improve Docker/Windows compatibility, and correct the model payload key used by the Openground UI.

Bug Fixes:
- Fix Windows Docker Desktop container startup issues caused by CRLF line endings in shell scripts.
- Ensure Next.js/Prisma builds succeed in the Docker builder image by including OpenSSL.
- Correct the Openground model editor payload to send the expected model ID field so newly added models behave correctly in the UI.

Enhancements:
- Add an OTel transform processor to normalize model and token usage attributes, including Claude cache token handling and total token calculation for accurate dashboard metrics.