### PR TITLE
fix: operator example app unused env OPENAI_API_KEY from kubernetes secret with fallback string

### DIFF
--- a/operator/examples/test-application-deployment.yaml
+++ b/operator/examples/test-application-deployment.yaml
@@ -206,8 +206,8 @@ data:
         """Test OpenAI API calls"""
         logger.info("🤖 Testing OpenAI API calls...")
         
-        # Check if OpenAI API key is available
-        api_key = "sk-proj-1234567890"
+        # Check if OpenAI API key is available (optional env from secret)
+        api_key = os.getenv("OPENAI_API_KEY", "sk-proj-1234567890")
         if not api_key:
             logger.warning("⚠️  OPENAI_API_KEY not found, skipping OpenAI tests")
             logger.info("💡 To test OpenAI instrumentation, provide an API key in the secret")


### PR DESCRIPTION
**Issue number**: #1135

### Change description:
Modified the operator test application to fetch the OPENAI_API_KEY from the environment variable instead of using a hard-coded placeholder. With fallback to a static value intentionally.

### Checklist

* [X] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [X] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).
