### PR TITLE
fix(openai): preserve endpoint metadata when chat calls fail

### DIFF
--- a/sdk/python/src/openlit/instrumentation/openai/async_openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/async_openai.py
@@ -25,6 +25,8 @@ from openlit.instrumentation.openai.utils import (
     process_transcription_response,
     process_moderation_response,
     process_lightweight_response,
+    set_openai_request_span_attributes,
+    set_span_error_type,
 )
 from openlit.semcov import SemanticConvention
 
@@ -134,6 +136,17 @@ def async_chat_completions(
 
         if streaming:
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
+            set_openai_request_span_attributes(
+                span,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                server_address,
+                server_port,
+                request_model,
+                environment,
+                application_name,
+                True,
+                version,
+            )
             ctx = trace_api.set_span_in_context(span)
             token = context_api.attach(ctx)
             try:
@@ -158,7 +171,42 @@ def async_chat_completions(
         else:
             with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
                 start_time = time.time()
-                response = await wrapped(*args, **kwargs)
+                set_openai_request_span_attributes(
+                    span,
+                    SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    server_address,
+                    server_port,
+                    request_model,
+                    environment,
+                    application_name,
+                    False,
+                    version,
+                )
+                try:
+                    response = await wrapped(*args, **kwargs)
+                except Exception as e:
+                    err_type = set_span_error_type(span, e)
+                    if not disable_metrics and metrics:
+                        record_completion_metrics(
+                            metrics,
+                            SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                            SemanticConvention.GEN_AI_SYSTEM_OPENAI,
+                            server_address,
+                            server_port,
+                            request_model,
+                            kwargs.get("model", "unknown"),
+                            environment,
+                            application_name,
+                            start_time,
+                            time.time(),
+                            0,
+                            0,
+                            0,
+                            None,
+                            None,
+                            error_type=err_type,
+                        )
+                    raise
 
                 try:
                     response = process_chat_response(

--- a/sdk/python/src/openlit/instrumentation/openai/openai.py
+++ b/sdk/python/src/openlit/instrumentation/openai/openai.py
@@ -25,6 +25,8 @@ from openlit.instrumentation.openai.utils import (
     process_transcription_response,
     process_moderation_response,
     process_lightweight_response,
+    set_openai_request_span_attributes,
+    set_span_error_type,
 )
 from openlit.semcov import SemanticConvention
 
@@ -134,6 +136,17 @@ def chat_completions(
 
         if streaming:
             span = tracer.start_span(span_name, kind=SpanKind.CLIENT)
+            set_openai_request_span_attributes(
+                span,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                server_address,
+                server_port,
+                request_model,
+                environment,
+                application_name,
+                True,
+                version,
+            )
             ctx = trace_api.set_span_in_context(span)
             token = context_api.attach(ctx)
             try:
@@ -158,7 +171,42 @@ def chat_completions(
         else:
             with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
                 start_time = time.time()
-                response = wrapped(*args, **kwargs)
+                set_openai_request_span_attributes(
+                    span,
+                    SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                    server_address,
+                    server_port,
+                    request_model,
+                    environment,
+                    application_name,
+                    False,
+                    version,
+                )
+                try:
+                    response = wrapped(*args, **kwargs)
+                except Exception as e:
+                    err_type = set_span_error_type(span, e)
+                    if not disable_metrics and metrics:
+                        record_completion_metrics(
+                            metrics,
+                            SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                            SemanticConvention.GEN_AI_SYSTEM_OPENAI,
+                            server_address,
+                            server_port,
+                            request_model,
+                            kwargs.get("model", "unknown"),
+                            environment,
+                            application_name,
+                            start_time,
+                            time.time(),
+                            0,
+                            0,
+                            0,
+                            None,
+                            None,
+                            error_type=err_type,
+                        )
+                    raise
 
                 try:
                     response = process_chat_response(

--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -6,6 +6,11 @@ import json
 import time
 import logging
 
+from opentelemetry.sdk.resources import (
+    DEPLOYMENT_ENVIRONMENT,
+    SERVICE_NAME,
+    TELEMETRY_SDK_NAME,
+)
 from opentelemetry.trace import Status, StatusCode
 
 from openlit.__helpers import (
@@ -29,6 +34,49 @@ from openlit.semcov import SemanticConvention
 from openlit._config import OpenlitConfig
 
 logger = logging.getLogger(__name__)
+
+
+def set_openai_request_span_attributes(
+    span,
+    operation_name,
+    server_address,
+    server_port,
+    request_model,
+    environment,
+    application_name,
+    is_stream,
+    version,
+):
+    """
+    Set OpenAI request attributes that are known before the provider returns.
+    """
+
+    attributes = {
+        TELEMETRY_SDK_NAME: "openlit",
+        SemanticConvention.GEN_AI_OPERATION: operation_name,
+        SemanticConvention.GEN_AI_PROVIDER_NAME: SemanticConvention.GEN_AI_SYSTEM_OPENAI,
+        SemanticConvention.SERVER_ADDRESS: server_address,
+        SemanticConvention.SERVER_PORT: server_port,
+        DEPLOYMENT_ENVIRONMENT: environment,
+        SERVICE_NAME: application_name,
+        SemanticConvention.GEN_AI_REQUEST_IS_STREAM: is_stream,
+        SemanticConvention.GEN_AI_SDK_VERSION: version,
+    }
+    if request_model:
+        attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = request_model
+
+    for key, value in attributes.items():
+        if value is not None:
+            span.set_attribute(key, value)
+
+
+def set_span_error_type(span, error):
+    """Set error status and OTel error.type without recording duplicate events."""
+
+    error_type = type(error).__name__ or "_OTHER"
+    span.set_status(Status(StatusCode.ERROR))
+    span.set_attribute(SemanticConvention.ERROR_TYPE, error_type)
+    return error_type
 
 
 def handle_not_given(value, default=None):

--- a/sdk/python/tests/test_openai_error_attributes.py
+++ b/sdk/python/tests/test_openai_error_attributes.py
@@ -1,0 +1,160 @@
+"""Tests for OpenAI span attributes on provider call failures."""
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APITimeoutError
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openlit.instrumentation.openai.async_openai import async_chat_completions
+from openlit.instrumentation.openai.openai import chat_completions
+from openlit.semcov import SemanticConvention
+
+
+def _tracer_and_exporter():
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return tracer_provider.get_tracer("test-openai-errors"), exporter
+
+
+def _openai_instance(base_url="http://localhost:11434/v1"):
+    return SimpleNamespace(_client=SimpleNamespace(base_url=base_url))
+
+
+def _chat_kwargs(stream=False):
+    return {
+        "model": "ministral-3:3b",
+        "messages": [{"role": "user", "content": "ping"}],
+        "stream": stream,
+    }
+
+
+def _openai_timeout_error():
+    request = httpx.Request("POST", "http://localhost:11434/v1/chat/completions")
+    return APITimeoutError(request=request)
+
+
+def _assert_failed_chat_span(span, *, is_stream=False):
+    attrs = span.attributes
+
+    assert attrs[SemanticConvention.SERVER_ADDRESS] == "localhost"
+    assert attrs[SemanticConvention.SERVER_PORT] == 11434
+    assert attrs[SemanticConvention.GEN_AI_OPERATION] == (
+        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT
+    )
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == (
+        SemanticConvention.GEN_AI_SYSTEM_OPENAI
+    )
+    assert attrs[SemanticConvention.GEN_AI_REQUEST_MODEL] == "ministral-3:3b"
+    assert attrs[SemanticConvention.GEN_AI_REQUEST_IS_STREAM] is is_stream
+    assert attrs[SemanticConvention.ERROR_TYPE] == "APITimeoutError"
+
+
+def test_sync_chat_completion_error_keeps_request_span_attributes():
+    """Verify sync chat errors keep request-known OpenAI span attributes."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = chat_completions(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+    def raise_timeout(*_args, **_kwargs):
+        raise _openai_timeout_error()
+
+    with pytest.raises(APITimeoutError):
+        wrapper(raise_timeout, _openai_instance(), [], _chat_kwargs())
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    _assert_failed_chat_span(spans[0])
+
+
+def test_sync_streaming_chat_completion_error_keeps_request_span_attributes():
+    """Verify sync streaming setup errors keep request-known span attributes."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = chat_completions(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+    def raise_timeout(*_args, **_kwargs):
+        raise _openai_timeout_error()
+
+    with pytest.raises(APITimeoutError):
+        wrapper(raise_timeout, _openai_instance(), [], _chat_kwargs(stream=True))
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    _assert_failed_chat_span(spans[0], is_stream=True)
+
+
+@pytest.mark.asyncio
+async def test_async_chat_completion_error_keeps_request_span_attributes():
+    """Verify async chat errors keep request-known OpenAI span attributes."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = async_chat_completions(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+    async def raise_timeout(*_args, **_kwargs):
+        raise _openai_timeout_error()
+
+    with pytest.raises(APITimeoutError):
+        await wrapper(raise_timeout, _openai_instance(), [], _chat_kwargs())
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    _assert_failed_chat_span(spans[0])
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_chat_completion_error_keeps_request_span_attributes():
+    """Verify async streaming setup errors keep request-known span attributes."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = async_chat_completions(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+    async def raise_timeout(*_args, **_kwargs):
+        raise _openai_timeout_error()
+
+    with pytest.raises(APITimeoutError):
+        await wrapper(raise_timeout, _openai_instance(), [], _chat_kwargs(stream=True))
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    _assert_failed_chat_span(spans[0], is_stream=True)


### PR DESCRIPTION
## Summary

Preserve request-known OpenAI span attributes when chat completion calls fail before OpenLIT receives a provider response.

## Motivation

OpenAI-compatible local endpoints, proxies, and gateways can fail before returning a response, for example on timeout. In that path, OpenLIT currently creates an error span but misses endpoint and request metadata such as `server.address`, `server.port`, provider, operation, and request model.

That makes timeout traces much harder to debug because the span says the call failed, but not which endpoint or model request failed.

## Changes

- Add a small OpenAI helper that sets request-known span attributes before the provider call.
- Apply it to sync and async chat completions, including streaming setup.
- Preserve the existing success-path response processing.
- Set `error.type` for provider-call failures before re-raising the original exception.
- Add focused tests using OpenAI SDK `APITimeoutError` for sync/async and streaming/non-streaming chat failure paths.

## Test Plan

```bash
PYTHONPYCACHEPREFIX=/tmp/openlit-pycache python -m pytest sdk/python/tests/test_openai_error_attributes.py -q
```

```text
4 passed in 0.52s
```

```bash
PYTHONPYCACHEPREFIX=/tmp/openlit-pycache python -m py_compile sdk/python/src/openlit/instrumentation/openai/openai.py sdk/python/src/openlit/instrumentation/openai/async_openai.py sdk/python/src/openlit/instrumentation/openai/utils.py sdk/python/tests/test_openai_error_attributes.py
```

Result: passed.

```bash
cd sdk/python
PYLINTHOME=/tmp/openlit-pylint python -m pylint src/openlit/instrumentation/openai/openai.py src/openlit/instrumentation/openai/async_openai.py src/openlit/instrumentation/openai/utils.py tests/test_openai_error_attributes.py
```

```text
Your code has been rated at 10.00/10
```

## Risk

Low. The change only sets attributes that are already known before the OpenAI call starts and keeps the existing successful response processing unchanged. The provider exception is still re-raised to the caller.

## Related Issue

Fixes #1132.

## Maintainer Context

This keeps the scope limited to OpenAI chat completion error paths while covering both sync and async clients, plus streaming setup failures. It improves failed-call observability without changing successful response parsing or message capture behavior.

## Summary by Sourcery

Improve OpenAI chat completion instrumentation to retain endpoint and request metadata on failed provider calls and surface error type in spans and metrics.

Bug Fixes:
- Ensure OpenAI chat completion spans include endpoint, model, and request metadata even when provider calls fail before returning a response.

Enhancements:
- Add a shared helper to set OpenAI request span attributes before provider calls for sync/async and streaming chat completions.
- Record error.type on spans and propagate it into completion metrics when OpenAI provider calls fail.

Tests:
- Add sync and async, streaming and non-streaming tests validating OpenAI span attributes and error typing on APITimeoutError failures.