### PR TITLE
feat(ci): add contributor reputation check workflow

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -1,0 +1,146 @@
+name: Contributor Reputation Check
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'copilot-swe-agent[bot]'
+    steps:
+      - name: Checkout AGT scripts
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: microsoft/agent-governance-toolkit
+          sparse-checkout: scripts
+          path: agt
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Determine author
+        id: author
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            echo "username=${{ github.event.pull_request.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "type=pr" >> "$GITHUB_OUTPUT"
+          else
+            echo "username=${{ github.event.issue.user.login }}" >> "$GITHUB_OUTPUT"
+            echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+            echo "type=issue" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run profile check
+        id: profile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          python agt/scripts/contributor_check.py \
+            --username "${{ steps.author.outputs.username }}" \
+            --json > /tmp/profile.json 2>/tmp/profile.log
+          set -e
+          risk=$(python -c "import json; print(json.load(open('/tmp/profile.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
+          echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+      - name: Run credential audit
+        id: credential
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          python agt/scripts/credential_audit.py \
+            --username "${{ steps.author.outputs.username }}" \
+            --repo "${{ github.repository }}" \
+            --json > /tmp/cred.json 2>/tmp/cred.log
+          set -e
+          risk=$(python -c "import json; print(json.load(open('/tmp/cred.json'))['risk'])" 2>/dev/null || echo "UNKNOWN")
+          echo "risk=$risk" >> "$GITHUB_OUTPUT"
+
+      - name: Compute overall risk
+        id: overall
+        run: |
+          risk_to_num() {
+            case "$1" in HIGH) echo 3 ;; MEDIUM) echo 2 ;; LOW) echo 1 ;; *) echo 0 ;; esac
+          }
+          p=$(risk_to_num "${{ steps.profile.outputs.risk }}")
+          c=$(risk_to_num "${{ steps.credential.outputs.risk }}")
+          max=$p; [ "$c" -gt "$max" ] && max=$c
+          case "$max" in 3) r="HIGH" ;; 2) r="MEDIUM" ;; *) r="LOW" ;; esac
+          echo "risk=$r" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on MEDIUM or HIGH risk
+        if: steps.overall.outputs.risk == 'MEDIUM' || steps.overall.outputs.risk == 'HIGH'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          username="${{ steps.author.outputs.username }}"
+          number="${{ steps.author.outputs.number }}"
+          type="${{ steps.author.outputs.type }}"
+          risk="${{ steps.overall.outputs.risk }}"
+          profile="${{ steps.profile.outputs.risk }}"
+          cred="${{ steps.credential.outputs.risk }}"
+
+          if [ "$risk" = "HIGH" ]; then icon="🔴"; else icon="🟡"; fi
+
+          body="<!-- agt-contributor-check -->
+          $icon **Contributor Reputation Check: $risk risk**
+
+          | Check | Risk |
+          |-------|------|
+          | Profile | $profile |
+          | Credential audit | $cred |
+
+          Maintainers: please review this contributor before merging.
+          *Automated check powered by [AGT](https://github.com/microsoft/agent-governance-toolkit).*"
+
+          if [ "$type" = "pr" ]; then
+            gh pr comment "$number" --body "$body"
+          else
+            gh issue comment "$number" --body "$body"
+          fi
+
+      - name: Add risk label
+        if: steps.overall.outputs.risk == 'MEDIUM' || steps.overall.outputs.risk == 'HIGH'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number="${{ steps.author.outputs.number }}"
+          type="${{ steps.author.outputs.type }}"
+          risk="${{ steps.overall.outputs.risk }}"
+
+          gh label create "needs-review:$risk" \
+            --description "Contributor reputation check flagged $risk risk" \
+            --color "FFA500" --force 2>/dev/null || true
+
+          if [ "$type" = "pr" ]; then
+            gh pr edit "$number" --add-label "needs-review:$risk"
+          else
+            gh issue edit "$number" --add-label "needs-review:$risk"
+          fi
+
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Contributor Check: \`${{ steps.author.outputs.username }}\`"
+            echo "| Check | Risk |"
+            echo "|-------|------|"
+            echo "| Profile | ${{ steps.profile.outputs.risk }} |"
+            echo "| Credential | ${{ steps.credential.outputs.risk }} |"
+            echo "| **Overall** | **${{ steps.overall.outputs.risk }}** |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Add automated contributor reputation screening on PR/issue open events to detect coordinated inauthentic contribution patterns (e.g., credential-laundering campaigns, spray-and-pray governance issues).

## How it works

1. Checks out AGT's contributor reputation scripts via sparse-checkout
2. Runs **profile check** (account age, repo patterns, spray detection)
3. Runs **credential audit** (checks for merged-PR-to-citation pipelines)
4. Posts a comment and adds a label on MEDIUM/HIGH risk contributions
5. Skips bot accounts (dependabot, github-actions, copilot-swe-agent)

## Why this matters

Multiple AI agent framework repos have been targeted by coordinated campaigns that:
- Spray low-effort governance issues across 30+ repos in days
- Get trivial PRs merged, then cite them as credentials in other repos
- Use foundation submissions to build credibility for product placement

This workflow helps maintainers catch these patterns early.

## Dependencies

- Uses scripts from [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit) (stdlib-only Python, no pip install needed)
- Runs on `pull_request_target` and `issues` events only
- No secrets beyond the default `GITHUB_TOKEN`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Summary by Sourcery

Add an automated workflow to evaluate contributor reputation on new pull requests and issues and flag potentially risky contributions for maintainer review.

Enhancements:
- Automatically comment on and label PRs and issues assessed as medium or high contributor risk to highlight items needing additional review.

CI:
- Introduce a GitHub Actions workflow that runs AGT-based profile and credential audits for new PRs/issues, skipping trusted bots, and summarizes risk in job output.