### PR TITLE
fix: correct payload field names when saving a custom model

### DIFF
--- a/src/client/src/components/(playground)/openground/model-editor-panel.tsx
+++ b/src/client/src/components/(playground)/openground/model-editor-panel.tsx
@@ -21,7 +21,7 @@ import { toast } from "sonner";
 
 interface CustomModel extends ModelMetadata {
   id: string; // UUID from database
-  model_id: string; // Model identifier like "gpt-4o"
+  modelId: string; // Model identifier like "gpt-4o"
 }
 
 interface ModelEditorPanelProps {
@@ -50,7 +50,7 @@ export default function ModelEditorPanel({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [formData, setFormData] = useState<Partial<CustomModel>>({
     id: "", // UUID (only for existing custom models)
-    model_id: "", // Model identifier
+    modelId: "", // Model identifier
     displayName: "",
     contextWindow: 4096,
     inputPricePerMToken: 0,
@@ -64,7 +64,7 @@ export default function ModelEditorPanel({
       const customModel = model as CustomModel;
       setFormData({
         id: customModel.id || "", // UUID for existing custom models
-        model_id: customModel.model_id,
+        modelId: customModel.modelId,
         displayName: model.displayName,
         contextWindow: model.contextWindow,
         inputPricePerMToken: model.inputPricePerMToken,
@@ -75,7 +75,7 @@ export default function ModelEditorPanel({
       // Reset form for new model
       setFormData({
         id: "",
-        model_id: "",
+        modelId: "",
         displayName: "",
         contextWindow: 4096,
         inputPricePerMToken: 0,
@@ -86,7 +86,7 @@ export default function ModelEditorPanel({
   }, [model, isAddingNew, isCustomModel]);
 
   const handleSave = () => {
-    if (!formData.model_id || !formData.displayName || !provider) {
+    if (!formData.modelId || !formData.displayName || !provider) {
       toast.error(
         getMessage().OPENGROUND_MODEL_ID +
           " and " +
@@ -99,7 +99,7 @@ export default function ModelEditorPanel({
     const payload = {
       provider: provider,
       model: {
-        id: formData.model_id,
+        id: formData.modelId,
         displayName: formData.displayName,
         contextWindow: formData.contextWindow || 4096,
         inputPricePerMToken: formData.inputPricePerMToken || 0,
@@ -172,9 +172,9 @@ export default function ModelEditorPanel({
             <Input
               id="model-id"
               placeholder="gpt-4o-custom"
-              value={formData.model_id}
+              value={formData.modelId}
               onChange={(e) =>
-                setFormData({ ...formData, model_id: e.target.value })
+                setFormData({ ...formData, modelId: e.target.value })
               }
               disabled={!isAddingNew}
             />
@@ -281,28 +281,26 @@ export default function ModelEditorPanel({
           </div>
 
           {/* Actions */}
-          {
-            <div className="flex gap-2 pt-4">
-              <Button onClick={handleSave} disabled={saving} className="flex-1">
-                {saving
-                  ? getMessage().SAVING
-                  : getMessage().OPENGROUND_SAVE_MODEL}
+          <div className="flex gap-2 pt-4">
+            <Button onClick={handleSave} disabled={saving} className="flex-1">
+              {saving
+                ? getMessage().SAVING
+                : getMessage().OPENGROUND_SAVE_MODEL}
+            </Button>
+            {isCustomModel && !isAddingNew && (
+              <Button
+                variant="destructive"
+                onClick={() => setShowDeleteDialog(true)}
+                disabled={deleting}
+              >
+                <Trash2Icon className="h-4 w-4 mr-2" />
+                {getMessage().DELETE}
               </Button>
-              {isCustomModel && !isAddingNew && (
-                <Button
-                  variant="destructive"
-                  onClick={() => setShowDeleteDialog(true)}
-                  disabled={deleting}
-                >
-                  <Trash2Icon className="h-4 w-4 mr-2" />
-                  {getMessage().DELETE}
-                </Button>
-              )}
-              <Button variant="outline" onClick={onCancel}>
-                {getMessage().CANCEL}
-              </Button>
-            </div>
-          }
+            )}
+            <Button variant="outline" onClick={onCancel}>
+              {getMessage().CANCEL}
+            </Button>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/client/src/components/(playground)/openground/model-editor-panel.tsx
+++ b/src/client/src/components/(playground)/openground/model-editor-panel.tsx
@@ -1,278 +1,337 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Trash2Icon } from "lucide-react";
+import { Label } from "@/components/ui/label";
 import getMessage from "@/constants/messages";
 import { ModelMetadata } from "@/types/openground";
 import useFetchWrapper from "@/utils/hooks/useFetchWrapper";
+import { Trash2Icon } from "lucide-react";
+import { useState, useEffect } from "react";
 import { toast } from "sonner";
 
 interface CustomModel extends ModelMetadata {
-	id: string; // UUID from database
-	model_id: string; // Model identifier like "gpt-4o"
+  id: string; // UUID from database
+  model_id: string; // Model identifier like "gpt-4o"
 }
 
 interface ModelEditorPanelProps {
-	model: ModelMetadata | null;
-	provider: string | null;
-	isCustomModel: boolean;
-	isAddingNew: boolean;
-	onSave: () => void;
-	onDelete: () => void;
-	onCancel: () => void;
+  model: ModelMetadata | null;
+  provider: string | null;
+  isCustomModel: boolean;
+  isAddingNew: boolean;
+  onSave: () => void;
+  onDelete: () => void;
+  onCancel: () => void;
 }
 
 export default function ModelEditorPanel({
-	model,
-	provider,
-	isCustomModel,
-	isAddingNew,
-	onSave,
-	onDelete,
-	onCancel,
+  model,
+  provider,
+  isCustomModel,
+  isAddingNew,
+  onSave,
+  onDelete,
+  onCancel,
 }: ModelEditorPanelProps) {
-	const { fireRequest: fireSaveRequest, isLoading: saving } = useFetchWrapper();
-	const { fireRequest: fireDeleteRequest, isLoading: deleting } = useFetchWrapper();
+  const { fireRequest: fireSaveRequest, isLoading: saving } = useFetchWrapper();
+  const { fireRequest: fireDeleteRequest, isLoading: deleting } =
+    useFetchWrapper();
 
-	const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-	const [formData, setFormData] = useState<Partial<CustomModel>>({
-		id: "", // UUID (only for existing custom models)
-		model_id: "", // Model identifier
-		displayName: "",
-		contextWindow: 4096,
-		inputPricePerMToken: 0,
-		outputPricePerMToken: 0,
-		capabilities: [],
-	});
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [formData, setFormData] = useState<Partial<CustomModel>>({
+    id: "", // UUID (only for existing custom models)
+    model_id: "", // Model identifier
+    displayName: "",
+    contextWindow: 4096,
+    inputPricePerMToken: 0,
+    outputPricePerMToken: 0,
+    capabilities: [],
+  });
 
-	useEffect(() => {
-		if (model && isCustomModel) {
-			// Only allow editing custom models
-			const customModel = model as CustomModel;
-			setFormData({
-				id: customModel.id || "", // UUID for existing custom models
-				model_id: customModel.model_id,
-				displayName: model.displayName,
-				contextWindow: model.contextWindow,
-				inputPricePerMToken: model.inputPricePerMToken,
-				outputPricePerMToken: model.outputPricePerMToken,
-				capabilities: model.capabilities || [],
-			});
-		} else if (isAddingNew) {
-			// Reset form for new model
-			setFormData({
-				id: "",
-				model_id: "",
-				displayName: "",
-				contextWindow: 4096,
-				inputPricePerMToken: 0,
-				outputPricePerMToken: 0,
-				capabilities: [],
-			});
-		}
-	}, [model, isAddingNew, isCustomModel]);
+  useEffect(() => {
+    if (model && isCustomModel) {
+      // Only allow editing custom models
+      const customModel = model as CustomModel;
+      setFormData({
+        id: customModel.id || "", // UUID for existing custom models
+        model_id: customModel.model_id,
+        displayName: model.displayName,
+        contextWindow: model.contextWindow,
+        inputPricePerMToken: model.inputPricePerMToken,
+        outputPricePerMToken: model.outputPricePerMToken,
+        capabilities: model.capabilities || [],
+      });
+    } else if (isAddingNew) {
+      // Reset form for new model
+      setFormData({
+        id: "",
+        model_id: "",
+        displayName: "",
+        contextWindow: 4096,
+        inputPricePerMToken: 0,
+        outputPricePerMToken: 0,
+        capabilities: [],
+      });
+    }
+  }, [model, isAddingNew, isCustomModel]);
 
+  const handleSave = () => {
+    if (!formData.model_id || !formData.displayName || !provider) {
+      toast.error(
+        getMessage().OPENGROUND_MODEL_ID +
+          " and " +
+          getMessage().OPENGROUND_MODEL_DISPLAY_NAME +
+          " are required"
+      );
+      return;
+    }
 
-	const handleSave = () => {
-		if (!formData.model_id || !formData.displayName || !provider) {
-			toast.error(getMessage().OPENGROUND_MODEL_ID + " and " + getMessage().OPENGROUND_MODEL_DISPLAY_NAME + " are required");
-			return;
-		}
+    const payload = {
+      provider: provider,
+      model: {
+        id: formData.model_id,
+        displayName: formData.displayName,
+        contextWindow: formData.contextWindow || 4096,
+        inputPricePerMToken: formData.inputPricePerMToken || 0,
+        outputPricePerMToken: formData.outputPricePerMToken || 0,
+        capabilities: formData.capabilities || [],
+      },
+      // Send UUID customId for updates of existing custom models, undefined for new models
+      customId: formData.id || undefined,
+    };
 
-		const payload = {
-			provider: provider,
-			model: {
-				model_id: formData.model_id,
-				displayName: formData.displayName,
-				contextWindow: formData.contextWindow || 4096,
-				inputPricePerMToken: formData.inputPricePerMToken || 0,
-				outputPricePerMToken: formData.outputPricePerMToken || 0,
-				capabilities: formData.capabilities || [],
-			},
-			// Send UUID id for updates of existing custom models, undefined for new models
-			id: formData.id || undefined,
-		};
+    fireSaveRequest({
+      requestType: "POST",
+      url: "/api/openground/models",
+      body: JSON.stringify(payload),
+      successCb: () => {
+        toast.success(getMessage().OPENGROUND_MODEL_SAVED_SUCCESS, {
+          id: "model-saved",
+        });
+        onSave();
+      },
+      failureCb: (err?: string) => {
+        toast.error(err || getMessage().OPERATION_FAILED, {
+          id: "model-save-error",
+        });
+      },
+    });
+  };
 
-		fireSaveRequest({
-			requestType: "POST",
-			url: "/api/openground/models",
-			body: JSON.stringify(payload),
-			successCb: () => {
-				toast.success(getMessage().OPENGROUND_MODEL_SAVED_SUCCESS, {
-					id: "model-saved",
-				});
-				onSave();
-			},
-			failureCb: (err?: string) => {
-				toast.error(err || getMessage().OPERATION_FAILED, {
-					id: "model-save-error",
-				});
-			},
-		});
-	};
+  const handleDelete = () => {
+    const id = (model as CustomModel)?.id;
+    if (!id) return;
 
-	const handleDelete = () => {
-		const id = (model as CustomModel)?.id;
-		if (!id) return;
+    fireDeleteRequest({
+      requestType: "DELETE",
+      url: `/api/openground/models?id=${id}`,
+      successCb: () => {
+        toast.success(getMessage().OPENGROUND_MODEL_DELETED_SUCCESS, {
+          id: "model-deleted",
+        });
+        setShowDeleteDialog(false);
+        onDelete();
+      },
+      failureCb: (err?: string) => {
+        toast.error(err || getMessage().OPERATION_FAILED, {
+          id: "model-delete-error",
+        });
+      },
+    });
+  };
 
-		fireDeleteRequest({
-			requestType: "DELETE",
-			url: `/api/openground/models?id=${id}`,
-			successCb: () => {
-				toast.success(getMessage().OPENGROUND_MODEL_DELETED_SUCCESS, {
-					id: "model-deleted",
-				});
-				setShowDeleteDialog(false);
-				onDelete();
-			},
-			failureCb: (err?: string) => {
-				toast.error(err || getMessage().OPERATION_FAILED, {
-					id: "model-delete-error",
-				});
-			},
-		});
-	};
+  return (
+    <div className="p-6 max-w-3xl">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">
+              {isAddingNew
+                ? getMessage().OPENGROUND_ADD_CUSTOM_MODEL
+                : getMessage().OPENGROUND_EDIT_MODEL}
+            </CardTitle>
+          </div>
+        </CardHeader>
 
-	return (
-		<div className="p-6 max-w-3xl">
-			<Card>
-				<CardHeader>
-					<div className="flex items-center justify-between">
-						<CardTitle className="text-lg">
-							{isAddingNew
-								? getMessage().OPENGROUND_ADD_CUSTOM_MODEL
-								: getMessage().OPENGROUND_EDIT_MODEL}
-						</CardTitle>
-					</div>
-				</CardHeader>
+        <CardContent className="space-y-4">
+          {/* Model ID */}
+          <div className="space-y-2">
+            <Label htmlFor="model-id">
+              {getMessage().OPENGROUND_MODEL_ID}*
+            </Label>
+            <Input
+              id="model-id"
+              placeholder="gpt-4o-custom"
+              value={formData.model_id}
+              onChange={(e) =>
+                setFormData({ ...formData, model_id: e.target.value })
+              }
+              disabled={!isAddingNew}
+            />
+          </div>
 
-				<CardContent className="space-y-4">
-					{/* Model ID */}
-					<div className="space-y-2">
-						<Label htmlFor="model-id">{getMessage().OPENGROUND_MODEL_ID}*</Label>
-						<Input
-							id="model-id"
-							placeholder="gpt-4o-custom"
-							value={formData.model_id}
-							onChange={(e) => setFormData({ ...formData, model_id: e.target.value })}
-							disabled={!isAddingNew}
-						/>
-					</div>
+          {/* Display Name */}
+          <div className="space-y-2">
+            <Label htmlFor="display-name">
+              {getMessage().OPENGROUND_MODEL_DISPLAY_NAME}*
+            </Label>
+            <Input
+              id="display-name"
+              placeholder="GPT-4o Custom"
+              value={formData.displayName}
+              onChange={(e) =>
+                setFormData({ ...formData, displayName: e.target.value })
+              }
+            />
+          </div>
 
-					{/* Display Name */}
-					<div className="space-y-2">
-						<Label htmlFor="display-name">{getMessage().OPENGROUND_MODEL_DISPLAY_NAME}*</Label>
-						<Input
-							id="display-name"
-							placeholder="GPT-4o Custom"
-							value={formData.displayName}
-							onChange={(e) => setFormData({ ...formData, displayName: e.target.value })}
-						/>
-					</div>
+          {/* Context Window */}
+          <div className="space-y-2">
+            <Label htmlFor="context-window">
+              {getMessage().OPENGROUND_CONTEXT_WINDOW}
+            </Label>
+            <Input
+              id="context-window"
+              type="number"
+              placeholder="4096"
+              value={formData.contextWindow}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  contextWindow: parseInt(e.target.value) || 0,
+                })
+              }
+            />
+          </div>
 
-					{/* Context Window */}
-					<div className="space-y-2">
-						<Label htmlFor="context-window">{getMessage().OPENGROUND_CONTEXT_WINDOW}</Label>
-						<Input
-							id="context-window"
-							type="number"
-							placeholder="4096"
-							value={formData.contextWindow}
-							onChange={(e) => setFormData({ ...formData, contextWindow: parseInt(e.target.value) || 0 })}
-						/>
-					</div>
+          {/* Pricing */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="input-price">
+                {getMessage().OPENGROUND_INPUT_PRICE_PER_M_TOKENS}
+              </Label>
+              <Input
+                id="input-price"
+                type="number"
+                step="0.001"
+                placeholder="0.5"
+                value={formData.inputPricePerMToken}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    inputPricePerMToken: parseFloat(e.target.value) || 0,
+                  })
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="output-price">
+                {getMessage().OPENGROUND_OUTPUT_PRICE_PER_M_TOKENS}
+              </Label>
+              <Input
+                id="output-price"
+                type="number"
+                step="0.001"
+                placeholder="1.5"
+                value={formData.outputPricePerMToken}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    outputPricePerMToken: parseFloat(e.target.value) || 0,
+                  })
+                }
+              />
+            </div>
+          </div>
 
-					{/* Pricing */}
-					<div className="grid grid-cols-2 gap-4">
-						<div className="space-y-2">
-							<Label htmlFor="input-price">{getMessage().OPENGROUND_INPUT_PRICE_PER_M_TOKENS}</Label>
-							<Input
-								id="input-price"
-								type="number"
-								step="0.001"
-								placeholder="0.5"
-								value={formData.inputPricePerMToken}
-								onChange={(e) => setFormData({ ...formData, inputPricePerMToken: parseFloat(e.target.value) || 0 })}
-							/>
-						</div>
-						<div className="space-y-2">
-							<Label htmlFor="output-price">{getMessage().OPENGROUND_OUTPUT_PRICE_PER_M_TOKENS}</Label>
-							<Input
-								id="output-price"
-								type="number"
-								step="0.001"
-								placeholder="1.5"
-								value={formData.outputPricePerMToken}
-								onChange={(e) => setFormData({ ...formData, outputPricePerMToken: parseFloat(e.target.value) || 0 })}
-							/>
-						</div>
-					</div>
+          {/* Capabilities */}
+          <div className="space-y-2">
+            <Label htmlFor="capabilities">
+              {getMessage().OPENGROUND_MODEL_CAPABILITIES}
+            </Label>
+            <Input
+              id="capabilities"
+              placeholder="function-calling, vision, streaming"
+              value={
+                Array.isArray(formData.capabilities)
+                  ? formData.capabilities.join(", ")
+                  : ""
+              }
+              onChange={(e) => {
+                const caps = e.target.value
+                  .split(",")
+                  .map((s) => s.trim())
+                  .filter(Boolean);
+                setFormData({ ...formData, capabilities: caps });
+              }}
+            />
+            <p className="text-xs text-stone-500 dark:text-stone-400">
+              Comma-separated list of model capabilities
+            </p>
+          </div>
 
-					{/* Capabilities */}
-					<div className="space-y-2">
-						<Label htmlFor="capabilities">{getMessage().OPENGROUND_MODEL_CAPABILITIES}</Label>
-						<Input
-							id="capabilities"
-							placeholder="function-calling, vision, streaming"
-							value={Array.isArray(formData.capabilities) ? formData.capabilities.join(", ") : ""}
-							onChange={(e) => {
-								const caps = e.target.value.split(",").map(s => s.trim()).filter(Boolean);
-								setFormData({ ...formData, capabilities: caps });
-							}}
-						/>
-						<p className="text-xs text-stone-500 dark:text-stone-400">
-							Comma-separated list of model capabilities
-						</p>
-					</div>
+          {/* Actions */}
+          {
+            <div className="flex gap-2 pt-4">
+              <Button onClick={handleSave} disabled={saving} className="flex-1">
+                {saving
+                  ? getMessage().SAVING
+                  : getMessage().OPENGROUND_SAVE_MODEL}
+              </Button>
+              {isCustomModel && !isAddingNew && (
+                <Button
+                  variant="destructive"
+                  onClick={() => setShowDeleteDialog(true)}
+                  disabled={deleting}
+                >
+                  <Trash2Icon className="h-4 w-4 mr-2" />
+                  {getMessage().DELETE}
+                </Button>
+              )}
+              <Button variant="outline" onClick={onCancel}>
+                {getMessage().CANCEL}
+              </Button>
+            </div>
+          }
+        </CardContent>
+      </Card>
 
-					{/* Actions */}
-					{(
-						<div className="flex gap-2 pt-4">
-							<Button onClick={handleSave} disabled={saving} className="flex-1">
-								{saving ? getMessage().SAVING : getMessage().OPENGROUND_SAVE_MODEL}
-							</Button>
-							{isCustomModel && !isAddingNew && (
-								<Button
-									variant="destructive"
-									onClick={() => setShowDeleteDialog(true)}
-									disabled={deleting}
-								>
-									<Trash2Icon className="h-4 w-4 mr-2" />
-									{getMessage().DELETE}
-								</Button>
-							)}
-							<Button variant="outline" onClick={onCancel}>
-								{getMessage().CANCEL}
-							</Button>
-						</div>
-					)}
-				</CardContent>
-			</Card>
-
-			{/* Delete Confirmation Dialog */}
-			<Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-				<DialogContent>
-					<DialogHeader>
-						<DialogTitle>{getMessage().OPENGROUND_DELETE_MODEL}</DialogTitle>
-						<DialogDescription>
-							{getMessage().OPENGROUND_DELETE_MODEL_CONFIRMATION}
-						</DialogDescription>
-					</DialogHeader>
-					<DialogFooter>
-						<Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
-							{getMessage().CANCEL}
-						</Button>
-						<Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-							{deleting ? getMessage().LOADING : getMessage().DELETE}
-						</Button>
-					</DialogFooter>
-				</DialogContent>
-			</Dialog>
-		</div>
-	);
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{getMessage().OPENGROUND_DELETE_MODEL}</DialogTitle>
+            <DialogDescription>
+              {getMessage().OPENGROUND_DELETE_MODEL_CONFIRMATION}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteDialog(false)}
+            >
+              {getMessage().CANCEL}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleting}
+            >
+              {deleting ? getMessage().LOADING : getMessage().DELETE}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
 }

--- a/src/client/src/components/(playground)/openground/model-list-sidebar.tsx
+++ b/src/client/src/components/(playground)/openground/model-list-sidebar.tsx
@@ -1,213 +1,244 @@
 "use client";
 
-import { useState, useMemo } from "react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { SearchIcon, PlusIcon, ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import getMessage from "@/constants/messages";
-import { ProviderMetadata, ModelMetadata } from "@/types/openground";
 import { cn } from "@/lib/utils";
+import { ProviderMetadata, ModelMetadata } from "@/types/openground";
+import {
+  SearchIcon,
+  PlusIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+} from "lucide-react";
+import { useState, useMemo } from "react";
 
 interface CustomModel extends ModelMetadata {
-	id: string; // UUID from database
-	model_id: string; // Model identifier like "gpt-4o"
-	provider?: string;
+  id: string; // UUID from database
+  modelId: string; // Model identifier like "gpt-4o"
+  provider?: string;
 }
 
 interface ModelListSidebarProps {
-	providers: ProviderMetadata[];
-	customModels: Record<string, CustomModel[]>;
-	loading: boolean;
-	selectedModel: ModelMetadata | null;
-	selectedProvider: string | null;
-	selectedIsCustom: boolean;
-	onSelectModel: (model: ModelMetadata, provider: string, isCustom: boolean) => void;
-	onAddNew: (provider: string) => void;
+  providers: ProviderMetadata[];
+  customModels: Record<string, CustomModel[]>;
+  loading: boolean;
+  selectedModel: ModelMetadata | null;
+  selectedProvider: string | null;
+  selectedIsCustom: boolean;
+  onSelectModel: (
+    model: ModelMetadata,
+    provider: string,
+    isCustom: boolean
+  ) => void;
+  onAddNew: (provider: string) => void;
 }
 
 export default function ModelListSidebar({
-	providers,
-	customModels,
-	loading,
-	selectedModel,
-	selectedProvider,
-	selectedIsCustom,
-	onSelectModel,
-	onAddNew,
+  providers,
+  customModels,
+  loading,
+  selectedModel,
+  selectedProvider,
+  selectedIsCustom,
+  onSelectModel,
+  onAddNew,
 }: ModelListSidebarProps) {
-	const [searchQuery, setSearchQuery] = useState("");
-	const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
+  const [searchQuery, setSearchQuery] = useState("");
+  const [expandedProviders, setExpandedProviders] = useState<Set<string>>(
+    new Set()
+  );
 
-	const toggleProvider = (providerId: string) => {
-		const newExpanded = new Set(expandedProviders);
-		if (newExpanded.has(providerId)) {
-			newExpanded.delete(providerId);
-		} else {
-			newExpanded.add(providerId);
-		}
-		setExpandedProviders(newExpanded);
-	};
+  const toggleProvider = (providerId: string) => {
+    const newExpanded = new Set(expandedProviders);
+    if (newExpanded.has(providerId)) {
+      newExpanded.delete(providerId);
+    } else {
+      newExpanded.add(providerId);
+    }
+    setExpandedProviders(newExpanded);
+  };
 
-	const filteredProviders = useMemo(() => {
-		if (!searchQuery.trim()) return providers;
+  const filteredProviders = useMemo(() => {
+    if (!searchQuery.trim()) return providers;
 
-		const query = searchQuery.toLowerCase();
-		return providers.filter((provider) => {
-			const matchesProviderName = provider.displayName.toLowerCase().includes(query);
-			const matchesModelName = provider.supportedModels.some((model) =>
-				model.displayName.toLowerCase().includes(query) ||
-				model.id.toLowerCase().includes(query)
-			);
-			const matchesCustomModel = customModels[provider.providerId]?.some((model) =>
-				model.displayName.toLowerCase().includes(query) ||
-				model.model_id.toLowerCase().includes(query)
-			);
+    const query = searchQuery.toLowerCase();
+    return providers.filter((provider) => {
+      const matchesProviderName = provider.displayName
+        .toLowerCase()
+        .includes(query);
+      const matchesModelName = provider.supportedModels.some(
+        (model) =>
+          model.displayName.toLowerCase().includes(query) ||
+          model.id.toLowerCase().includes(query)
+      );
+      const matchesCustomModel = customModels[provider.providerId]?.some(
+        (model) =>
+          model.displayName.toLowerCase().includes(query) ||
+          model.modelId.toLowerCase().includes(query)
+      );
 
-			return matchesProviderName || matchesModelName || matchesCustomModel;
-		});
-	}, [providers, customModels, searchQuery]);
+      return matchesProviderName || matchesModelName || matchesCustomModel;
+    });
+  }, [providers, customModels, searchQuery]);
 
-	const isModelSelected = (model: ModelMetadata, provider: string, isCustom: boolean) => {
-		if (selectedProvider !== provider) return false;
-		if (!selectedModel) return false;
+  const isModelSelected = (
+    model: ModelMetadata,
+    provider: string,
+    isCustom: boolean
+  ) => {
+    if (selectedProvider !== provider) return false;
+    if (!selectedModel) return false;
 
-		// Only custom models can be selected (static models are display-only)
-		if (!isCustom || !selectedIsCustom) return false;
+    // Only custom models can be selected (static models are display-only)
+    if (!isCustom || !selectedIsCustom) return false;
 
-		// Check id (UUID) to match custom models
-		const customModel = model as CustomModel;
-		const selectedCustomModel = selectedModel as CustomModel;
-		return customModel.id === selectedCustomModel.id;
-	};
+    // Check id (UUID) to match custom models
+    const customModel = model as CustomModel;
+    const selectedCustomModel = selectedModel as CustomModel;
+    return customModel.id === selectedCustomModel.id;
+  };
 
-	return (
-		<div className="w-80 border-r border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 flex flex-col">
-			{/* Search */}
-			<div className="p-4 border-b border-stone-200 dark:border-stone-800">
-				<div className="relative">
-					<SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-stone-400" />
-					<Input
-						placeholder={getMessage().OPENGROUND_SEARCH_MODELS}
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-						className="pl-9"
-					/>
-				</div>
-			</div>
+  return (
+    <div className="w-80 border-r border-stone-200 dark:border-stone-800 bg-white dark:bg-stone-900 flex flex-col">
+      {/* Search */}
+      <div className="p-4 border-b border-stone-200 dark:border-stone-800">
+        <div className="relative">
+          <SearchIcon className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-stone-400" />
+          <Input
+            placeholder={getMessage().OPENGROUND_SEARCH_MODELS}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+      </div>
 
-			{/* Provider List */}
-			<div className="flex-1 overflow-y-auto">
-				{loading ? (
-					<div className="p-4 text-center text-sm text-stone-500">
-						{getMessage().LOADING}...
-					</div>
-				) : filteredProviders.length === 0 ? (
-					<div className="p-4 text-center text-sm text-stone-500">
-						{getMessage().OPENGROUND_NO_MODELS_FOUND}
-					</div>
-				) : (
-					<div className="p-2">
-						{filteredProviders.map((provider) => {
-							const isExpanded = expandedProviders.has(provider.providerId);
-							const providerCustomModels = customModels[provider.providerId] || [];
-							const totalModels = provider.supportedModels.length + providerCustomModels.length;
+      {/* Provider List */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="p-4 text-center text-sm text-stone-500">
+            {getMessage().LOADING}...
+          </div>
+        ) : filteredProviders.length === 0 ? (
+          <div className="p-4 text-center text-sm text-stone-500">
+            {getMessage().OPENGROUND_NO_MODELS_FOUND}
+          </div>
+        ) : (
+          <div className="p-2">
+            {filteredProviders.map((provider) => {
+              const isExpanded = expandedProviders.has(provider.providerId);
+              const providerCustomModels =
+                customModels[provider.providerId] || [];
+              const totalModels =
+                provider.supportedModels.length + providerCustomModels.length;
 
-							return (
-								<div key={provider.providerId} className="mb-2">
-									{/* Provider Header */}
-									<button
-										onClick={() => toggleProvider(provider.providerId)}
-										className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
-									>
-										<div className="flex items-center gap-2">
-											{isExpanded ? (
-												<ChevronDownIcon className="h-4 w-4 text-stone-500" />
-											) : (
-												<ChevronRightIcon className="h-4 w-4 text-stone-500" />
-											)}
-											<span className="font-medium text-sm text-stone-900 dark:text-stone-100">
-												{provider.displayName}
-											</span>
-											<Badge variant="secondary" className="text-xs">
-												{totalModels}
-											</Badge>
-										</div>
-										<Button
-											variant="ghost"
-											size="sm"
-											className="h-6 w-6 p-0 text-stone-500"
-											onClick={(e) => {
-												e.stopPropagation();
-												onAddNew(provider.providerId);
-											}}
-										>
-											<PlusIcon className="h-3 w-3" />
-										</Button>
-									</button>
+              return (
+                <div key={provider.providerId} className="mb-2">
+                  {/* Provider Header */}
+                  <button
+                    onClick={() => toggleProvider(provider.providerId)}
+                    className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      {isExpanded ? (
+                        <ChevronDownIcon className="h-4 w-4 text-stone-500" />
+                      ) : (
+                        <ChevronRightIcon className="h-4 w-4 text-stone-500" />
+                      )}
+                      <span className="font-medium text-sm text-stone-900 dark:text-stone-100">
+                        {provider.displayName}
+                      </span>
+                      <Badge variant="secondary" className="text-xs">
+                        {totalModels}
+                      </Badge>
+                    </div>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 w-6 p-0 text-stone-500"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAddNew(provider.providerId);
+                      }}
+                    >
+                      <PlusIcon className="h-3 w-3" />
+                    </Button>
+                  </button>
 
-									{/* Models List */}
-									{isExpanded && (
-										<div className="ml-4 mt-1 space-y-1">
-											{/* Static Models - Display only, not editable */}
-											{provider.supportedModels.map((model) => (
-												<div
-													key={model.id}
-													className="w-full text-left p-2 rounded-md border-l-2 border-transparent opacity-75"
-												>
-													<div className="text-sm font-medium text-stone-700 dark:text-stone-300">{model.displayName}</div>
-													<div className="flex items-center gap-2 mt-1">
-														<Badge variant="outline" className="text-xs">
-															{model.contextWindow.toLocaleString()} tokens
-														</Badge>
-														<Badge variant="outline" className="text-xs">
-															${model.inputPricePerMToken}/M
-														</Badge>
-													</div>
-												</div>
-											))}
+                  {/* Models List */}
+                  {isExpanded && (
+                    <div className="ml-4 mt-1 space-y-1">
+                      {/* Static Models - Display only, not editable */}
+                      {provider.supportedModels.map((model) => (
+                        <div
+                          key={model.id}
+                          className="w-full text-left p-2 rounded-md border-l-2 border-transparent opacity-75"
+                        >
+                          <div className="text-sm font-medium text-stone-700 dark:text-stone-300">
+                            {model.displayName}
+                          </div>
+                          <div className="flex items-center gap-2 mt-1">
+                            <Badge variant="outline" className="text-xs">
+                              {model.contextWindow.toLocaleString()} tokens
+                            </Badge>
+                            <Badge variant="outline" className="text-xs">
+                              ${model.inputPricePerMToken}/M
+                            </Badge>
+                          </div>
+                        </div>
+                      ))}
 
-											{/* Custom Models Section */}
-											{providerCustomModels.length > 0 && (
-												<>
-													<div className="text-xs font-medium text-stone-500 dark:text-stone-400 px-2 py-1 mt-2">
-														{getMessage().OPENGROUND_CUSTOM_MODELS}
-													</div>
-													{providerCustomModels.map((model) => (
-														<button
-															key={model.id}
-															onClick={() => onSelectModel(model, provider.providerId, true)}
-															className={cn(
-																"w-full text-left p-2 rounded-md transition-colors border-l-2",
-																isModelSelected(model, provider.providerId, true)
-																	? "bg-primary/10 dark:bg-primary/20 border-primary text-stone-900 dark:text-stone-100"
-																	: "border-transparent hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-700 dark:text-stone-300"
-															)}
-														>
-															<div className="flex items-center gap-2">
-																<div className="text-sm font-medium">{model.displayName}</div>
-																<Badge className="text-xs h-4">Custom</Badge>
-															</div>
-															<div className="flex items-center gap-2 mt-1">
-																<Badge variant="outline" className="text-xs">
-																	{model.contextWindow.toLocaleString()} tokens
-																</Badge>
-																<Badge variant="outline" className="text-xs">
-																	${model.inputPricePerMToken}/M
-																</Badge>
-															</div>
-														</button>
-													))}
-												</>
-											)}
-										</div>
-									)}
-								</div>
-							);
-						})}
-					</div>
-				)}
-			</div>
-		</div>
-	);
+                      {/* Custom Models Section */}
+                      {providerCustomModels.length > 0 && (
+                        <>
+                          <div className="text-xs font-medium text-stone-500 dark:text-stone-400 px-2 py-1 mt-2">
+                            {getMessage().OPENGROUND_CUSTOM_MODELS}
+                          </div>
+                          {providerCustomModels.map((model) => (
+                            <button
+                              key={model.id}
+                              onClick={() =>
+                                onSelectModel(model, provider.providerId, true)
+                              }
+                              className={cn(
+                                "w-full text-left p-2 rounded-md transition-colors border-l-2",
+                                isModelSelected(
+                                  model,
+                                  provider.providerId,
+                                  true
+                                )
+                                  ? "bg-primary/10 dark:bg-primary/20 border-primary text-stone-900 dark:text-stone-100"
+                                  : "border-transparent hover:bg-stone-100 dark:hover:bg-stone-800 text-stone-700 dark:text-stone-300"
+                              )}
+                            >
+                              <div className="flex items-center gap-2">
+                                <div className="text-sm font-medium">
+                                  {model.displayName}
+                                </div>
+                                <Badge className="text-xs h-4">Custom</Badge>
+                              </div>
+                              <div className="flex items-center gap-2 mt-1">
+                                <Badge variant="outline" className="text-xs">
+                                  {model.contextWindow.toLocaleString()} tokens
+                                </Badge>
+                                <Badge variant="outline" className="text-xs">
+                                  ${model.inputPricePerMToken}/M
+                                </Badge>
+                              </div>
+                            </button>
+                          ))}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
fixes #1107

The POST request from the Manage Models page was sending the wrong field names, causing saves to always fail with a 400.

Two mismatches: the model identifier was sent as model.model_id but the API reads model.id, and the UUID for updates was sent as id at the top level but the API expects customId.

Because model.id was always undefined, the validation check would reject every request. The customId mismatch also meant updates were never recognized as updates and fell through to inserts instead.

Fixed both field names in the handleSave payload in model-editor-panel.tsx.