### PR TITLE
fix(google_ai_studio): add missing GEN_AI_USAGE_REASONING_TOKENS semconv

### DIFF
--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -600,7 +600,8 @@ def common_chat_logic(
         and scope._reasoning_tokens > 0
     ):
         scope._span.set_attribute(
-            "gen_ai.usage.reasoning_tokens", scope._reasoning_tokens
+            SemanticConvention.GEN_AI_USAGE_REASONING_TOKENS,
+            scope._reasoning_tokens,
         )
 
     # OTel cached token attributes (set even when 0)

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -569,6 +569,7 @@ class SemanticConvention:
     GEN_AI_USAGE_COMPLETION_TOKENS_DETAILS_REASONING = (
         "gen_ai.usage.completion_tokens_details.reasoning_tokens"
     )
+    GEN_AI_USAGE_REASONING_TOKENS = "gen_ai.usage.reasoning_tokens"
     GEN_AI_USAGE_PROMPT_TOKENS_DETAILS_CACHE_READ = (
         "gen_ai.usage.prompt_tokens_details.cached_tokens"
     )


### PR DESCRIPTION
> [!IMPORTANT]
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: Fixes #1133

### Change description:

Gemini calls through OpenLIT have been crashing with:

```
AttributeError: type object 'SemanticConvention' has no attribute 'GEN_AI_USAGE_REASONING_TOKENS'
```

`google_ai_studio/utils.py` reads `SemanticConvention.GEN_AI_USAGE_REASONING_TOKENS` at line 408 inside `emit_inference_event`, but that constant was never added to `openlit/semcov/__init__.py`. Every streaming Gemini call that reports `thoughts_token_count` hits the missing attribute and dies before the span is emitted.

A few lines further down (line 603, `common_chat_logic`) the same attribute was being written with the raw string `"gen_ai.usage.reasoning_tokens"`, so the intent was clear. The constant just never made it into `semcov`.

This PR:

1. Adds `GEN_AI_USAGE_REASONING_TOKENS = "gen_ai.usage.reasoning_tokens"` to `SemanticConvention`, next to the other usage-token attributes.
2. Replaces the inline string at line 603 with the new constant so both call sites are consistent.

No behaviour changes for models that do not return reasoning tokens.

### Checklist

- [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
- [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add the missing semantic convention for reasoning token usage and align Google AI Studio instrumentation to use it consistently.

Bug Fixes:
- Prevent Gemini streaming calls from crashing by introducing the GEN_AI_USAGE_REASONING_TOKENS semantic convention used by Google AI Studio instrumentation.

Enhancements:
- Use the shared GEN_AI_USAGE_REASONING_TOKENS semantic convention constant instead of an inline string in Google AI Studio chat logic for consistency.