### PR TITLE
fix: `generalize-controller-desired-states-v2` migration error

### DIFF
--- a/src/client/src/clickhouse/migrations/create-controller-desired-states-migration.ts
+++ b/src/client/src/clickhouse/migrations/create-controller-desired-states-migration.ts
@@ -28,7 +28,7 @@ export default async function CreateControllerDesiredStatesTableMigration(
 			cluster_id,
 			argMax(desired_instrumentation_status, updated_at) AS latest_instrumentation_status,
 			argMax(desired_agent_status, updated_at) AS latest_agent_status,
-			max(updated_at) AS latest_updated_at
+			max(updated_at)
 		FROM ${CONTROLLER_SERVICES_TABLE}
 		FINAL
 		WHERE workload_key != ''

--- a/src/client/src/clickhouse/migrations/generalize-controller-desired-states-migration.ts
+++ b/src/client/src/clickhouse/migrations/generalize-controller-desired-states-migration.ts
@@ -35,7 +35,7 @@ export default async function GeneralizeControllerDesiredStatesMigration(
 			'instrumentation' AS feature,
 			argMax(desired_instrumentation_status, updated_at) AS desired_status,
 			'{}' AS config,
-			max(updated_at) AS updated_at
+			max(updated_at)
 		FROM openlit_controller_desired_states
 		FINAL
 		WHERE workload_key != ''
@@ -52,7 +52,7 @@ export default async function GeneralizeControllerDesiredStatesMigration(
 			'agent' AS feature,
 			argMax(desired_agent_status, updated_at) AS desired_status,
 			'{}' AS config,
-			max(updated_at) AS updated_at
+			max(updated_at)
 		FROM openlit_controller_desired_states
 		FINAL
 		WHERE workload_key != ''


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Fix ClickHouse migration queries for controller desired states to remove invalid column aliases in aggregate subselects.

Bug Fixes:
- Correct the generalize-controller-desired-states migration to avoid selecting max(updated_at) with an alias where it is not allowed in the target schema.
- Correct the create-controller-desired-states migration to align the aggregate projection with the expected table definition.