### PR TITLE
feat: add telemetry support for Anthropic stream helper methods

### DIFF
--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -227,7 +227,7 @@ def response_as_dict(response):
     if isinstance(response, dict):
         return response
     if hasattr(response, "model_dump"):
-        return response.model_dump()
+        return response.model_dump(warnings=False)
     elif hasattr(response, "parse"):
         if inspect.iscoroutinefunction(response.parse):
             logger.warning("response.parse() is a coroutine function; skipping")

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -227,7 +227,11 @@ def response_as_dict(response):
     if isinstance(response, dict):
         return response
     if hasattr(response, "model_dump"):
-        return response.model_dump(warnings=False)
+        try:
+            return response.model_dump(warnings=False)
+        except TypeError:
+            # Fallback for non-Pydantic v2 objects with model_dump method
+            return response.model_dump()
     elif hasattr(response, "parse"):
         if inspect.iscoroutinefunction(response.parse):
             logger.warning("response.parse() is a coroutine function; skipping")

--- a/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
@@ -48,7 +48,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 event_provider,
             ),
         )
-        
+
         # sync stream
         wrap_function_wrapper(
             "anthropic.resources.messages",
@@ -82,7 +82,7 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 event_provider,
             ),
         )
-        
+
         # async stream
         wrap_function_wrapper(
             "anthropic.resources.messages",

--- a/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/__init__.py
@@ -7,8 +7,8 @@ from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from wrapt import wrap_function_wrapper
 
 from openlit._config import OpenlitConfig
-from openlit.instrumentation.anthropic.anthropic import messages
-from openlit.instrumentation.anthropic.async_anthropic import async_messages
+from openlit.instrumentation.anthropic.anthropic import messages, messages_stream
+from openlit.instrumentation.anthropic.async_anthropic import async_messages, async_messages_stream
 
 _instruments = ("anthropic >= 0.21.0",)
 
@@ -48,12 +48,46 @@ class AnthropicInstrumentor(BaseInstrumentor):
                 event_provider,
             ),
         )
+        
+        # sync stream
+        wrap_function_wrapper(
+            "anthropic.resources.messages",
+            "Messages.stream",
+            messages_stream(
+                version,
+                environment,
+                application_name,
+                tracer,
+                pricing_info,
+                capture_message_content,
+                metrics,
+                disable_metrics,
+                event_provider,
+            ),
+        )
 
         # async
         wrap_function_wrapper(
             "anthropic.resources.messages",
             "AsyncMessages.create",
             async_messages(
+                version,
+                environment,
+                application_name,
+                tracer,
+                pricing_info,
+                capture_message_content,
+                metrics,
+                disable_metrics,
+                event_provider,
+            ),
+        )
+        
+        # async stream
+        wrap_function_wrapper(
+            "anthropic.resources.messages",
+            "AsyncMessages.stream",
+            async_messages_stream(
                 version,
                 environment,
                 application_name,

--- a/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
@@ -272,7 +272,7 @@ def messages_stream(
             if name == "until_done":
                 return self._instrumented_until_done
             return getattr(self.__wrapped__, name)
-        
+
         def _instrumented_get_final_message(self):
             """Drains the stream to finalize the span before returning the result."""
             for _ in self:

--- a/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
@@ -202,3 +202,218 @@ def messages(
             return response
 
     return wrapper
+
+
+def messages_stream(
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+    event_provider=None,
+):
+    """
+    Generates a telemetry wrapper for Anthropic Messages.stream calls.
+    """
+
+    class TracedMessageStream:
+        """
+        Wrapper for Anthropic Sync MessageStream to collect telemetry.
+        """
+
+        def __init__(
+            self,
+            wrapped,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider=None,
+        ):
+            self.__wrapped__ = wrapped
+            self._span = span
+            self._span_name = span_name
+            self._llmresponse = ""
+            self._response_id = ""
+            self._response_model = ""
+            self._finish_reason = ""
+            self._input_tokens = 0
+            self._output_tokens = 0
+            self._cache_read_input_tokens = 0
+            self._cache_creation_input_tokens = 0
+            self._tool_arguments = ""
+            self._tool_id = ""
+            self._tool_name = ""
+            self._tool_calls = None
+            self._response_role = ""
+            self._kwargs = kwargs
+            self._start_time = time.time()
+            self._end_time = None
+            self._timestamps = []
+            self._ttft = 0
+            self._tbt = 0
+            self._server_address = server_address
+            self._server_port = server_port
+            self._event_provider = event_provider
+
+        def __iter__(self):
+            return self
+
+        def __getattr__(self, name):
+            """Delegate attribute access to the wrapped stream object."""
+            if name == "text_stream":
+                return self._instrumented_text_stream
+            if name == "get_final_message":
+                return self._instrumented_get_final_message
+            if name == "until_done":
+                return self._instrumented_until_done
+            return getattr(self.__wrapped__, name)
+        
+        def _instrumented_get_final_message(self):
+            """Drains the stream to finalize the span before returning the result."""
+            for _ in self:
+                pass
+            original_get_final_message = getattr(self.__wrapped__, 'get_final_message')
+            return original_get_final_message()
+
+        @property
+        def _instrumented_text_stream(self):
+            """Yields text while ensuring every chunk hits our instrumentation."""
+            def text_generator():
+                for event in self:
+                    if (hasattr(event, 'delta') and
+                        hasattr(event.delta, 'type') and
+                        event.delta.type == 'text_delta' and
+                            hasattr(event.delta, 'text')):
+                        yield event.delta.text
+            return text_generator()
+
+        def _instrumented_until_done(self):
+            """Consumes the stream to ensure background telemetry is completed."""
+            for _ in self:
+                pass
+
+        def __next__(self):
+            try:
+                chunk = self.__wrapped__.__next__()
+                process_chunk(self, chunk)
+                return chunk
+            except StopIteration:
+                try:
+                    with self._span:
+                        process_streaming_chat_response(
+                            self,
+                            pricing_info=pricing_info,
+                            environment=environment,
+                            application_name=application_name,
+                            metrics=metrics,
+                            capture_message_content=capture_message_content,
+                            disable_metrics=disable_metrics,
+                            version=version,
+                            event_provider=self._event_provider,
+                        )
+                except Exception as e:
+                    handle_exception(self._span, e)
+                raise
+
+    class TracedMessageStreamManager:
+        """
+        Wrapper for Anthropic MessageStreamManager to instrument the 'with' block.
+        """
+
+        def __init__(
+            self,
+            original_manager,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider=None,
+        ):
+            self._original_manager = original_manager
+            self._span = span
+            self._span_name = span_name
+            self._kwargs = kwargs
+            self._server_address = server_address
+            self._server_port = server_port
+            self._event_provider = event_provider
+            self._token = None
+
+        def __enter__(self):
+            """
+            Attaches the span context and enters the original stream manager.
+            """
+            ctx = trace_api.set_span_in_context(self._span)
+            self._token = context_api.attach(ctx)
+
+            stream = self._original_manager.__enter__()
+
+            return TracedMessageStream(
+                stream,
+                self._span,
+                self._span_name,
+                self._kwargs,
+                self._server_address,
+                self._server_port,
+                self._event_provider,
+            )
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            """
+            Detaches the context and handles any exceptions inside the 'with' block.
+            """
+            if self._token:
+                context_api.detach(self._token)
+
+            if exc_type:
+                handle_exception(self._span, exc_val)
+                if self._span.is_recording():
+                    self._span.end()
+
+            return self._original_manager.__exit__(exc_type, exc_val, exc_tb)
+
+        def __getattr__(self, name):
+            """Delegate attribute access to the original manager."""
+            return getattr(self._original_manager, name)
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the Anthropic Messages.stream call.
+        """
+
+        if is_framework_llm_active():
+            return wrapped(*args, **kwargs)
+
+        server_address, server_port = set_server_address_and_port(
+            instance, "api.anthropic.com", 443
+        )
+        request_model = kwargs.get("model", "claude-3-5-sonnet-latest")
+
+        # Start span - Span activation is handled by the Manager class
+        span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
+
+        span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
+
+        try:
+            original_manager = wrapped(*args, **kwargs)
+        except Exception as e:
+            handle_exception(span, e)
+            span.end()
+            raise
+
+        return TracedMessageStreamManager(
+            original_manager,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider,
+        )
+
+    return wrapper

--- a/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
@@ -272,14 +272,14 @@ def async_messages_stream(
             if name == "until_done":
                 return self._instrumented_until_done
             return getattr(self.__wrapped__, name)
-        
+
         async def _instrumented_get_final_message(self):
             """Awaits stream completion via proxy then returns the final message."""
             async for _ in self:
                 pass
             original_get_final_message = getattr(self.__wrapped__, 'get_final_message')
             return await original_get_final_message()
-        
+
         @property
         def _instrumented_text_stream(self):
             """Async generator that processes chunks through our proxy."""
@@ -291,7 +291,7 @@ def async_messages_stream(
                             hasattr(event.delta, 'text')):
                         yield event.delta.text
             return text_generator()
-        
+
         async def _instrumented_until_done(self):
             """Ensures the async span is closed by draining the stream."""
             async for _ in self:

--- a/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
@@ -202,3 +202,216 @@ def async_messages(
             return response
 
     return wrapper
+
+
+def async_messages_stream(
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+    event_provider=None,
+):
+    """
+    Generates a telemetry wrapper for Anthropic AsyncMessages.stream calls.
+    """
+
+    class TracedAsyncMessageStream:
+        """
+        Wrapper for Anthropic Async MessageStream to collect telemetry
+        """
+
+        def __init__(
+            self,
+            wrapped,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider=None,
+        ):
+            self.__wrapped__ = wrapped
+            self._span = span
+            self._span_name = span_name
+            self._llmresponse = ""
+            self._response_id = ""
+            self._response_model = ""
+            self._finish_reason = ""
+            self._input_tokens = 0
+            self._output_tokens = 0
+            self._cache_read_input_tokens = 0
+            self._cache_creation_input_tokens = 0
+            self._tool_arguments = ""
+            self._tool_id = ""
+            self._tool_name = ""
+            self._tool_calls = None
+            self._response_role = ""
+            self._kwargs = kwargs
+            self._start_time = time.time()
+            self._end_time = None
+            self._timestamps = []
+            self._ttft = 0
+            self._tbt = 0
+            self._server_address = server_address
+            self._server_port = server_port
+            self._event_provider = event_provider
+
+        def __aiter__(self):
+            return self
+
+        def __getattr__(self, name):
+            """Delegate attribute access to the wrapped stream object."""
+            if name == "text_stream":
+                return self._instrumented_text_stream
+            if name == "get_final_message":
+                return self._instrumented_get_final_message
+            if name == "until_done":
+                return self._instrumented_until_done
+            return getattr(self.__wrapped__, name)
+        
+        async def _instrumented_get_final_message(self):
+            """Awaits stream completion via proxy then returns the final message."""
+            async for _ in self:
+                pass
+            original_get_final_message = getattr(self.__wrapped__, 'get_final_message')
+            return await original_get_final_message()
+        
+        @property
+        def _instrumented_text_stream(self):
+            """Async generator that processes chunks through our proxy."""
+            async def text_generator():
+                async for event in self:
+                    if (hasattr(event, 'delta') and
+                        hasattr(event.delta, 'type') and
+                        event.delta.type == 'text_delta' and
+                            hasattr(event.delta, 'text')):
+                        yield event.delta.text
+            return text_generator()
+        
+        async def _instrumented_until_done(self):
+            """Ensures the async span is closed by draining the stream."""
+            async for _ in self:
+                pass
+
+        async def __anext__(self):
+            try:
+                chunk = await self.__wrapped__.__anext__()
+                process_chunk(self, chunk)
+                return chunk
+            except StopAsyncIteration:
+                try:
+                    with self._span:
+                        process_streaming_chat_response(
+                            self,
+                            pricing_info=pricing_info,
+                            environment=environment,
+                            application_name=application_name,
+                            metrics=metrics,
+                            capture_message_content=capture_message_content,
+                            disable_metrics=disable_metrics,
+                            version=version,
+                            event_provider=self._event_provider,
+                        )
+                except Exception as e:
+                    handle_exception(self._span, e)
+                raise
+
+    class TracedAsyncMessageStreamManager:
+        """
+        Wrapper for Anthropic AsyncMessageStreamManager to instrument the 'async with' block.
+        """
+
+        def __init__(
+            self,
+            original_manager,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider=None,
+        ):
+            self._original_manager = original_manager
+            self._span = span
+            self._span_name = span_name
+            self._kwargs = kwargs
+            self._server_address = server_address
+            self._server_port = server_port
+            self._event_provider = event_provider
+            self._token = None
+
+        async def __aenter__(self):
+            """
+            Attaches the span context and enters the original async stream manager.
+            """
+            ctx = trace_api.set_span_in_context(self._span)
+            self._token = context_api.attach(ctx)
+
+            stream = await self._original_manager.__aenter__()
+
+            return TracedAsyncMessageStream(
+                stream,
+                self._span,
+                self._span_name,
+                self._kwargs,
+                self._server_address,
+                self._server_port,
+                self._event_provider,
+            )
+
+        async def __aexit__(self, exc_type, exc_val, exc_tb):
+            """
+            Detaches context and handles exceptions occurring inside the 'async with' block.
+            """
+            if self._token:
+                context_api.detach(self._token)
+
+            if exc_type:
+                handle_exception(self._span, exc_val)
+                if self._span.is_recording():
+                    self._span.end()
+
+            return await self._original_manager.__aexit__(exc_type, exc_val, exc_tb)
+
+        def __getattr__(self, name):
+            """Delegate attribute access to the original manager."""
+            return getattr(self._original_manager, name)
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Intercepts the Anthropic async_messages.stream call to inject telemetry.
+        """
+
+        if is_framework_llm_active():
+            return wrapped(*args, **kwargs)
+
+        server_address, server_port = set_server_address_and_port(
+            instance, "api.anthropic.com", 443
+        )
+        request_model = kwargs.get("model", "claude-3-5-sonnet-latest")
+        span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
+
+        span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
+
+        try:
+            original_manager = wrapped(*args, **kwargs)
+        except Exception as e:
+            handle_exception(span, e)
+            span.end()
+            raise
+
+        return TracedAsyncMessageStreamManager(
+            original_manager,
+            span,
+            span_name,
+            kwargs,
+            server_address,
+            server_port,
+            event_provider,
+        )
+
+    return wrapper


### PR DESCRIPTION
# Pull Request

**Issue number**: #1111

### Change description:
This PR add support for the Anthropic instrumentation `Messages.stream` (Sync and Async) context managers. 

## Why

Anthropic SDK has two streaming approaches:
- `messages.create(stream=True)` — returns a raw iterator (already instrumented)
- `messages.stream()` — returns a context manager with helper methods (not instrumented)

Frameworks like Agno use `messages.stream()` exclusively, resulting in zero telemetry spans for streaming LLM calls.

## What Changed

- **`anthropic.py`**: Added `messages_stream()` wrapper for sync `Messages.stream()`
- **`async_anthropic.py`**: Added `async_messages_stream()` wrapper for async `AsyncMessages.stream()`


### Checklist

* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [[contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [[Pull Requests](https://github.com/openlit/openlit/pulls)](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [[project license](https://github.com/openlit/openlit/blob/main/LICENSE)](https://github.com/openlit/openlit/blob/main/LICENSE).

---

## Summary by Sourcery

Add telemetry instrumentation for Anthropic sync and async Messages.stream helpers and refine response serialization behavior.

New Features:
- Add telemetry wrapper for Anthropic sync Messages.stream to capture streaming chat spans and metrics.
- Add telemetry wrapper for Anthropic async AsyncMessages.stream to enable tracing of async streaming chat flows.

Enhancements:
- Instrument Anthropic integration wiring to wrap both sync and async Messages.stream helpers during SDK initialization.
- Adjust generic response serialization to call model_dump with warnings disabled to avoid noisy warnings from SDK response models.