### PR TITLE
chore: add new providers for pricing and new models

### DIFF
--- a/docs/latest/openlit/pricing/manage-models.mdx
+++ b/docs/latest/openlit/pricing/manage-models.mdx
@@ -29,7 +29,27 @@ Every ClickHouse database connected to OpenLIT automatically gets a pre-populate
 | Hugging Face | Llama 3 70B, Mistral 7B, Gemma 2 9B |
 | Replicate | Llama 3 70B, Llama 3 8B, Mixtral 8x7B |
 
-## Get started
+## Managing providers
+
+Providers (e.g. OpenAI, Anthropic) are the top-level grouping for models. OpenLIT ships with 14 built-in providers, but you can add your own or edit any existing one.
+
+<Steps>
+  <Step title="Add a new provider">
+    Click the **Add Provider** button (`+` icon) in the header toolbar. Fill in:
+    - **Provider ID** — a lowercase slug (e.g. `my-llm`). As you type, special characters are automatically replaced with hyphens. This must match the value your SDK sends in `gen_ai.system`.
+    - **Display Name** — the label shown in the UI (e.g. "My LLM").
+    - **Description** — optional, shown in provider lists.
+    - **Requires API Key** — toggle on if the provider needs a Vault secret.
+  </Step>
+  <Step title="Edit an existing provider">
+    Hover over a provider name in the sidebar and click the pencil icon. You can change the display name, description, and vault requirement. The Provider ID cannot be changed after creation.
+  </Step>
+  <Step title="Delete a provider">
+    Use the `DELETE /api/openground/providers?provider=<id>` API endpoint. This removes the provider **and all its models**.
+  </Step>
+</Steps>
+
+## Managing models
 
 <Steps>
   <Step title="Open Manage Models">
@@ -141,9 +161,9 @@ The URL contains your database config ID. While the endpoint only returns pricin
 The SDK fetches this URL on startup. If you update a model's price in Manage Models, restart your app (or wait for the SDK's refresh interval) to pick up the new pricing.
 </Note>
 
-## Import pricing JSON
+## Import providers and models
 
-You can bulk-import models from a JSON file. This is useful for syncing pricing across environments or importing from a colleague's export.
+You can bulk-import providers and models from a JSON file. This is useful for syncing across environments, sharing setups with teammates, or adding a custom provider with all its models in one step.
 
 <Steps>
   <Step title="Open the import dialog">
@@ -152,7 +172,29 @@ You can bulk-import models from a JSON file. This is useful for syncing pricing 
   <Step title="Paste JSON">
     Paste either the **structured format** or the **SDK pricing_json format**.
 
-    **Structured format** (recommended — includes provider and metadata):
+    **Structured format with providers + models** (recommended):
+    ```json
+    {
+      "providers": [
+        {
+          "providerId": "my-provider",
+          "displayName": "My Provider",
+          "description": "Custom LLM provider"
+        }
+      ],
+      "models": [
+        {
+          "provider": "my-provider",
+          "model_id": "my-model-v1",
+          "displayName": "My Model v1",
+          "inputPricePerMToken": 2.5,
+          "outputPricePerMToken": 10
+        }
+      ]
+    }
+    ```
+
+    **Models only** (provider must already exist):
     ```json
     {
       "models": [
@@ -177,15 +219,33 @@ You can bulk-import models from a JSON file. This is useful for syncing pricing 
     ```
   </Step>
   <Step title="Import">
-    Click **Import Pricing JSON**. Models that already exist (same `provider` + `model_id`) are automatically **skipped** — no duplicates are created.
+    Click **Import Pricing JSON**. Providers and models that already exist are automatically **skipped** — no duplicates are created. The response shows counts for both:
+    - `imported` / `skipped` — models
+    - `providersImported` / `providersSkipped` — providers
   </Step>
 </Steps>
 
 **Endpoint:** `POST /api/openground/models/import` (authenticated)
 
+## API reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/openground/providers` | `GET` | List all providers with models |
+| `/api/openground/providers` | `POST` | Create a new provider |
+| `/api/openground/providers` | `PUT` | Update a provider's metadata |
+| `/api/openground/providers?provider=<id>` | `DELETE` | Delete a provider and all its models |
+| `/api/openground/models` | `GET` | List all models |
+| `/api/openground/models` | `POST` | Create or update a model |
+| `/api/openground/models` | `DELETE` | Delete a model |
+| `/api/openground/models/import` | `POST` | Bulk import providers + models from JSON |
+| `/api/openground/models/export` | `GET` | Export pricing as downloadable JSON |
+| `/api/pricing/export/{dbConfigId}` | `GET` | Public pricing URL for SDK (no auth) |
+
 ## Architecture
 
-- **ClickHouse tables**: `openlit_providers` (API key configs) and `openlit_provider_models` (all models with pricing).
-- **No `database_config_id` column** — each ClickHouse instance is its own scope. When you connect a new ClickHouse database, the migration automatically creates the tables and seeds all default models.
+- **ClickHouse tables**: `openlit_provider_metadata` (provider definitions), `openlit_providers` (API key configs), and `openlit_provider_models` (all models with pricing).
+- **No `database_config_id` column** — each ClickHouse instance is its own scope. When you connect a new ClickHouse database, the migration automatically creates the tables and seeds all default providers and models.
+- **Fully dynamic** — both providers and models are stored in ClickHouse and editable via the UI or API. No hardcoded provider list.
 - **Platform library**: `src/lib/platform/providers/` — `provider-registry.ts`, `models-service.ts`, `config.ts`, `default-models.ts`.
-- **API routes**: `GET/POST/DELETE /api/openground/models`, `GET /api/openground/models/export`, `GET /api/openground/providers`, `POST /api/openground/models/import`, `GET /api/pricing/export/{dbConfigId}` (public).
+- **Seeding**: `default-models.ts` contains the initial 14 providers and 45+ models used only by the migration for first-run seeding.

--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openlit",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openlit",
-      "version": "1.18.0",
+      "version": "1.18.1",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.6",
         "@ai-sdk/cohere": "^3.0.3",

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openlit",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/client/src/__tests__/lib/platform/providers/provider-registry.test.ts
+++ b/src/client/src/__tests__/lib/platform/providers/provider-registry.test.ts
@@ -9,7 +9,28 @@ jest.mock('@/utils/sanitizer', () => ({
 import { ProviderRegistry } from '@/lib/platform/providers/provider-registry';
 import { dataCollector } from '@/lib/platform/common';
 
-const mockModels = [
+const Sanitizer = require('@/utils/sanitizer').default;
+
+const mockProviderRows = [
+  {
+    provider_id: 'openai',
+    display_name: 'OpenAI',
+    description: 'GPT models',
+    requires_vault: true,
+    config_schema: JSON.stringify({ temperature: { min: 0, max: 2, step: 0.1, default: 1 } }),
+    is_default: true,
+  },
+  {
+    provider_id: 'anthropic',
+    display_name: 'Anthropic',
+    description: 'Claude models',
+    requires_vault: true,
+    config_schema: '{}',
+    is_default: true,
+  },
+];
+
+const mockModelRows = [
   {
     provider: 'openai',
     id: 'gpt-4o',
@@ -20,90 +41,71 @@ const mockModels = [
     outputPricePerMToken: 10.0,
     capabilities: ['streaming'],
   },
-  {
-    provider: 'anthropic',
-    id: 'claude-3-5-sonnet-20240620',
-    displayName: 'Claude 3.5 Sonnet',
-    modelType: 'chat',
-    contextWindow: 200000,
-    inputPricePerMToken: 3.0,
-    outputPricePerMToken: 15.0,
-    capabilities: ['streaming', 'vision'],
-  },
 ];
 
 beforeEach(() => {
   jest.resetAllMocks();
+  Sanitizer.sanitizeValue.mockImplementation((v: string) => v);
 });
 
+// Helper: mock dataCollector for 2 parallel calls (providers metadata + models)
+function mockGetAvailableProviders(providerRows: any[] = mockProviderRows, modelRows: any[] = mockModelRows) {
+  (dataCollector as jest.Mock)
+    .mockResolvedValueOnce({ data: providerRows }) // provider metadata query
+    .mockResolvedValueOnce({ data: modelRows }); // models query
+}
+
 describe('ProviderRegistry', () => {
-  describe('getProviderMetadata', () => {
-    it('returns static metadata for a known provider', () => {
-      const meta = ProviderRegistry.getProviderMetadata('openai');
-      expect(meta).not.toBeNull();
-      expect(meta!.providerId).toBe('openai');
-      expect(meta!.displayName).toBe('OpenAI');
-      expect(meta).toHaveProperty('configSchema');
-      expect(meta).toHaveProperty('requiresVault');
-    });
-
-    it('returns null for an unknown provider', () => {
-      expect(ProviderRegistry.getProviderMetadata('nonexistent')).toBeNull();
-    });
-  });
-
-  describe('getAllProviderMetadata', () => {
-    it('returns all static providers', () => {
-      const all = ProviderRegistry.getAllProviderMetadata();
-      expect(all.length).toBeGreaterThan(10);
-      const ids = all.map((p) => p.providerId);
-      expect(ids).toContain('openai');
-      expect(ids).toContain('anthropic');
-      expect(ids).toContain('google');
-    });
-  });
-
   describe('getAvailableProviders', () => {
-    it('returns providers with models from DB', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({ data: mockModels });
+    it('returns providers with models merged from DB', async () => {
+      mockGetAvailableProviders();
 
       const providers = await ProviderRegistry.getAvailableProviders('db-1');
 
-      expect(dataCollector).toHaveBeenCalledWith(
-        expect.objectContaining({ query: expect.stringContaining('openlit_provider_models') }),
-        'query',
-        'db-1'
-      );
+      // Should call dataCollector twice (provider metadata + models)
+      expect(dataCollector).toHaveBeenCalledTimes(2);
 
       const openai = providers.find((p) => p.providerId === 'openai');
       expect(openai).toBeDefined();
-      expect(openai!.supportedModels.length).toBeGreaterThanOrEqual(1);
+      expect(openai!.displayName).toBe('OpenAI');
+      expect(openai!.supportedModels).toHaveLength(1);
       expect(openai!.supportedModels[0].id).toBe('gpt-4o');
+
+      const anthropic = providers.find((p) => p.providerId === 'anthropic');
+      expect(anthropic).toBeDefined();
+      expect(anthropic!.supportedModels).toEqual([]);
     });
 
-    it('returns providers with empty models when DB returns no data', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({ data: [] });
+    it('parses configSchema from JSON string', async () => {
+      mockGetAvailableProviders();
 
       const providers = await ProviderRegistry.getAvailableProviders('db-1');
       const openai = providers.find((p) => p.providerId === 'openai');
-      expect(openai).toBeDefined();
-      expect(openai!.supportedModels).toEqual([]);
+      expect(openai!.configSchema.temperature).toEqual(
+        expect.objectContaining({ min: 0, max: 2 })
+      );
     });
 
-    it('returns providers with empty models on DB error', async () => {
+    it('returns empty array when no providers in DB', async () => {
+      mockGetAvailableProviders([], []);
+
+      const providers = await ProviderRegistry.getAvailableProviders('db-1');
+      expect(providers).toEqual([]);
+    });
+
+    it('handles DB errors gracefully', async () => {
       (dataCollector as jest.Mock).mockRejectedValue(new Error('DB down'));
 
       const providers = await ProviderRegistry.getAvailableProviders('db-1');
-      expect(providers.length).toBeGreaterThan(0);
-      providers.forEach((p) => expect(p.supportedModels).toEqual([]));
+      expect(providers).toEqual([]);
     });
   });
 
   describe('getProviderById', () => {
-    it('returns the provider with models when found', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({
-        data: [mockModels[0]],
-      });
+    it('returns provider with models', async () => {
+      (dataCollector as jest.Mock)
+        .mockResolvedValueOnce({ data: [mockProviderRows[0]] }) // single provider
+        .mockResolvedValueOnce({ data: mockModelRows }); // models
 
       const provider = await ProviderRegistry.getProviderById('openai', 'db-1');
       expect(provider).not.toBeNull();
@@ -111,23 +113,21 @@ describe('ProviderRegistry', () => {
       expect(provider!.supportedModels).toHaveLength(1);
     });
 
-    it('returns null for an unknown provider', async () => {
+    it('returns null when provider not found in DB', async () => {
+      (dataCollector as jest.Mock).mockResolvedValueOnce({ data: [] });
+
       const provider = await ProviderRegistry.getProviderById('nonexistent', 'db-1');
       expect(provider).toBeNull();
-      expect(dataCollector).not.toHaveBeenCalled();
     });
   });
 
   describe('getModel', () => {
     it('returns a specific model', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({
-        data: [mockModels[0]],
-      });
+      (dataCollector as jest.Mock).mockResolvedValue({ data: mockModelRows });
 
       const model = await ProviderRegistry.getModel('openai', 'gpt-4o', 'db-1');
       expect(model).not.toBeNull();
       expect(model!.id).toBe('gpt-4o');
-      expect(model!.inputPricePerMToken).toBe(2.5);
     });
 
     it('returns null when model not found', async () => {
@@ -139,19 +139,36 @@ describe('ProviderRegistry', () => {
   });
 
   describe('searchProviders', () => {
-    it('filters providers by name', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({ data: mockModels });
+    it('filters providers by display name', async () => {
+      mockGetAvailableProviders();
 
-      const results = await ProviderRegistry.searchProviders('groq', 'db-1');
-      expect(results.length).toBe(1);
-      expect(results[0].providerId).toBe('groq');
+      const results = await ProviderRegistry.searchProviders('anthropic', 'db-1');
+      expect(results).toHaveLength(1);
+      expect(results[0].providerId).toBe('anthropic');
     });
 
-    it('returns empty array when nothing matches', async () => {
-      (dataCollector as jest.Mock).mockResolvedValue({ data: [] });
+    it('is case-insensitive', async () => {
+      mockGetAvailableProviders();
+
+      const results = await ProviderRegistry.searchProviders('OPENAI', 'db-1');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('returns empty for no match', async () => {
+      mockGetAvailableProviders();
 
       const results = await ProviderRegistry.searchProviders('zzzzz', 'db-1');
       expect(results).toEqual([]);
+    });
+  });
+
+  describe('getProviderModels', () => {
+    it('returns models for a provider', async () => {
+      (dataCollector as jest.Mock).mockResolvedValue({ data: mockModelRows });
+
+      const models = await ProviderRegistry.getProviderModels('openai', 'db-1');
+      expect(models).toHaveLength(1);
+      expect(models[0].id).toBe('gpt-4o');
     });
   });
 });

--- a/src/client/src/__tests__/lib/platform/providers/provider-registry.test.ts
+++ b/src/client/src/__tests__/lib/platform/providers/provider-registry.test.ts
@@ -93,11 +93,12 @@ describe('ProviderRegistry', () => {
       expect(providers).toEqual([]);
     });
 
-    it('handles DB errors gracefully', async () => {
-      (dataCollector as jest.Mock).mockRejectedValue(new Error('DB down'));
+    it('propagates DB errors to the caller', async () => {
+      (dataCollector as jest.Mock).mockResolvedValue({ err: 'connection refused' });
 
-      const providers = await ProviderRegistry.getAvailableProviders('db-1');
-      expect(providers).toEqual([]);
+      await expect(
+        ProviderRegistry.getAvailableProviders('db-1')
+      ).rejects.toThrow('Failed to load provider metadata');
     });
   });
 
@@ -114,10 +115,18 @@ describe('ProviderRegistry', () => {
     });
 
     it('returns null when provider not found in DB', async () => {
-      (dataCollector as jest.Mock).mockResolvedValueOnce({ data: [] });
+      (dataCollector as jest.Mock).mockResolvedValue({ data: [] });
 
       const provider = await ProviderRegistry.getProviderById('nonexistent', 'db-1');
       expect(provider).toBeNull();
+    });
+
+    it('propagates DB errors', async () => {
+      (dataCollector as jest.Mock).mockResolvedValue({ err: 'query failed' });
+
+      await expect(
+        ProviderRegistry.getProviderById('openai', 'db-1')
+      ).rejects.toThrow('Failed to load provider openai');
     });
   });
 

--- a/src/client/src/app/(playground)/manage-models/page.tsx
+++ b/src/client/src/app/(playground)/manage-models/page.tsx
@@ -11,11 +11,15 @@ import {
 	Copy,
 	Link as LinkIcon,
 	Code2,
+	PlusCircle,
 } from "lucide-react";
 import getMessage from "@/constants/messages";
 import ModelListSidebar from "@/components/(playground)/openground/model-list-sidebar";
 import ModelEditorPanel from "@/components/(playground)/openground/model-editor-panel";
 import SdkUsageDialog from "@/components/(playground)/openground/sdk-usage-dialog";
+import ProviderEditorDialog, {
+	ProviderFormData,
+} from "@/components/(playground)/openground/provider-editor-dialog";
 import { ProviderMetadata, ModelMetadata } from "@/types/openground";
 import useFetchWrapper from "@/utils/hooks/useFetchWrapper";
 import {
@@ -51,6 +55,8 @@ export default function ManageModelsPage() {
 	const [isAddingNew, setIsAddingNew] = useState(false);
 	const [showImport, setShowImport] = useState(false);
 	const [showSdkUsage, setShowSdkUsage] = useState(false);
+	const [showProviderEditor, setShowProviderEditor] = useState(false);
+	const [editingProvider, setEditingProvider] = useState<ProviderFormData | null>(null);
 	const [importJson, setImportJson] = useState("");
 
 	// Pull the active database config from the zustand store
@@ -120,6 +126,26 @@ export default function ManageModelsPage() {
 		setIsCustomModel(false);
 	};
 
+	const handleAddProvider = () => {
+		setEditingProvider(null);
+		setShowProviderEditor(true);
+	};
+
+	const handleEditProvider = (provider: ProviderMetadata) => {
+		setEditingProvider({
+			providerId: provider.providerId,
+			displayName: provider.displayName,
+			description: provider.description || "",
+			requiresVault: provider.requiresVault,
+		});
+		setShowProviderEditor(true);
+	};
+
+	const handleProviderSaved = () => {
+		loadProviders();
+		loadAllCustomModels();
+	};
+
 	// Build the public pricing URL from the active db config
 	const pricingUrl = dbConfigId
 		? `${typeof window !== "undefined" ? window.location.origin : ""}/api/pricing/export/${dbConfigId}`
@@ -173,8 +199,22 @@ export default function ManageModelsPage() {
 					</p>
 				</div>
 				<div className="flex items-center gap-2">
+					<Tooltip>
+						<TooltipTrigger>
+							<Button
+								variant="outline"
+								size="sm"
+								className="gap-2"
+								onClick={handleAddProvider}
+							>
+								<PlusCircle className="h-4 w-4" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent>
+							{m.MANAGE_PROVIDERS_ADD}
+						</TooltipContent>
+					</Tooltip>
 					{pricingUrl && (
-
 						<Tooltip>
 							<TooltipTrigger>
 								<Button
@@ -262,6 +302,7 @@ export default function ManageModelsPage() {
 					selectedIsCustom={isCustomModel}
 					onSelectModel={handleSelectModel}
 					onAddNew={handleAddNew}
+					onEditProvider={handleEditProvider}
 				/>
 
 				<div className="flex-1 overflow-auto bg-stone-50 dark:bg-stone-950">
@@ -315,11 +356,18 @@ export default function ManageModelsPage() {
 					</DialogHeader>
 					<Textarea
 						placeholder={`{
+  "providers": [
+    {
+      "providerId": "my-provider",
+      "displayName": "My Provider",
+      "description": "Custom LLM provider"
+    }
+  ],
   "models": [
     {
-      "provider": "openai",
-      "model_id": "gpt-4o-2024-08-06",
-      "displayName": "GPT-4o (Aug 2024)",
+      "provider": "my-provider",
+      "model_id": "my-model-v1",
+      "displayName": "My Model v1",
       "inputPricePerMToken": 2.5,
       "outputPricePerMToken": 10
     }
@@ -345,6 +393,14 @@ export default function ManageModelsPage() {
 				open={showSdkUsage}
 				onOpenChange={setShowSdkUsage}
 				pricingUrl={pricingUrl}
+			/>
+
+			{/* Provider Editor Dialog */}
+			<ProviderEditorDialog
+				open={showProviderEditor}
+				onOpenChange={setShowProviderEditor}
+				provider={editingProvider}
+				onSaved={handleProviderSaved}
 			/>
 		</div>
 	);

--- a/src/client/src/app/api/openground/models/import/route.ts
+++ b/src/client/src/app/api/openground/models/import/route.ts
@@ -4,7 +4,10 @@ import { authOptions } from "@/app/auth";
 import { dataCollector } from "@/lib/platform/common";
 import { getDBConfigByUser } from "@/lib/db-config";
 import getMessage from "@/constants/messages";
-import { OPENLIT_PROVIDER_MODELS_TABLE_NAME } from "@/lib/platform/providers/table-details";
+import {
+	OPENLIT_PROVIDER_MODELS_TABLE_NAME,
+	OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+} from "@/lib/platform/providers/table-details";
 import asaw from "@/utils/asaw";
 
 interface SessionWithId {
@@ -126,62 +129,106 @@ export async function POST(request: NextRequest) {
 		}
 	}
 
-	if (modelsToImport.length === 0) {
+	// --- Import providers if present ---
+	let providersImported = 0;
+	let providersSkipped = 0;
+
+	if (Array.isArray(body.providers) && body.providers.length > 0) {
+		const { data: existingProviders } = await dataCollector(
+			{
+				query: `SELECT provider_id FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL`,
+			},
+			"query",
+			dbConfig.id
+		);
+
+		const existingProviderIds = new Set(
+			((existingProviders as any[]) || []).map((r: any) => r.provider_id)
+		);
+
+		const providersToInsert = body.providers
+			.filter((p: any) => p.providerId && !existingProviderIds.has(p.providerId))
+			.map((p: any) => ({
+				provider_id: p.providerId,
+				display_name: p.displayName || p.providerId,
+				description: p.description || "",
+				requires_vault: p.requiresVault ?? true,
+				config_schema: JSON.stringify(p.configSchema || {}),
+				is_default: false,
+			}));
+
+		providersSkipped = body.providers.length - providersToInsert.length;
+
+		if (providersToInsert.length > 0) {
+			await dataCollector(
+				{
+					table: OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+					values: providersToInsert,
+				},
+				"insert",
+				dbConfig.id
+			);
+			providersImported = providersToInsert.length;
+		}
+	}
+
+	// --- Import models ---
+	if (modelsToImport.length === 0 && providersImported === 0 && providersSkipped === 0) {
 		return NextResponse.json(
-			{ error: "No models to import. Provide a 'models' array or SDK pricing_json format." },
+			{ error: "No models or providers to import." },
 			{ status: 400 }
 		);
 	}
 
-	// Fetch existing models to skip duplicates
-	const existingQuery = `
-		SELECT provider, model_id
-		FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
-	`;
-	const { data: existingRows } = await dataCollector(
-		{ query: existingQuery },
-		"query",
-		dbConfig.id
-	);
+	let modelsImported = 0;
+	let modelsSkipped = 0;
 
-	const existingKeys = new Set(
-		((existingRows as any[]) || []).map((r: any) => `${r.provider}::${r.model_id}`)
-	);
-
-	const toInsert = modelsToImport.filter(
-		(m) => !existingKeys.has(`${m.provider}::${m.model_id}`)
-	);
-
-	const skipped = modelsToImport.length - toInsert.length;
-
-	if (toInsert.length === 0) {
-		return NextResponse.json({
-			success: true,
-			imported: 0,
-			skipped,
-			message: "All models already exist",
-		});
-	}
-
-	const { err } = await dataCollector(
-		{
-			table: OPENLIT_PROVIDER_MODELS_TABLE_NAME,
-			values: toInsert,
-		},
-		"insert",
-		dbConfig.id
-	);
-
-	if (err) {
-		return NextResponse.json(
-			{ error: err || getMessage().OPERATION_FAILED },
-			{ status: 500 }
+	if (modelsToImport.length > 0) {
+		const { data: existingRows } = await dataCollector(
+			{
+				query: `SELECT provider, model_id FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}`,
+			},
+			"query",
+			dbConfig.id
 		);
+
+		const existingKeys = new Set(
+			((existingRows as any[]) || []).map(
+				(r: any) => `${r.provider}::${r.model_id}`
+			)
+		);
+
+		const toInsert = modelsToImport.filter(
+			(m) => !existingKeys.has(`${m.provider}::${m.model_id}`)
+		);
+
+		modelsSkipped = modelsToImport.length - toInsert.length;
+
+		if (toInsert.length > 0) {
+			const { err } = await dataCollector(
+				{
+					table: OPENLIT_PROVIDER_MODELS_TABLE_NAME,
+					values: toInsert,
+				},
+				"insert",
+				dbConfig.id
+			);
+
+			if (err) {
+				return NextResponse.json(
+					{ error: err || getMessage().OPERATION_FAILED },
+					{ status: 500 }
+				);
+			}
+			modelsImported = toInsert.length;
+		}
 	}
 
 	return NextResponse.json({
 		success: true,
-		imported: toInsert.length,
-		skipped,
+		imported: modelsImported,
+		skipped: modelsSkipped,
+		providersImported,
+		providersSkipped,
 	});
 }

--- a/src/client/src/app/api/openground/providers/route.ts
+++ b/src/client/src/app/api/openground/providers/route.ts
@@ -12,7 +12,10 @@ import {
 	searchProvidersWithCustomModels,
 } from "@/lib/platform/providers/provider-service";
 import { dataCollector } from "@/lib/platform/common";
-import { OPENLIT_PROVIDER_METADATA_TABLE_NAME } from "@/lib/platform/providers/table-details";
+import {
+	OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+	OPENLIT_PROVIDER_MODELS_TABLE_NAME,
+} from "@/lib/platform/providers/table-details";
 
 /**
  * GET /api/openground/providers
@@ -189,7 +192,12 @@ export async function POST(request: NextRequest) {
 
 /**
  * PUT /api/openground/providers
- * Update an existing provider's metadata
+ * Update an existing provider's metadata.
+ *
+ * Since the table uses ReplacingMergeTree, we INSERT a new row with the same
+ * provider_id — the engine deduplicates by primary key, keeping the row with
+ * the latest updated_at. This avoids string-interpolated ALTER TABLE UPDATE
+ * and the SQL injection surface that comes with it.
  */
 export async function PUT(request: NextRequest) {
 	try {
@@ -219,28 +227,48 @@ export async function PUT(request: NextRequest) {
 			);
 		}
 
-		const updateFields: string[] = [];
-		if (displayName !== undefined) {
-			updateFields.push(`display_name = '${Sanitizer.sanitizeValue(displayName)}'`);
-		}
-		if (description !== undefined) {
-			updateFields.push(`description = '${Sanitizer.sanitizeValue(description)}'`);
-		}
-		if (requiresVault !== undefined) {
-			updateFields.push(`requires_vault = ${!!requiresVault}`);
-		}
-		if (configSchema !== undefined) {
-			updateFields.push(`config_schema = '${Sanitizer.sanitizeValue(JSON.stringify(configSchema))}'`);
-		}
-		updateFields.push(`updated_at = now()`);
-
-		const query = `
-			ALTER TABLE ${OPENLIT_PROVIDER_METADATA_TABLE_NAME}
-			UPDATE ${updateFields.join(", ")}
+		// Fetch the existing row so we can merge unchanged fields
+		const existingQuery = `
+			SELECT provider_id, display_name, description, requires_vault, config_schema, is_default
+			FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
 			WHERE provider_id = '${Sanitizer.sanitizeValue(providerId)}'
+			LIMIT 1
 		`;
+		const { data: existingRows } = await dataCollector(
+			{ query: existingQuery },
+			"query",
+			dbConfig.id
+		);
 
-		const { err } = await dataCollector({ query }, "exec", dbConfig.id);
+		const existing = (existingRows as any[])?.[0];
+		if (!existing) {
+			return NextResponse.json(
+				{ error: "Provider not found" },
+				{ status: 404 }
+			);
+		}
+
+		// INSERT a new row — ReplacingMergeTree deduplicates by provider_id
+		const { err } = await dataCollector(
+			{
+				table: OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+				values: [
+					{
+						provider_id: providerId,
+						display_name: displayName ?? existing.display_name,
+						description: description ?? existing.description,
+						requires_vault: requiresVault ?? existing.requires_vault,
+						config_schema:
+							configSchema !== undefined
+								? JSON.stringify(configSchema)
+								: existing.config_schema,
+						is_default: existing.is_default,
+					},
+				],
+			},
+			"insert",
+			dbConfig.id
+		);
 
 		if (err) {
 			return NextResponse.json(
@@ -304,7 +332,7 @@ export async function DELETE(request: NextRequest) {
 			),
 			dataCollector(
 				{
-					query: `DELETE FROM openlit_provider_models WHERE provider = '${sanitizedId}'`,
+					query: `DELETE FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME} WHERE provider = '${sanitizedId}'`,
 				},
 				"exec",
 				dbConfig.id

--- a/src/client/src/app/api/openground/providers/route.ts
+++ b/src/client/src/app/api/openground/providers/route.ts
@@ -4,12 +4,15 @@ import { getCurrentUser } from "@/lib/session";
 import { getDBConfigByUser } from "@/lib/db-config";
 import getMessage from "@/constants/messages";
 import PostHogServer from "@/lib/posthog";
+import Sanitizer from "@/utils/sanitizer";
 import asaw from "@/utils/asaw";
 import {
 	getAllProvidersWithCustomModels,
 	getProviderByIdWithCustomModels,
 	searchProvidersWithCustomModels,
 } from "@/lib/platform/providers/provider-service";
+import { dataCollector } from "@/lib/platform/common";
+import { OPENLIT_PROVIDER_METADATA_TABLE_NAME } from "@/lib/platform/providers/table-details";
 
 /**
  * GET /api/openground/providers
@@ -110,6 +113,214 @@ export async function GET(request: NextRequest) {
 			startTimestamp,
 		});
 		console.error("Providers GET error:", error);
+		return NextResponse.json(
+			{ error: getMessage().OPERATION_FAILED },
+			{ status: 500 }
+		);
+	}
+}
+
+/**
+ * POST /api/openground/providers
+ * Create a new provider
+ */
+export async function POST(request: NextRequest) {
+	try {
+		const user = await getCurrentUser();
+		if (!user) {
+			return NextResponse.json(
+				{ error: getMessage().UNAUTHORIZED_USER },
+				{ status: 401 }
+			);
+		}
+
+		const [, dbConfig] = await asaw(getDBConfigByUser(true));
+		if (!dbConfig?.id) {
+			return NextResponse.json(
+				{ error: getMessage().DATABASE_CONFIG_NOT_FOUND },
+				{ status: 500 }
+			);
+		}
+
+		const body = await request.json();
+		const { providerId, displayName, description, requiresVault, configSchema } = body;
+
+		if (!providerId || !displayName) {
+			return NextResponse.json(
+				{ error: "Provider ID and display name are required" },
+				{ status: 400 }
+			);
+		}
+
+		const { err } = await dataCollector(
+			{
+				table: OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+				values: [
+					{
+						provider_id: providerId,
+						display_name: displayName,
+						description: description || "",
+						requires_vault: requiresVault ?? true,
+						config_schema: JSON.stringify(configSchema || {}),
+						is_default: false,
+					},
+				],
+			},
+			"insert",
+			dbConfig.id
+		);
+
+		if (err) {
+			return NextResponse.json(
+				{ error: err || getMessage().OPERATION_FAILED },
+				{ status: 500 }
+			);
+		}
+
+		return NextResponse.json({ success: true, providerId });
+	} catch (error: any) {
+		console.error("Providers POST error:", error);
+		return NextResponse.json(
+			{ error: getMessage().OPERATION_FAILED },
+			{ status: 500 }
+		);
+	}
+}
+
+/**
+ * PUT /api/openground/providers
+ * Update an existing provider's metadata
+ */
+export async function PUT(request: NextRequest) {
+	try {
+		const user = await getCurrentUser();
+		if (!user) {
+			return NextResponse.json(
+				{ error: getMessage().UNAUTHORIZED_USER },
+				{ status: 401 }
+			);
+		}
+
+		const [, dbConfig] = await asaw(getDBConfigByUser(true));
+		if (!dbConfig?.id) {
+			return NextResponse.json(
+				{ error: getMessage().DATABASE_CONFIG_NOT_FOUND },
+				{ status: 500 }
+			);
+		}
+
+		const body = await request.json();
+		const { providerId, displayName, description, requiresVault, configSchema } = body;
+
+		if (!providerId) {
+			return NextResponse.json(
+				{ error: "Provider ID is required" },
+				{ status: 400 }
+			);
+		}
+
+		const updateFields: string[] = [];
+		if (displayName !== undefined) {
+			updateFields.push(`display_name = '${Sanitizer.sanitizeValue(displayName)}'`);
+		}
+		if (description !== undefined) {
+			updateFields.push(`description = '${Sanitizer.sanitizeValue(description)}'`);
+		}
+		if (requiresVault !== undefined) {
+			updateFields.push(`requires_vault = ${!!requiresVault}`);
+		}
+		if (configSchema !== undefined) {
+			updateFields.push(`config_schema = '${Sanitizer.sanitizeValue(JSON.stringify(configSchema))}'`);
+		}
+		updateFields.push(`updated_at = now()`);
+
+		const query = `
+			ALTER TABLE ${OPENLIT_PROVIDER_METADATA_TABLE_NAME}
+			UPDATE ${updateFields.join(", ")}
+			WHERE provider_id = '${Sanitizer.sanitizeValue(providerId)}'
+		`;
+
+		const { err } = await dataCollector({ query }, "exec", dbConfig.id);
+
+		if (err) {
+			return NextResponse.json(
+				{ error: err || getMessage().OPERATION_FAILED },
+				{ status: 500 }
+			);
+		}
+
+		return NextResponse.json({ success: true, providerId });
+	} catch (error: any) {
+		console.error("Providers PUT error:", error);
+		return NextResponse.json(
+			{ error: getMessage().OPERATION_FAILED },
+			{ status: 500 }
+		);
+	}
+}
+
+/**
+ * DELETE /api/openground/providers
+ * Delete a provider and all its models
+ */
+export async function DELETE(request: NextRequest) {
+	try {
+		const user = await getCurrentUser();
+		if (!user) {
+			return NextResponse.json(
+				{ error: getMessage().UNAUTHORIZED_USER },
+				{ status: 401 }
+			);
+		}
+
+		const [, dbConfig] = await asaw(getDBConfigByUser(true));
+		if (!dbConfig?.id) {
+			return NextResponse.json(
+				{ error: getMessage().DATABASE_CONFIG_NOT_FOUND },
+				{ status: 500 }
+			);
+		}
+
+		const { searchParams } = new URL(request.url);
+		const providerId = searchParams.get("provider");
+
+		if (!providerId) {
+			return NextResponse.json(
+				{ error: "Provider ID is required" },
+				{ status: 400 }
+			);
+		}
+
+		const sanitizedId = Sanitizer.sanitizeValue(providerId);
+
+		// Delete provider metadata + all its models
+		const [metaResult, modelsResult] = await Promise.all([
+			dataCollector(
+				{
+					query: `DELETE FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} WHERE provider_id = '${sanitizedId}'`,
+				},
+				"exec",
+				dbConfig.id
+			),
+			dataCollector(
+				{
+					query: `DELETE FROM openlit_provider_models WHERE provider = '${sanitizedId}'`,
+				},
+				"exec",
+				dbConfig.id
+			),
+		]);
+
+		if (metaResult.err || modelsResult.err) {
+			return NextResponse.json(
+				{ error: metaResult.err || modelsResult.err || getMessage().OPERATION_FAILED },
+				{ status: 500 }
+			);
+		}
+
+		return NextResponse.json({ success: true, deleted: providerId });
+	} catch (error: any) {
+		console.error("Providers DELETE error:", error);
 		return NextResponse.json(
 			{ error: getMessage().OPERATION_FAILED },
 			{ status: 500 }

--- a/src/client/src/clickhouse/migrations/create-provider-metadata-migration.ts
+++ b/src/client/src/clickhouse/migrations/create-provider-metadata-migration.ts
@@ -1,0 +1,56 @@
+import { dataCollector } from "@/lib/platform/common";
+import migrationHelper from "./migration-helper";
+import { OPENLIT_PROVIDER_METADATA_TABLE_NAME } from "@/lib/platform/providers/table-details";
+import { DEFAULT_PROVIDERS } from "@/lib/platform/providers/default-models";
+
+const MIGRATION_ID = "create-provider-metadata-table";
+
+/**
+ * Creates the openlit_provider_metadata table and seeds it with the 14
+ * built-in providers. After this migration, providers are fully editable
+ * and new ones can be added via the UI or import API.
+ */
+export default async function CreateProviderMetadataMigration(
+	databaseConfigId?: string
+) {
+	const createQuery = `
+		CREATE TABLE IF NOT EXISTS ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} (
+			provider_id String,
+			display_name String,
+			description String DEFAULT '',
+			requires_vault Boolean DEFAULT true,
+			config_schema String DEFAULT '{}',
+			is_default Boolean DEFAULT false,
+			created_at DateTime DEFAULT now(),
+			updated_at DateTime DEFAULT now()
+		) ENGINE = ReplacingMergeTree(updated_at)
+		PRIMARY KEY (provider_id)
+		ORDER BY (provider_id);
+	`;
+
+	const seedValues = DEFAULT_PROVIDERS.map((p) => ({
+		provider_id: p.providerId,
+		display_name: p.displayName,
+		description: p.description,
+		requires_vault: p.requiresVault,
+		config_schema: JSON.stringify(p.configSchema),
+		is_default: true,
+	}));
+
+	const queries = [
+		createQuery,
+		{
+			type: "insert" as const,
+			table: OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+			values: seedValues,
+		},
+	];
+
+	const { migrationExist, queriesRun } = await migrationHelper({
+		clickhouseMigrationId: MIGRATION_ID,
+		databaseConfigId,
+		queries,
+	});
+
+	return { migrationExist, queriesRun };
+}

--- a/src/client/src/clickhouse/migrations/index.ts
+++ b/src/client/src/clickhouse/migrations/index.ts
@@ -8,6 +8,7 @@ import CreateOpengroundMigration from "./create-openground-migration";
 import CreateRuleEngineMigration from "./create-rule-engine-migration";
 import CreateChatMigration from "./create-chat-migration";
 import CreateProvidersMigration from "./create-providers-migration";
+import CreateProviderMetadataMigration from "./create-provider-metadata-migration";
 import DropLegacyOpengroundTablesMigration from "./drop-legacy-openground-tables-migration";
 
 export default async function migrations(databaseConfigId?: string) {
@@ -27,6 +28,9 @@ export default async function migrations(databaseConfigId?: string) {
 	// Create new provider/model tables, copy any legacy data, seed defaults
 	await CreateProvidersMigration(databaseConfigId);
 
-	// Drop the legacy openground config + custom-models tables
-	await DropLegacyOpengroundTablesMigration(databaseConfigId);
+	// Create provider metadata table + seed default providers, then drop legacy tables
+	await Promise.all([
+		CreateProviderMetadataMigration(databaseConfigId),
+		DropLegacyOpengroundTablesMigration(databaseConfigId),
+	]);
 }

--- a/src/client/src/components/(playground)/openground/model-editor-panel.tsx
+++ b/src/client/src/components/(playground)/openground/model-editor-panel.tsx
@@ -178,7 +178,11 @@ export default function ModelEditorPanel({
 							id="model-id"
 							placeholder="gpt-4o-custom"
 							value={formData.model_id}
-							onChange={(e) => setFormData({ ...formData, model_id: e.target.value })}
+							onChange={(e) => {
+								let v = e.target.value.toLowerCase().replace(/ /g, "-");
+								v = v.replace(/[^a-z0-9-/.]/g, "");
+								setFormData({ ...formData, model_id: v });
+							}}
 							disabled={!isAddingNew}
 						/>
 					</div>

--- a/src/client/src/components/(playground)/openground/model-list-sidebar.tsx
+++ b/src/client/src/components/(playground)/openground/model-list-sidebar.tsx
@@ -27,6 +27,7 @@ interface ModelListSidebarProps {
 	selectedIsCustom: boolean;
 	onSelectModel: (model: ModelMetadata, provider: string, isCustom: boolean) => void;
 	onAddNew: (provider: string) => void;
+	onEditProvider?: (provider: ProviderMetadata) => void;
 }
 
 export default function ModelListSidebar({
@@ -38,6 +39,7 @@ export default function ModelListSidebar({
 	selectedIsCustom,
 	onSelectModel,
 	onAddNew,
+	onEditProvider,
 }: ModelListSidebarProps) {
 	const [searchQuery, setSearchQuery] = useState("");
 	const [expandedProviders, setExpandedProviders] = useState<Set<string>>(new Set());
@@ -116,7 +118,7 @@ export default function ModelListSidebar({
 									{/* Provider Header */}
 									<button
 										onClick={() => toggleProvider(provider.providerId)}
-										className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+										className="w-full flex items-center justify-between p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors group/provider"
 									>
 										<div className="flex items-center gap-2">
 											{isExpanded ? (
@@ -131,17 +133,32 @@ export default function ModelListSidebar({
 												{totalModels}
 											</Badge>
 										</div>
-										<Button
-											variant="ghost"
-											size="sm"
-											className="h-6 w-6 p-0 text-stone-500"
-											onClick={(e) => {
-												e.stopPropagation();
-												onAddNew(provider.providerId);
-											}}
-										>
-											<PlusIcon className="h-3 w-3" />
-										</Button>
+										<div className="flex items-center gap-0.5">
+											{onEditProvider && (
+												<Button
+													variant="ghost"
+													size="sm"
+													className="h-6 w-6 p-0 text-stone-400 opacity-0 group-hover/provider:opacity-100 transition-opacity"
+													onClick={(e) => {
+														e.stopPropagation();
+														onEditProvider(provider);
+													}}
+												>
+													<PencilIcon className="h-3 w-3" />
+												</Button>
+											)}
+											<Button
+												variant="ghost"
+												size="sm"
+												className="h-6 w-6 p-0 text-stone-500"
+												onClick={(e) => {
+													e.stopPropagation();
+													onAddNew(provider.providerId);
+												}}
+											>
+												<PlusIcon className="h-3 w-3" />
+											</Button>
+										</div>
 									</button>
 
 									{/* Models List — all editable */}

--- a/src/client/src/components/(playground)/openground/provider-editor-dialog.tsx
+++ b/src/client/src/components/(playground)/openground/provider-editor-dialog.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import getMessage from "@/constants/messages";
+import useFetchWrapper from "@/utils/hooks/useFetchWrapper";
+import { toast } from "sonner";
+
+export interface ProviderFormData {
+	providerId: string;
+	displayName: string;
+	description: string;
+	requiresVault: boolean;
+}
+
+interface ProviderEditorDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	provider: ProviderFormData | null; // null = adding new
+	onSaved: () => void;
+}
+
+export default function ProviderEditorDialog({
+	open,
+	onOpenChange,
+	provider,
+	onSaved,
+}: ProviderEditorDialogProps) {
+	const m = getMessage();
+	const isEditing = !!provider;
+
+	const [formData, setFormData] = useState<ProviderFormData>({
+		providerId: "",
+		displayName: "",
+		description: "",
+		requiresVault: true,
+	});
+
+	const { fireRequest, isLoading } = useFetchWrapper();
+
+	useEffect(() => {
+		if (provider) {
+			setFormData(provider);
+		} else {
+			setFormData({
+				providerId: "",
+				displayName: "",
+				description: "",
+				requiresVault: true,
+			});
+		}
+	}, [provider, open]);
+
+	const handleSave = () => {
+		if (!formData.providerId || !formData.displayName) {
+			toast.error(
+				`${m.MANAGE_PROVIDERS_ID_LABEL} and ${m.MANAGE_PROVIDERS_DISPLAY_NAME} are required`
+			);
+			return;
+		}
+
+		fireRequest({
+			requestType: isEditing ? "PUT" : "POST",
+			url: "/api/openground/providers",
+			body: JSON.stringify(formData),
+			successCb: () => {
+				toast.success(m.MANAGE_PROVIDERS_SAVED, { id: "provider-save" });
+				onOpenChange(false);
+				onSaved();
+			},
+			failureCb: (err?: string) => {
+				toast.error(err || m.MANAGE_PROVIDERS_SAVE_FAILED, {
+					id: "provider-save",
+				});
+			},
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<DialogTitle>
+						{isEditing ? m.MANAGE_PROVIDERS_EDIT : m.MANAGE_PROVIDERS_ADD}
+					</DialogTitle>
+					<DialogDescription>
+						{isEditing
+							? m.MANAGE_PROVIDERS_ID_HINT
+							: m.MANAGE_PROVIDERS_ID_HINT}
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					<div className="space-y-2">
+						<Label htmlFor="provider-id">{m.MANAGE_PROVIDERS_ID_LABEL}</Label>
+						<Input
+							id="provider-id"
+							placeholder="my-provider"
+							value={formData.providerId}
+							onChange={(e) => {
+								let v = e.target.value.toLowerCase().replace(/ /g, "-");
+								v = v.replace(/[^a-z0-9-]/g, "");
+								setFormData({ ...formData, providerId: v });
+							}}
+							disabled={isEditing}
+						/>
+						{!isEditing && (
+							<p className="text-xs text-stone-500 dark:text-stone-400">
+								{m.MANAGE_PROVIDERS_ID_HINT}
+							</p>
+						)}
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="display-name">
+							{m.MANAGE_PROVIDERS_DISPLAY_NAME}
+						</Label>
+						<Input
+							id="display-name"
+							placeholder="My Provider"
+							value={formData.displayName}
+							onChange={(e) =>
+								setFormData({ ...formData, displayName: e.target.value })
+							}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="description">
+							{m.MANAGE_PROVIDERS_DESCRIPTION}
+						</Label>
+						<Input
+							id="description"
+							placeholder="Custom LLM provider"
+							value={formData.description}
+							onChange={(e) =>
+								setFormData({ ...formData, description: e.target.value })
+							}
+						/>
+					</div>
+
+					<div className="flex items-center justify-between rounded-lg border border-stone-200 dark:border-stone-700 p-4">
+						<div className="space-y-0.5">
+							<Label>{m.MANAGE_PROVIDERS_REQUIRES_VAULT}</Label>
+						</div>
+						<Switch
+							checked={formData.requiresVault}
+							onCheckedChange={(val) =>
+								setFormData({ ...formData, requiresVault: val })
+							}
+						/>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						{m.CANCEL}
+					</Button>
+					<Button onClick={handleSave} disabled={isLoading}>
+						{isLoading
+							? m.SAVING
+							: isEditing
+								? m.MANAGE_PROVIDERS_EDIT
+								: m.MANAGE_PROVIDERS_ADD}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/src/client/src/constants/messages/en.ts
+++ b/src/client/src/constants/messages/en.ts
@@ -280,6 +280,23 @@ export const MANAGE_MODELS_SDK_USAGE_NOTE =
 export const COPY = "Copy";
 export const MANAGE_MODELS_INVALID_JSON = "Invalid JSON";
 
+// Provider management
+export const MANAGE_PROVIDERS_ADD = "Add Provider";
+export const MANAGE_PROVIDERS_EDIT = "Edit Provider";
+export const MANAGE_PROVIDERS_DELETE = "Delete Provider";
+export const MANAGE_PROVIDERS_DELETE_CONFIRM =
+	"This will delete the provider and all its models. Are you sure?";
+export const MANAGE_PROVIDERS_SAVED = "Provider saved";
+export const MANAGE_PROVIDERS_DELETED = "Provider deleted";
+export const MANAGE_PROVIDERS_SAVE_FAILED = "Failed to save provider";
+export const MANAGE_PROVIDERS_DELETE_FAILED = "Failed to delete provider";
+export const MANAGE_PROVIDERS_ID_LABEL = "Provider ID";
+export const MANAGE_PROVIDERS_ID_HINT =
+	"Lowercase identifier (e.g. my-provider). Must match what the SDK sends in gen_ai.system.";
+export const MANAGE_PROVIDERS_DISPLAY_NAME = "Display Name";
+export const MANAGE_PROVIDERS_DESCRIPTION = "Description";
+export const MANAGE_PROVIDERS_REQUIRES_VAULT = "Requires API Key (Vault)";
+
 // Pricing
 export const PRICING_TITLE = "Pricing";
 export const PRICING_PAGE_DESCRIPTION =

--- a/src/client/src/lib/platform/providers/default-models.ts
+++ b/src/client/src/lib/platform/providers/default-models.ts
@@ -1,14 +1,141 @@
-import { ModelMetadata } from "@/types/openground";
+import { ModelMetadata, ConfigField } from "@/types/openground";
 
 /**
- * Default (built-in) models that are seeded into the openlit_provider_models table.
- * These become editable once seeded — they are not read from here at runtime.
- * This file is the source of truth for initial seeding and for reference.
+ * Default (built-in) provider metadata and models. Seeded into ClickHouse tables
+ * on first run. After seeding these are NOT read at runtime — the DB is the
+ * source of truth and everything is editable.
  */
 
 export interface DefaultModelEntry extends ModelMetadata {
 	modelType?: string;
 }
+
+export interface DefaultProviderEntry {
+	providerId: string;
+	displayName: string;
+	description: string;
+	requiresVault: boolean;
+	configSchema: {
+		temperature?: ConfigField;
+		maxTokens?: ConfigField;
+		topP?: ConfigField;
+	};
+}
+
+export const DEFAULT_PROVIDERS: DefaultProviderEntry[] = [
+	{
+		providerId: "openai", displayName: "OpenAI", description: "GPT models from OpenAI", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature (0 = deterministic, 2 = very random)" },
+			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "anthropic", displayName: "Anthropic", description: "Claude models from Anthropic", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 1, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 8096, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "google", displayName: "Google AI", description: "Gemini models from Google", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 0.95, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "mistral", displayName: "Mistral AI", description: "Mistral and Mixtral models", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "groq", displayName: "Groq", description: "Ultra-fast inference for open source models", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 32768, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "perplexity", displayName: "Perplexity", description: "Models with online search capabilities", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 0.2, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 0.9, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "azure", displayName: "Azure OpenAI", description: "OpenAI models via Azure", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "cohere", displayName: "Cohere", description: "Command models with RAG capabilities", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 5, step: 0.1, default: 0.3, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 0.99, step: 0.01, default: 0.75, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "together", displayName: "Together AI", description: "Fast inference for open source models", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "fireworks", displayName: "Fireworks AI", description: "Production-ready LLM inference", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 16384, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "deepseek", displayName: "DeepSeek", description: "Advanced reasoning and coding models", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "xai", displayName: "xAI", description: "Grok models with real-time knowledge", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 0, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 131072, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "huggingface", displayName: "Hugging Face", description: "Open source models via Inference API", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 0.7, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 2048, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 0.95, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "replicate", displayName: "Replicate", description: "Run open source models in the cloud", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 5, step: 0.01, default: 0.75, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.01, default: 0.9, description: "Nucleus sampling threshold" },
+		},
+	},
+];
 
 export const DEFAULT_MODELS_BY_PROVIDER: Record<string, DefaultModelEntry[]> = {
 	openai: [

--- a/src/client/src/lib/platform/providers/provider-registry.ts
+++ b/src/client/src/lib/platform/providers/provider-registry.ts
@@ -1,175 +1,92 @@
 import { ProviderMetadata, ModelMetadata, ConfigField } from "@/types/openground";
 import { dataCollector } from "@/lib/platform/common";
 import Sanitizer from "@/utils/sanitizer";
-import { OPENLIT_PROVIDER_MODELS_TABLE_NAME } from "./table-details";
+import {
+	OPENLIT_PROVIDER_MODELS_TABLE_NAME,
+	OPENLIT_PROVIDER_METADATA_TABLE_NAME,
+} from "./table-details";
 
 // Re-export types for convenience
 export type { ProviderMetadata, ModelMetadata, ConfigField };
 
-/**
- * Static provider metadata — structural information only (name, description,
- * configSchema, vault requirement). The list of supported models is NO LONGER
- * stored here; models live in the openlit_provider_models ClickHouse table and
- * are fully editable via the manage-models UI.
- */
-type StaticProviderMetadata = Omit<ProviderMetadata, "supportedModels">;
-
-const PROVIDER_METADATA: Record<string, StaticProviderMetadata> = {
-	openai: {
-		providerId: "openai",
-		displayName: "OpenAI",
-		description: "GPT models from OpenAI",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature (0 = deterministic, 2 = very random)" },
-			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	anthropic: {
-		providerId: "anthropic",
-		displayName: "Anthropic",
-		description: "Claude models from Anthropic",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 1, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 8096, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	google: {
-		providerId: "google",
-		displayName: "Google AI",
-		description: "Gemini models from Google",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 0.95, description: "Nucleus sampling threshold" },
-		},
-	},
-	mistral: {
-		providerId: "mistral",
-		displayName: "Mistral AI",
-		description: "Mistral and Mixtral models",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	groq: {
-		providerId: "groq",
-		displayName: "Groq",
-		description: "Ultra-fast inference for open source models",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 32768, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	perplexity: {
-		providerId: "perplexity",
-		displayName: "Perplexity",
-		description: "Models with online search capabilities",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 0.2, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 0.9, description: "Nucleus sampling threshold" },
-		},
-	},
-	azure: {
-		providerId: "azure",
-		displayName: "Azure OpenAI",
-		description: "OpenAI models via Azure",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	cohere: {
-		providerId: "cohere",
-		displayName: "Cohere",
-		description: "Command models with RAG capabilities",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 5, step: 0.1, default: 0.3, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 0.99, step: 0.01, default: 0.75, description: "Nucleus sampling threshold" },
-		},
-	},
-	together: {
-		providerId: "together",
-		displayName: "Together AI",
-		description: "Fast inference for open source models",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 8192, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 0.7, description: "Nucleus sampling threshold" },
-		},
-	},
-	fireworks: {
-		providerId: "fireworks",
-		displayName: "Fireworks AI",
-		description: "Production-ready LLM inference",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 16384, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	deepseek: {
-		providerId: "deepseek",
-		displayName: "DeepSeek",
-		description: "Advanced reasoning and coding models",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	xai: {
-		providerId: "xai",
-		displayName: "xAI",
-		description: "Grok models with real-time knowledge",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 0, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 131072, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
-		},
-	},
-	huggingface: {
-		providerId: "huggingface",
-		displayName: "Hugging Face",
-		description: "Open source models via Inference API",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 2, step: 0.1, default: 0.7, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 2048, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.1, default: 0.95, description: "Nucleus sampling threshold" },
-		},
-	},
-	replicate: {
-		providerId: "replicate",
-		displayName: "Replicate",
-		description: "Run open source models in the cloud",
-		requiresVault: true,
-		configSchema: {
-			temperature: { min: 0, max: 5, step: 0.01, default: 0.75, description: "Sampling temperature" },
-			maxTokens: { min: 1, max: 4096, step: 1, default: 1000, description: "Maximum tokens to generate" },
-			topP: { min: 0, max: 1, step: 0.01, default: 0.9, description: "Nucleus sampling threshold" },
-		},
-	},
+type ProviderMetadataRow = {
+	provider_id: string;
+	display_name: string;
+	description: string;
+	requires_vault: boolean;
+	config_schema: string;
+	is_default: boolean;
 };
+
+function parseProviderRow(row: ProviderMetadataRow): Omit<ProviderMetadata, "supportedModels"> {
+	let configSchema: ProviderMetadata["configSchema"] = {};
+	try {
+		configSchema = JSON.parse(row.config_schema || "{}");
+	} catch {
+		// keep empty
+	}
+	return {
+		providerId: row.provider_id,
+		displayName: row.display_name,
+		description: row.description || "",
+		requiresVault: !!row.requires_vault,
+		configSchema,
+	};
+}
+
+/**
+ * Load all provider metadata rows from ClickHouse.
+ */
+async function loadAllProvidersFromDb(
+	databaseConfigId: string
+): Promise<Omit<ProviderMetadata, "supportedModels">[]> {
+	try {
+		const query = `
+			SELECT
+				provider_id,
+				display_name,
+				description,
+				requires_vault,
+				config_schema,
+				is_default
+			FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
+			ORDER BY is_default DESC, display_name ASC
+		`;
+
+		const { data } = await dataCollector({ query }, "query", databaseConfigId);
+		return ((data as ProviderMetadataRow[]) || []).map(parseProviderRow);
+	} catch (error) {
+		console.error("Error loading provider metadata:", error);
+		return [];
+	}
+}
+
+async function loadProviderFromDb(
+	providerId: string,
+	databaseConfigId: string
+): Promise<Omit<ProviderMetadata, "supportedModels"> | null> {
+	try {
+		const query = `
+			SELECT
+				provider_id,
+				display_name,
+				description,
+				requires_vault,
+				config_schema,
+				is_default
+			FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
+			WHERE provider_id = '${Sanitizer.sanitizeValue(providerId)}'
+			LIMIT 1
+		`;
+
+		const { data } = await dataCollector({ query }, "query", databaseConfigId);
+		const rows = (data as ProviderMetadataRow[]) || [];
+		return rows.length > 0 ? parseProviderRow(rows[0]) : null;
+	} catch (error) {
+		console.error("Error loading provider:", providerId, error);
+		return null;
+	}
+}
 
 /**
  * Load all models for a database config from openlit_provider_models,
@@ -247,34 +164,24 @@ async function loadProviderModelsFromDb(
 			capabilities: row.capabilities || [],
 		}));
 	} catch (error) {
-		console.error("Error loading provider models for", error);
+		console.error("Error loading provider models for", providerId, error);
 		return [];
 	}
 }
 
 export class ProviderRegistry {
 	/**
-	 * Get provider metadata only (no models). For UI lists that don't need models.
-	 */
-	static getProviderMetadata(
-		providerId: string
-	): StaticProviderMetadata | null {
-		return PROVIDER_METADATA[providerId] || null;
-	}
-
-	static getAllProviderMetadata(): StaticProviderMetadata[] {
-		return Object.values(PROVIDER_METADATA);
-	}
-
-	/**
 	 * Get all providers with their models loaded from the DB.
 	 */
 	static async getAvailableProviders(
 		databaseConfigId: string
 	): Promise<ProviderMetadata[]> {
-		const modelsByProvider = await loadAllModelsFromDb(databaseConfigId);
+		const [providers, modelsByProvider] = await Promise.all([
+			loadAllProvidersFromDb(databaseConfigId),
+			loadAllModelsFromDb(databaseConfigId),
+		]);
 
-		return Object.values(PROVIDER_METADATA).map((provider) => ({
+		return providers.map((provider) => ({
 			...provider,
 			supportedModels: modelsByProvider[provider.providerId] || [],
 		}));
@@ -287,35 +194,27 @@ export class ProviderRegistry {
 		providerId: string,
 		databaseConfigId: string
 	): Promise<ProviderMetadata | null> {
-		const provider = PROVIDER_METADATA[providerId];
+		const provider = await loadProviderFromDb(providerId, databaseConfigId);
 		if (!provider) return null;
 
 		const models = await loadProviderModelsFromDb(providerId, databaseConfigId);
-		return {
-			...provider,
-			supportedModels: models,
-		};
+		return { ...provider, supportedModels: models };
 	}
 
 	/**
-	 * Search providers by name or description (structural search — does not search models).
+	 * Search providers by name or description.
 	 */
 	static async searchProviders(
 		query: string,
 		databaseConfigId: string
 	): Promise<ProviderMetadata[]> {
+		const allProviders = await this.getAvailableProviders(databaseConfigId);
 		const lowerQuery = query.toLowerCase();
-		const matched = Object.values(PROVIDER_METADATA).filter(
-			(provider) =>
-				provider.displayName.toLowerCase().includes(lowerQuery) ||
-				provider.description?.toLowerCase().includes(lowerQuery)
+		return allProviders.filter(
+			(p) =>
+				p.displayName.toLowerCase().includes(lowerQuery) ||
+				p.description?.toLowerCase().includes(lowerQuery)
 		);
-
-		const modelsByProvider = await loadAllModelsFromDb(databaseConfigId);
-		return matched.map((provider) => ({
-			...provider,
-			supportedModels: modelsByProvider[provider.providerId] || [],
-		}));
 	}
 
 	/**
@@ -325,7 +224,6 @@ export class ProviderRegistry {
 		providerId: string,
 		databaseConfigId: string
 	): Promise<ModelMetadata[]> {
-		if (!PROVIDER_METADATA[providerId]) return [];
 		return loadProviderModelsFromDb(providerId, databaseConfigId);
 	}
 

--- a/src/client/src/lib/platform/providers/provider-registry.ts
+++ b/src/client/src/lib/platform/providers/provider-registry.ts
@@ -36,125 +36,82 @@ function parseProviderRow(row: ProviderMetadataRow): Omit<ProviderMetadata, "sup
 
 /**
  * Load all provider metadata rows from ClickHouse.
+ *
+ * Errors are intentionally NOT caught — they propagate to the caller so the
+ * API can respond with a 5xx instead of silently returning an empty list.
  */
 async function loadAllProvidersFromDb(
 	databaseConfigId: string
 ): Promise<Omit<ProviderMetadata, "supportedModels">[]> {
-	try {
-		const query = `
-			SELECT
-				provider_id,
-				display_name,
-				description,
-				requires_vault,
-				config_schema,
-				is_default
-			FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
-			ORDER BY is_default DESC, display_name ASC
-		`;
+	const query = `
+		SELECT
+			provider_id,
+			display_name,
+			description,
+			requires_vault,
+			config_schema,
+			is_default
+		FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
+		ORDER BY is_default DESC, display_name ASC
+	`;
 
-		const { data } = await dataCollector({ query }, "query", databaseConfigId);
-		return ((data as ProviderMetadataRow[]) || []).map(parseProviderRow);
-	} catch (error) {
-		console.error("Error loading provider metadata:", error);
-		return [];
-	}
+	const { data, err } = await dataCollector({ query }, "query", databaseConfigId);
+	if (err) throw new Error(`Failed to load provider metadata: ${err}`);
+	return ((data as ProviderMetadataRow[]) || []).map(parseProviderRow);
 }
 
 async function loadProviderFromDb(
 	providerId: string,
 	databaseConfigId: string
 ): Promise<Omit<ProviderMetadata, "supportedModels"> | null> {
-	try {
-		const query = `
-			SELECT
-				provider_id,
-				display_name,
-				description,
-				requires_vault,
-				config_schema,
-				is_default
-			FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
-			WHERE provider_id = '${Sanitizer.sanitizeValue(providerId)}'
-			LIMIT 1
-		`;
+	const query = `
+		SELECT
+			provider_id,
+			display_name,
+			description,
+			requires_vault,
+			config_schema,
+			is_default
+		FROM ${OPENLIT_PROVIDER_METADATA_TABLE_NAME} FINAL
+		WHERE provider_id = '${Sanitizer.sanitizeValue(providerId)}'
+		LIMIT 1
+	`;
 
-		const { data } = await dataCollector({ query }, "query", databaseConfigId);
-		const rows = (data as ProviderMetadataRow[]) || [];
-		return rows.length > 0 ? parseProviderRow(rows[0]) : null;
-	} catch (error) {
-		console.error("Error loading provider:", providerId, error);
-		return null;
-	}
+	const { data, err } = await dataCollector({ query }, "query", databaseConfigId);
+	if (err) throw new Error(`Failed to load provider ${providerId}: ${err}`);
+	const rows = (data as ProviderMetadataRow[]) || [];
+	return rows.length > 0 ? parseProviderRow(rows[0]) : null;
 }
 
 /**
- * Load all models for a database config from openlit_provider_models,
- * grouped by providerId.
+ * Load all models grouped by provider. Errors propagate.
  */
 async function loadAllModelsFromDb(
 	databaseConfigId: string
 ): Promise<Record<string, ModelMetadata[]>> {
-	try {
-		const query = `
-			SELECT
-				provider,
-				model_id as id,
-				display_name as displayName,
-				model_type as modelType,
-				context_window as contextWindow,
-				input_price_per_m_token as inputPricePerMToken,
-				output_price_per_m_token as outputPricePerMToken,
-				capabilities
-			FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
-			ORDER BY provider, is_default DESC, created_at DESC
-		`;
+	const query = `
+		SELECT
+			provider,
+			model_id as id,
+			display_name as displayName,
+			model_type as modelType,
+			context_window as contextWindow,
+			input_price_per_m_token as inputPricePerMToken,
+			output_price_per_m_token as outputPricePerMToken,
+			capabilities
+		FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
+		ORDER BY provider, is_default DESC, created_at DESC
+	`;
 
-		const { data } = await dataCollector({ query }, "query", databaseConfigId);
-		const rows = (data as any[]) || [];
+	const { data, err } = await dataCollector({ query }, "query", databaseConfigId);
+	if (err) throw new Error(`Failed to load provider models: ${err}`);
+	const rows = (data as any[]) || [];
 
-		const grouped: Record<string, ModelMetadata[]> = {};
-		for (const row of rows) {
-			const provider = row.provider;
-			if (!grouped[provider]) grouped[provider] = [];
-			grouped[provider].push({
-				id: row.id,
-				displayName: row.displayName,
-				modelType: row.modelType,
-				contextWindow: Number(row.contextWindow) || 0,
-				inputPricePerMToken: Number(row.inputPricePerMToken) || 0,
-				outputPricePerMToken: Number(row.outputPricePerMToken) || 0,
-				capabilities: row.capabilities || [],
-			});
-		}
-		return grouped;
-	} catch (error) {
-		console.error("Error loading provider models:", error);
-		return {};
-	}
-}
-
-async function loadProviderModelsFromDb(
-	providerId: string,
-	databaseConfigId: string
-): Promise<ModelMetadata[]> {
-	try {
-		const query = `
-			SELECT
-				model_id as id,
-				display_name as displayName,
-				model_type as modelType,
-				context_window as contextWindow,
-				input_price_per_m_token as inputPricePerMToken,
-				output_price_per_m_token as outputPricePerMToken,
-				capabilities
-			FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
-			WHERE provider = '${Sanitizer.sanitizeValue(providerId)}'
-			ORDER BY is_default DESC, created_at DESC
-		`;
-
-		const { data } = await dataCollector({ query }, "query", databaseConfigId);
-		return ((data as any[]) || []).map((row) => ({
+	const grouped: Record<string, ModelMetadata[]> = {};
+	for (const row of rows) {
+		const provider = row.provider;
+		if (!grouped[provider]) grouped[provider] = [];
+		grouped[provider].push({
 			id: row.id,
 			displayName: row.displayName,
 			modelType: row.modelType,
@@ -162,11 +119,40 @@ async function loadProviderModelsFromDb(
 			inputPricePerMToken: Number(row.inputPricePerMToken) || 0,
 			outputPricePerMToken: Number(row.outputPricePerMToken) || 0,
 			capabilities: row.capabilities || [],
-		}));
-	} catch (error) {
-		console.error("Error loading provider models for", providerId, error);
-		return [];
+		});
 	}
+	return grouped;
+}
+
+async function loadProviderModelsFromDb(
+	providerId: string,
+	databaseConfigId: string
+): Promise<ModelMetadata[]> {
+	const query = `
+		SELECT
+			model_id as id,
+			display_name as displayName,
+			model_type as modelType,
+			context_window as contextWindow,
+			input_price_per_m_token as inputPricePerMToken,
+			output_price_per_m_token as outputPricePerMToken,
+			capabilities
+		FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
+		WHERE provider = '${Sanitizer.sanitizeValue(providerId)}'
+		ORDER BY is_default DESC, created_at DESC
+	`;
+
+	const { data, err } = await dataCollector({ query }, "query", databaseConfigId);
+	if (err) throw new Error(`Failed to load models for provider ${providerId}: ${err}`);
+	return ((data as any[]) || []).map((row) => ({
+		id: row.id,
+		displayName: row.displayName,
+		modelType: row.modelType,
+		contextWindow: Number(row.contextWindow) || 0,
+		inputPricePerMToken: Number(row.inputPricePerMToken) || 0,
+		outputPricePerMToken: Number(row.outputPricePerMToken) || 0,
+		capabilities: row.capabilities || [],
+	}));
 }
 
 export class ProviderRegistry {

--- a/src/client/src/lib/platform/providers/table-details.ts
+++ b/src/client/src/lib/platform/providers/table-details.ts
@@ -1,2 +1,3 @@
 export const OPENLIT_PROVIDERS_TABLE_NAME = "openlit_providers";
 export const OPENLIT_PROVIDER_MODELS_TABLE_NAME = "openlit_provider_models";
+export const OPENLIT_PROVIDER_METADATA_TABLE_NAME = "openlit_provider_metadata";


### PR DESCRIPTION
> [!IMPORTANT]
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating
to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

Fixes #1125

### Change description:

Moves provider definitions from hardcoded TypeScript into a ClickHouse table, making providers fully dynamic — users can add, edit, and delete providers through the UI, API, or import.

#### New ClickHouse table

- `openlit_provider_metadata` (`ReplacingMergeTree`) — stores `provider_id`, `display_name`, `description`, `requires_vault`,
`config_schema` (JSON), `is_default`
- Migration `create-provider-metadata-migration.ts` creates the table and seeds 14 built-in providers from `DEFAULT_PROVIDERS` in
`default-models.ts`
- Wired into `migrations/index.ts` to run alongside the existing provider/model migrations

#### Provider registry rewrite

- Removed static `PROVIDER_METADATA` record (~160 lines) from `provider-registry.ts`
- `getAvailableProviders()` now loads provider metadata + models in parallel from ClickHouse
- `getProviderById()`, `searchProviders()` all query the DB
- Uses `FINAL` keyword on `ReplacingMergeTree` queries to deduplicate
- Static data moved to `DEFAULT_PROVIDERS` in `default-models.ts` (used only by migration seeding)

#### Provider CRUD API

- `POST /api/openground/providers` — create a new provider
- `PUT /api/openground/providers` — update provider metadata (displayName, description, requiresVault, configSchema)
- `DELETE /api/openground/providers?provider=<id>` — delete provider + all its models

#### Provider add/edit UI

- **Add Provider button** (`PlusCircle` icon with tooltip) in the Manage Models header
- **Edit icon** (pencil) on provider headers in the sidebar — appears on hover via `group/provider` CSS
- **`ProviderEditorDialog`** component — form fields: Provider ID (read-only when editing), Display Name, Description, Requires Vault toggle
- Provider ID auto-formats on input: lowercase, spaces → hyphens, special chars stripped

#### Model ID auto-formatting

- Model ID input in `model-editor-panel.tsx` now applies the same transformation: lowercase, spaces → hyphens, strips chars outside `a-z 0-9 - / .`
- Allows path-style IDs like `accounts/fireworks/models/llama-v3p1-70b-instruct`

#### Import extended

- `POST /api/openground/models/import` now accepts optional `providers` array
- Existing providers are skipped by `provider_id` (no duplicates)
- Response includes `providersImported` and `providersSkipped` counts
- Import dialog placeholder updated to show the combined providers + models format

#### Files changed

| Area | Files |
|------|-------|
| Table | `providers/table-details.ts` — added `OPENLIT_PROVIDER_METADATA_TABLE_NAME` |
| Seed data | `providers/default-models.ts` — added `DEFAULT_PROVIDERS` array + `DefaultProviderEntry` type |
| Migration | `create-provider-metadata-migration.ts` (new), `migrations/index.ts` (wired in) |
| Registry | `providers/provider-registry.ts` — rewritten, fully DB-driven |
| API | `api/openground/providers/route.ts` — added `POST`, `PUT`, `DELETE` handlers |
| Import API | `api/openground/models/import/route.ts` — extended with providers support |
| UI | `provider-editor-dialog.tsx` (new), `model-list-sidebar.tsx` (added `onEditProvider` + hover pencil),
`manage-models/page.tsx` (Add Provider button + dialog wiring), `model-editor-panel.tsx` (model ID auto-formatting) |
| Messages | `en.ts` — added `MANAGE_PROVIDERS_*` strings |
| Tests | `provider-registry.test.ts` — rewritten for DB-driven architecture |
| Docs | `manage-models.mdx` — added "Managing providers" section, updated import docs, added API reference table |

#### Tests

`provider-registry.test.ts` fully rewritten — mocks both provider metadata and model DB queries. All 114 suites / 1716 tests pass.

### Checklist

- [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
- [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same
update/change?
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Make provider definitions fully dynamic by storing metadata in ClickHouse, exposing CRUD APIs and UI for managing providers, and extending import/export flows and docs accordingly.

New Features:
- Introduce a ClickHouse-backed provider metadata table seeded with default providers and used at runtime instead of hardcoded provider definitions.
- Add API endpoints to create, update, and delete providers, including cascading deletion of a provider’s models.
- Add a Provider editor dialog and sidebar affordances to add and edit providers directly from the Manage Models UI.
- Support bulk import of providers alongside models, with duplicate detection and per-type import/skip counts.

Enhancements:
- Refactor the provider registry to load provider metadata and models from ClickHouse, making the provider list fully data-driven.
- Auto-format provider and model IDs into normalized slugs suitable for SDK usage.
- Extend pricing management docs with provider management workflows, updated import examples, and an API reference table.

Build:
- Bump client package version from 1.18.0 to 1.18.1.

Documentation:
- Document managing providers, combined provider+model imports, and the updated pricing architecture in the manage-models guide.

Tests:
- Rewrite provider registry tests to validate the new DB-driven provider metadata and model loading behavior.