### PR TITLE
fix: controller release workflow

### DIFF
--- a/.github/workflows/controller-release.yml
+++ b/.github/workflows/controller-release.yml
@@ -132,13 +132,11 @@ jobs:
           cd dist
           sha256sum * > SHA256SUMS.txt
 
-      - name: Create GitHub Release
+      - name: Upload release assets
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
-          name: "OpenLIT Controller ${{ steps.version.outputs.version }}"
           files: |
             dist/*
-          generate_release_notes: true
 
   # ── 4. Docker multi-arch image → GHCR ─────────────────────────────────────
   docker:

--- a/openlit-controller/.gitignore
+++ b/openlit-controller/.gitignore
@@ -2,3 +2,12 @@ openlit-controller
 .obi-src/
 *.tar.gz
 dist/
+
+# libbpf headers copied by `make setup-bpf-headers` (vmlinux.h is committed)
+internal/scanner/bpf/bpf_helpers.h
+internal/scanner/bpf/bpf_helper_defs.h
+internal/scanner/bpf/bpf_tracing.h
+
+# bpf2go generated files (rebuilt by `make generate`)
+internal/scanner/*_bpfel.go
+internal/scanner/*_bpfel.o

--- a/openlit-controller/Dockerfile
+++ b/openlit-controller/Dockerfile
@@ -30,7 +30,7 @@ FROM golang:1.24-bookworm AS builder
 ARG VERSION=dev
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    clang llvm libbpf-dev linux-headers-generic bpftool && \
+    clang llvm libbpf-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build
@@ -39,7 +39,7 @@ RUN go mod download
 
 COPY . .
 
-RUN make setup-bpf generate
+RUN make setup-bpf-headers generate
 
 RUN CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/openlit/openlit/openlit-controller/internal/server.Version=${VERSION}" \
     -o openlit-controller ./cmd/controller

--- a/openlit-controller/Makefile
+++ b/openlit-controller/Makefile
@@ -11,12 +11,19 @@ else
     BPF_TARGET_ARCH := $(UNAME_M)
 endif
 
-.PHONY: setup-bpf
-setup-bpf:
-	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(SCANNER_DIR)/bpf/vmlinux.h
+# Copy libbpf headers needed for BPF compilation.
+# vmlinux.h is committed as a minimal hand-maintained header (see bpf/vmlinux.h).
+.PHONY: setup-bpf-headers
+setup-bpf-headers:
 	cp /usr/include/bpf/bpf_helpers.h $(SCANNER_DIR)/bpf/
 	cp /usr/include/bpf/bpf_helper_defs.h $(SCANNER_DIR)/bpf/
 	cp /usr/include/bpf/bpf_tracing.h $(SCANNER_DIR)/bpf/
+
+# Full setup: regenerate vmlinux.h from the running kernel + copy headers.
+# Requires /sys/kernel/btf/vmlinux (available on the host, NOT inside Docker).
+.PHONY: setup-bpf
+setup-bpf: setup-bpf-headers
+	bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(SCANNER_DIR)/bpf/vmlinux.h
 
 .PHONY: generate
 generate:

--- a/openlit-controller/internal/scanner/bpf/vmlinux.h
+++ b/openlit-controller/internal/scanner/bpf/vmlinux.h
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/*
+ * Minimal vmlinux.h — hand-maintained subset of kernel types used by
+ * llm_scanner.bpf.c.  This avoids a build-time dependency on
+ * /sys/kernel/btf/vmlinux (which is unavailable inside Docker BuildKit).
+ *
+ * Only the types actually referenced by the BPF program are included.
+ * CO-RE (preserve_access_index) is applied so the BPF loader can
+ * relocate field accesses at runtime if the target kernel's layout
+ * differs.
+ *
+ * To regenerate a full vmlinux.h from a running kernel (local dev):
+ *     bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+ */
+
+#ifndef __VMLINUX_H__
+#define __VMLINUX_H__
+
+#pragma clang attribute push (__attribute__((preserve_access_index)), apply_to = record)
+
+/* ── Basic scalar types ───────────────────────────────────────────── */
+
+typedef unsigned char        __u8;
+typedef short unsigned int   __u16;
+typedef unsigned int         __u32;
+typedef unsigned long long   __u64;
+typedef signed char          __s8;
+typedef short int            __s16;
+typedef int                  __s32;
+typedef long long            __s64;
+
+typedef __u16 __be16;
+typedef __u32 __be32;
+typedef __u64 __be64;
+
+typedef _Bool bool;
+enum { false = 0, true = 1 };
+
+/* ── Opaque kernel types (used only as kprobe parameter types) ──── */
+
+struct sock;
+struct sockaddr;
+
+/* ── IPv4 socket address ──────────────────────────────────────────── */
+
+struct in_addr {
+	__be32 s_addr;
+};
+
+struct sockaddr_in {
+	__u16          sin_family;
+	__be16         sin_port;
+	struct in_addr sin_addr;
+	unsigned char  __pad[8];   /* sizeof(struct sockaddr) == 16 */
+};
+
+/* ── IPv6 socket address ──────────────────────────────────────────── */
+
+struct in6_addr {
+	union {
+		__u8   in6_u[16];
+	};
+};
+
+struct sockaddr_in6 {
+	__u16           sin6_family;
+	__be16          sin6_port;
+	__be32          sin6_flowinfo;
+	struct in6_addr sin6_addr;
+	__u32           sin6_scope_id;
+};
+
+/* ── Architecture-specific pt_regs ────────────────────────────────
+ *
+ * bpf_tracing.h's BPF_KPROBE macro reads function arguments from
+ * registers via struct pt_regs (x86) or struct user_pt_regs (arm64).
+ * The field names below must match what bpf_tracing.h expects.
+ */
+
+#if defined(__TARGET_ARCH_x86)
+
+struct pt_regs {
+	long unsigned int r15;
+	long unsigned int r14;
+	long unsigned int r13;
+	long unsigned int r12;
+	long unsigned int bp;
+	long unsigned int bx;
+	long unsigned int r11;
+	long unsigned int r10;
+	long unsigned int r9;
+	long unsigned int r8;
+	long unsigned int ax;
+	long unsigned int cx;
+	long unsigned int dx;
+	long unsigned int si;
+	long unsigned int di;
+	long unsigned int orig_ax;
+	long unsigned int ip;
+	long unsigned int cs;
+	long unsigned int flags;
+	long unsigned int sp;
+	long unsigned int ss;
+};
+
+#elif defined(__TARGET_ARCH_arm64)
+
+struct user_pt_regs {
+	__u64 regs[31];
+	__u64 sp;
+	__u64 pc;
+	__u64 pstate;
+};
+
+struct pt_regs {
+	struct user_pt_regs user_regs;
+	__u64 orig_x0;
+	__s32 syscallno;
+	__u32 unused2;
+};
+
+#endif /* __TARGET_ARCH_* */
+
+#pragma clang attribute pop
+
+#endif /* __VMLINUX_H__ */


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [ ] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [ ] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Adjust BPF build setup for the controller to avoid depending on kernel BTF inside Docker and streamline release asset publishing.

Enhancements:
- Introduce a dedicated target to copy required libbpf headers and use a minimal committed vmlinux.h for BPF compilation.
- Update the controller Docker build to use only the header-setup target so it no longer requires kernel BTF or extra tooling in the image.
- Simplify the GitHub Actions controller release workflow to only upload prebuilt artifacts as release assets.

Documentation:
- Add a minimal, hand-maintained vmlinux.h documenting its purpose and regeneration instructions.