### PR TITLE
fix(client): sanitize SQL inputs to prevent injection in metrics queries

### DIFF
--- a/src/client/src/__tests__/helpers/server/platform.test.ts
+++ b/src/client/src/__tests__/helpers/server/platform.test.ts
@@ -328,6 +328,42 @@ describe('getFilterWhereCondition', () => {
     expect(result).toContain("= 'it''s'");
   });
 
+  it('escapes single quotes in model names to prevent SQL injection', () => {
+    const result = getFilterWhereCondition(
+      {
+        timeLimit: { start: new Date('2024-01-01'), end: new Date('2024-01-31') },
+        selectedConfig: { models: ["model'; DROP TABLE traces; --"] },
+      } as any,
+      true
+    );
+    expect(result).toContain("'model''; DROP TABLE traces; --'");
+    expect(result).not.toContain("model'; DROP");
+  });
+
+  it('escapes single quotes in provider names to prevent SQL injection', () => {
+    const result = getFilterWhereCondition(
+      {
+        timeLimit: { start: new Date('2024-01-01'), end: new Date('2024-01-31') },
+        selectedConfig: { providers: ["open'ai"] },
+      } as any,
+      true
+    );
+    expect(result).toContain("'open''ai'");
+    expect(result).not.toContain("open'ai'");
+  });
+
+  it('escapes single quotes in environment names to prevent SQL injection', () => {
+    const result = getFilterWhereCondition(
+      {
+        timeLimit: { start: new Date('2024-01-01'), end: new Date('2024-01-31') },
+        selectedConfig: { environments: ["prod'; DROP TABLE traces; --"] },
+      } as any,
+      true
+    );
+    expect(result).toContain("'prod''; DROP TABLE traces; --'");
+    expect(result).not.toContain("prod'; DROP");
+  });
+
   it('adds notOrEmpty conditions', () => {
     const result = getFilterWhereCondition({
       notOrEmpty: [{ key: 'SpanAttributes' }, { key: 'ServiceName' }],

--- a/src/client/src/__tests__/lib/platform/request/request.test.ts
+++ b/src/client/src/__tests__/lib/platform/request/request.test.ts
@@ -231,6 +231,25 @@ describe('getHeirarchyViaSpanId', () => {
     expect(dataCollector).toHaveBeenCalledTimes(2);
     expect(result.err).toBeTruthy();
   });
+
+  it('escapes single quotes in spanId to prevent SQL injection', async () => {
+    (dataCollector as jest.Mock).mockResolvedValue({ data: [], err: null });
+    await getHeirarchyViaSpanId("span'; DROP TABLE otel_traces; --");
+    const { query } = (dataCollector as jest.Mock).mock.calls[0][0];
+    expect(query).toContain("SpanId = 'span''; DROP TABLE otel_traces; --'");
+    expect(query).not.toContain("span'; DROP");
+  });
+
+  it('escapes single quotes in derived traceId in allSpans query', async () => {
+    (dataCollector as jest.Mock)
+      .mockResolvedValueOnce({ data: [{ TraceId: "t1'; DROP TABLE otel_traces; --" }], err: null })
+      .mockResolvedValueOnce({ data: [], err: null });
+
+    await getHeirarchyViaSpanId('safe-span');
+    const { query: allSpansQuery } = (dataCollector as jest.Mock).mock.calls[1][0];
+    expect(allSpansQuery).toContain("t1''; DROP TABLE otel_traces; --'");
+    expect(allSpansQuery).not.toContain("t1'; DROP");
+  });
 });
 
 describe('getRequestExist', () => {

--- a/src/client/src/__tests__/lib/platform/request/request.test.ts
+++ b/src/client/src/__tests__/lib/platform/request/request.test.ts
@@ -130,6 +130,35 @@ describe('getRequests', () => {
     const { query } = (dataCollector as jest.Mock).mock.calls[1][0];
     expect(query).toContain('toInt32OrZero(gen_ai.usage.prompt_tokens)');
   });
+
+  it('sanitizes malicious sorting direction to prevent SQL injection', async () => {
+    (dataCollector as jest.Mock)
+      .mockResolvedValueOnce({ data: [{ total: 5 }], err: null })
+      .mockResolvedValueOnce({ data: [], err: null });
+
+    await getRequests({
+      ...baseParams,
+      sorting: { type: 'Timestamp', direction: "ASC; DROP TABLE otel_traces; --" as any },
+    });
+    const { query } = (dataCollector as jest.Mock).mock.calls[1][0];
+    expect(query).toContain('ORDER BY Timestamp DESC');
+    expect(query).not.toContain('DROP');
+  });
+
+  it('strips unsafe characters from sorting type to prevent SQL injection', async () => {
+    (dataCollector as jest.Mock)
+      .mockResolvedValueOnce({ data: [{ total: 5 }], err: null })
+      .mockResolvedValueOnce({ data: [], err: null });
+
+    await getRequests({
+      ...baseParams,
+      sorting: { type: "Timestamp; DROP TABLE otel_traces; --", direction: 'ASC' },
+    });
+    const { query } = (dataCollector as jest.Mock).mock.calls[1][0];
+    // Semicolons, spaces, and dashes are stripped, preventing statement injection
+    expect(query).not.toContain(';');
+    expect(query).not.toContain('--');
+  });
 });
 
 describe('getRequestViaSpanId', () => {
@@ -143,6 +172,14 @@ describe('getRequestViaSpanId', () => {
     expect(query).toContain("SpanId='span-1'");
     expect(result.record).toEqual({ SpanId: 'span-1', SpanName: 'test' });
   });
+
+  it('escapes single quotes in spanId to prevent SQL injection', async () => {
+    (dataCollector as jest.Mock).mockResolvedValue({ data: [], err: null });
+    await getRequestViaSpanId("span'; DROP TABLE otel_traces; --");
+    const { query } = (dataCollector as jest.Mock).mock.calls[0][0];
+    expect(query).toContain("SpanId='span''; DROP TABLE otel_traces; --'");
+    expect(query).not.toContain("span'; DROP");
+  });
 });
 
 describe('getRequestViaTraceId', () => {
@@ -153,6 +190,14 @@ describe('getRequestViaTraceId', () => {
     });
     const result = await getRequestViaTraceId('trace-1');
     expect(result.record).toEqual({ TraceId: 'trace-1' });
+  });
+
+  it('escapes single quotes in traceId to prevent SQL injection', async () => {
+    (dataCollector as jest.Mock).mockResolvedValue({ data: [], err: null });
+    await getRequestViaTraceId("trace'; DROP TABLE otel_traces; --");
+    const { query } = (dataCollector as jest.Mock).mock.calls[0][0];
+    expect(query).toContain("trace''; DROP TABLE otel_traces; --'");
+    expect(query).not.toContain("trace'; DROP");
   });
 });
 

--- a/src/client/src/helpers/server/platform.ts
+++ b/src/client/src/helpers/server/platform.ts
@@ -8,14 +8,7 @@ import {
 } from "date-fns";
 import { getTraceMappingKeyFullPath } from "../server/trace";
 import { FilterWhereConditionType } from "@/types/platform";
-
-/**
- * Escape a string value for safe inclusion in a ClickHouse SQL single-quoted literal.
- * Prevents SQL injection by escaping single quotes.
- */
-function escapeStringValue(value: string): string {
-	return value.replace(/'/g, "''");
-}
+import { escapeStringValue } from "./sql-sanitize";
 
 export const validateMetricsRequestType = {
 	// Request

--- a/src/client/src/helpers/server/platform.ts
+++ b/src/client/src/helpers/server/platform.ts
@@ -9,6 +9,14 @@ import {
 import { getTraceMappingKeyFullPath } from "../server/trace";
 import { FilterWhereConditionType } from "@/types/platform";
 
+/**
+ * Escape a string value for safe inclusion in a ClickHouse SQL single-quoted literal.
+ * Prevents SQL injection by escaping single quotes.
+ */
+function escapeStringValue(value: string): string {
+	return value.replace(/'/g, "''");
+}
+
 export const validateMetricsRequestType = {
 	// Request
 	REQUEST_PER_TIME: "REQUEST_PER_TIME",
@@ -186,7 +194,7 @@ export const getFilterWhereCondition = (
 					`SpanAttributes['${getTraceMappingKeyFullPath(
 						"model"
 					)}'] IN (${filter.selectedConfig.models
-						.map((model) => `'${model}'`)
+						.map((model) => `'${escapeStringValue(model)}'`)
 						.join(", ")})`
 				);
 			}
@@ -196,11 +204,11 @@ export const getFilterWhereCondition = (
 					`(SpanAttributes['${getTraceMappingKeyFullPath(
 						"system"
 					)}'] IN (${filter.selectedConfig.providers
-						.map((provider) => `'${provider}'`)
+						.map((provider) => `'${escapeStringValue(provider)}'`)
 						.join(", ")}) OR SpanAttributes['${getTraceMappingKeyFullPath(
 						"provider"
 					)}'] IN (${filter.selectedConfig.providers
-						.map((provider) => `'${provider}'`)
+						.map((provider) => `'${escapeStringValue(provider)}'`)
 						.join(", ")}))`
 				);
 			}
@@ -210,7 +218,7 @@ export const getFilterWhereCondition = (
 					`SpanAttributes['${getTraceMappingKeyFullPath(
 						"type"
 					)}'] IN (${filter.selectedConfig.traceTypes
-						.map((type) => `'${type}'`)
+						.map((type) => `'${escapeStringValue(type)}'`)
 						.join(", ")})`
 				);
 			}
@@ -228,7 +236,7 @@ export const getFilterWhereCondition = (
 					`ResourceAttributes['${getTraceMappingKeyFullPath(
 						"applicationName"
 					)}'] IN (${filter.selectedConfig.applicationNames
-						.map((applicationName) => `'${applicationName}'`)
+						.map((applicationName) => `'${escapeStringValue(applicationName)}'`)
 						.join(", ")})`
 				);
 			}
@@ -236,7 +244,7 @@ export const getFilterWhereCondition = (
 			if (filter.selectedConfig.spanNames?.length) {
 				whereArray.push(
 					`SpanName IN (${filter.selectedConfig.spanNames
-						.map((spanName) => `'${spanName}'`)
+						.map((spanName) => `'${escapeStringValue(spanName)}'`)
 						.join(", ")})`
 				);
 			}
@@ -246,7 +254,7 @@ export const getFilterWhereCondition = (
 					`ResourceAttributes['${getTraceMappingKeyFullPath(
 						"environment"
 					)}'] IN (${filter.selectedConfig.environments
-						.map((environment) => `'${environment}'`)
+						.map((environment) => `'${escapeStringValue(environment)}'`)
 						.join(", ")})`
 				);
 			}

--- a/src/client/src/helpers/server/sql-sanitize.ts
+++ b/src/client/src/helpers/server/sql-sanitize.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a string value for safe inclusion in a ClickHouse SQL single-quoted literal.
+ * Prevents SQL injection by escaping single quotes.
+ */
+export function escapeStringValue(value: string): string {
+	return value.replace(/'/g, "''");
+}

--- a/src/client/src/lib/platform/request/index.ts
+++ b/src/client/src/lib/platform/request/index.ts
@@ -9,6 +9,35 @@ import {
 	getFilterWhereCondition,
 } from "@/helpers/server/platform";
 
+/**
+ * Sanitize a sorting direction to prevent SQL injection.
+ * Only allows "ASC" or "DESC" (case-insensitive), defaults to "desc".
+ */
+function sanitizeSortDirection(direction: string): string {
+	const upper = direction.toUpperCase();
+	return upper === "ASC" || upper === "DESC" ? upper : "DESC";
+}
+
+/**
+ * Sanitize a sorting column/type to prevent SQL injection.
+ * Only allows characters valid in ClickHouse column identifiers and
+ * SpanAttributes['...'] accessor patterns.
+ */
+function sanitizeSortType(type: string): string {
+	// Strip any character that isn't alphanumeric, dot, underscore,
+	// single quote, or square bracket — the set needed for column names
+	// and SpanAttributes['gen_ai.usage.cost'] patterns.
+	return type.replace(/[^A-Za-z0-9_.'[\]]/g, "");
+}
+
+/**
+ * Escape a string value for safe inclusion in a ClickHouse SQL single-quoted literal.
+ * Prevents SQL injection by escaping single quotes.
+ */
+function escapeStringValue(value: string): string {
+	return value.replace(/'/g, "''");
+}
+
 export async function getRequestPerTime(params: MetricParams) {
 	const { start, end } = params.timeLimit;
 	const dateTrunc = dateTruncGroupingLogic(end as Date, start as Date);
@@ -162,14 +191,21 @@ export async function getRequests(params: MetricParams) {
 		};
 	}
 
-	const query = `SELECT *	FROM ${OTEL_TRACES_TABLE_NAME} 
+	const safeDirection = params.sorting
+		? sanitizeSortDirection(params.sorting.direction)
+		: "DESC";
+	const safeType = params.sorting
+		? sanitizeSortType(params.sorting.type)
+		: "Timestamp";
+
+	const query = `SELECT *	FROM ${OTEL_TRACES_TABLE_NAME}
 		WHERE ${getFilterWhereCondition(params, true)}
 		${params.sorting
-			? params.sorting.type.includes("cost")
-				? `ORDER BY toFloat64OrZero(${params.sorting.type}) ${params.sorting.direction} `
-				: params.sorting.type.includes("tokens")
-					? `ORDER BY toInt32OrZero(${params.sorting.type}) ${params.sorting.direction} `
-					: `ORDER BY ${params.sorting.type} ${params.sorting.direction} `
+			? safeType.includes("cost")
+				? `ORDER BY toFloat64OrZero(${safeType}) ${safeDirection} `
+				: safeType.includes("tokens")
+					? `ORDER BY toInt32OrZero(${safeType}) ${safeDirection} `
+					: `ORDER BY ${safeType} ${safeDirection} `
 			: `ORDER BY Timestamp desc `
 		}
 		LIMIT ${limit}
@@ -184,8 +220,9 @@ export async function getRequests(params: MetricParams) {
 }
 
 export async function getRequestViaSpanId(spanId: string) {
-	const query = `SELECT *	FROM ${OTEL_TRACES_TABLE_NAME} 
-		WHERE SpanId='${spanId}'`;
+	const safeSpanId = escapeStringValue(spanId);
+	const query = `SELECT *	FROM ${OTEL_TRACES_TABLE_NAME}
+		WHERE SpanId='${safeSpanId}'`;
 
 	const { data, err } = await dataCollector({ query });
 	return {
@@ -195,9 +232,10 @@ export async function getRequestViaSpanId(spanId: string) {
 }
 
 export async function getRequestViaTraceId(traceId: string) {
+	const safeTraceId = escapeStringValue(traceId);
 	const query = `SELECT *	FROM ${OTEL_TRACES_TABLE_NAME} WHERE ${getTraceMappingKeyFullPath(
 		"id"
-	)}='${traceId}'`;
+	)}='${safeTraceId}'`;
 
 	const { data, err } = await dataCollector({ query });
 	return {
@@ -207,11 +245,12 @@ export async function getRequestViaTraceId(traceId: string) {
 }
 
 export async function getHeirarchyViaSpanId(spanId: string) {
+	const safeSpanId = escapeStringValue(spanId);
 	// Step 1: Get the TraceId for this span
 	const traceIdQuery = `
 		SELECT ${getTraceMappingKeyFullPath("id")}
 		FROM ${OTEL_TRACES_TABLE_NAME}
-		WHERE SpanId = '${spanId}'
+		WHERE SpanId = '${safeSpanId}'
 		LIMIT 1`;
 
 	const { data: traceIdData, err: traceIdErr } = await dataCollector({
@@ -229,6 +268,7 @@ export async function getHeirarchyViaSpanId(spanId: string) {
 		return { err: "TraceId not found for span", record: {} };
 	}
 
+	const safeTraceId = escapeStringValue(traceId);
 	// Step 2: Fetch ALL spans belonging to this trace (include SpanAttributes for chat view)
 	const allSpansQuery = `
 		SELECT
@@ -242,7 +282,7 @@ export async function getHeirarchyViaSpanId(spanId: string) {
 			StatusCode,
 			SpanAttributes
 		FROM ${OTEL_TRACES_TABLE_NAME}
-		WHERE ${getTraceMappingKeyFullPath("id")} = '${traceId}'
+		WHERE ${getTraceMappingKeyFullPath("id")} = '${safeTraceId}'
 		ORDER BY Timestamp ASC`;
 
 	const { data: allSpans, err: allSpansErr } = await dataCollector({

--- a/src/client/src/lib/platform/request/index.ts
+++ b/src/client/src/lib/platform/request/index.ts
@@ -8,10 +8,11 @@ import {
 	getFilterPreviousParams,
 	getFilterWhereCondition,
 } from "@/helpers/server/platform";
+import { escapeStringValue } from "@/helpers/server/sql-sanitize";
 
 /**
  * Sanitize a sorting direction to prevent SQL injection.
- * Only allows "ASC" or "DESC" (case-insensitive), defaults to "desc".
+ * Only allows "ASC" or "DESC" (case-insensitive), defaults to "DESC".
  */
 function sanitizeSortDirection(direction: string): string {
 	const upper = direction.toUpperCase();
@@ -21,21 +22,14 @@ function sanitizeSortDirection(direction: string): string {
 /**
  * Sanitize a sorting column/type to prevent SQL injection.
  * Only allows characters valid in ClickHouse column identifiers and
- * SpanAttributes['...'] accessor patterns.
+ * SpanAttributes['...'] accessor patterns. Falls back to "Timestamp"
+ * if the sanitized result is empty.
  */
 function sanitizeSortType(type: string): string {
 	// Strip any character that isn't alphanumeric, dot, underscore,
 	// single quote, or square bracket — the set needed for column names
 	// and SpanAttributes['gen_ai.usage.cost'] patterns.
-	return type.replace(/[^A-Za-z0-9_.'[\]]/g, "");
-}
-
-/**
- * Escape a string value for safe inclusion in a ClickHouse SQL single-quoted literal.
- * Prevents SQL injection by escaping single quotes.
- */
-function escapeStringValue(value: string): string {
-	return value.replace(/'/g, "''");
+	return type.replace(/[^A-Za-z0-9_.'[\]]/g, "") || "Timestamp";
 }
 
 export async function getRequestPerTime(params: MetricParams) {


### PR DESCRIPTION
## Summary

Fixes multiple SQL injection vulnerabilities in the ClickHouse query construction layer where user-controlled values were interpolated directly into raw SQL strings without sanitization.

**Vulnerable sinks addressed:**
- `sorting.type` and `sorting.direction` in ORDER BY clauses (`request/index.ts:167-172`)
- `spanId` and `traceId` in WHERE clauses (`request/index.ts:186-200`)
- `selectedConfig` arrays (models, providers, traceTypes, applicationNames, spanNames, environments) in IN-list clauses (`platform.ts:184-252`)

**Fixes applied:**
- **Sorting direction**: Whitelist validation — only `ASC` or `DESC` allowed, defaults to `DESC` for any other value
- **Sorting type**: Character-level sanitization — strips any character that isn't alphanumeric, dot, underscore, single quote, or square bracket (the set needed for valid column names and `SpanAttributes['...']` patterns)
- **String parameters** (spanId, traceId, IN-list values): Single-quote escaping via `replace(/'/g, "''")`, consistent with the existing `customFilters` escaping pattern already in the codebase

All existing tests pass, and new tests verify each injection vector is properly neutralized.

Closes #1116

## Test plan

- [x] All 143 existing tests in `request.test.ts` and `platform.test.ts` continue to pass
- [x] New test: malicious sorting direction (`ASC; DROP TABLE...`) is rejected and defaults to `DESC`
- [x] New test: malicious sorting type (`Timestamp; DROP TABLE...`) has unsafe characters stripped
- [x] New test: single-quote injection in `spanId` is escaped
- [x] New test: single-quote injection in `traceId` is escaped
- [x] New test: single-quote injection in model/provider/environment IN-lists is escaped
- [x] Full test suite (1550 tests) passes with no regressions

## Summary by Sourcery

Harden ClickHouse metrics query construction against SQL injection by sanitizing user-controlled inputs and updating tests accordingly.

Bug Fixes:
- Sanitize sorting direction and column identifiers in metrics queries to prevent SQL injection via ORDER BY clauses.
- Escape spanId and traceId values used in WHERE clauses to avoid SQL injection in trace and hierarchy lookups.
- Escape user-supplied configuration values (models, providers, traceTypes, applicationNames, spanNames, environments) before building IN-list filters to prevent SQL injection.

Tests:
- Extend platform and request tests to cover SQL injection attempts on sorting parameters, IDs, and configuration filters, ensuring malicious input is safely neutralized.