### PR TITLE
feat: Add server attributes in langchain instrumentation

### DIFF
--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -145,10 +145,12 @@ def apply_controller_mode_defaults(controller_mode, disabled_instrumentors):
     if controller_mode != "agent_observability":
         return normalized_disabled
 
-    merged = list(dict.fromkeys(
-        normalized_disabled
-        + normalize_instrumentor_names(CONTROLLER_MANAGED_DISABLED_INSTRUMENTORS)
-    ))
+    merged = list(
+        dict.fromkeys(
+            normalized_disabled
+            + normalize_instrumentor_names(CONTROLLER_MANAGED_DISABLED_INSTRUMENTORS)
+        )
+    )
     logger.info(
         "Controller-managed agent observability mode enabled; default duplicate-prone instrumentors will be disabled"
     )

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -519,7 +519,6 @@ def _create_callback_handler_class(
         is_langgraph_wrapper_active,
         set_framework_llm_active,
         reset_framework_llm_active,
-        get_server_address_for_provider,
     )
     from openlit.semcov import SemanticConvention
 
@@ -678,9 +677,7 @@ def _create_callback_handler_class(
                 span.set_attribute(
                     SemanticConvention.SERVER_ADDRESS, holder.server_address
                 )
-                span.set_attribute(
-                    SemanticConvention.SERVER_PORT, holder.server_port
-                )
+                span.set_attribute(SemanticConvention.SERVER_PORT, holder.server_port)
 
         def _extract_from_generations(
             self,
@@ -1123,9 +1120,7 @@ def _create_callback_handler_class(
                 self.spans[run_id].prompts = prompts if prompts else []
                 self.spans[run_id].provider = provider
 
-                self._resolve_and_set_server(
-                    run_id, span, provider, serialized, kwargs
-                )
+                self._resolve_and_set_server(run_id, span, provider, serialized, kwargs)
 
                 if prompts:
                     prompt_str = truncate_content("\n".join(prompts))
@@ -1192,9 +1187,7 @@ def _create_callback_handler_class(
                 self.spans[run_id].model_parameters = model_params
                 self.spans[run_id].provider = provider
 
-                self._resolve_and_set_server(
-                    run_id, span, provider, serialized, kwargs
-                )
+                self._resolve_and_set_server(run_id, span, provider, serialized, kwargs)
 
                 # Always calculate prompt content for token estimation
                 if messages:

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -449,6 +449,40 @@ def _resolve_conversation_id(metadata: Optional[Dict[str, Any]]) -> Optional[str
     return None
 
 
+_API_BASE_KEYS = (
+    "api_base",
+    "base_url",
+    "openai_api_base",
+    "openai_proxy",
+    "azure_endpoint",
+    "endpoint",
+    "host",
+)
+
+
+def _resolve_api_base(
+    serialized: Optional[Dict[str, Any]], kwargs: Dict[str, Any]
+) -> Optional[str]:
+    """Find an explicit API base URL from langchain callback inputs.
+
+    LangChain passes connection details inconsistently across providers and
+    versions: some put it in `invocation_params`, others only inside
+    `serialized["kwargs"]`. Check both, then a few common keys.
+    """
+    invocation_params = kwargs.get("invocation_params") or {}
+    for key in _API_BASE_KEYS:
+        val = invocation_params.get(key)
+        if val:
+            return str(val)
+
+    serialized_kwargs = (serialized or {}).get("kwargs") or {}
+    for key in _API_BASE_KEYS:
+        val = serialized_kwargs.get(key)
+        if val:
+            return str(val)
+    return None
+
+
 # =============================================================================
 # Callback Handler
 # =============================================================================
@@ -604,6 +638,49 @@ def _create_callback_handler_class(
                 SemanticConvention.GEN_AI_APPLICATION_NAME, self._application_name
             )
             span.set_attribute(SemanticConvention.GEN_AI_SDK_VERSION, self._version)
+
+        def _resolve_and_set_server(
+            self, run_id, span, provider, serialized, kwargs
+        ) -> None:
+            """Resolve server.address/port and set them on the span and holder.
+
+            Setting these on the span at start (rather than only at on_llm_end)
+            guarantees they are present on error spans too — see issue #1169.
+            """
+            from openlit.__helpers import get_server_address_for_provider
+
+            holder = self.spans[run_id]
+
+            api_base = _resolve_api_base(serialized, kwargs)
+            if api_base:
+                try:
+                    from urllib.parse import urlparse
+
+                    parsed = urlparse(api_base)
+                    if parsed.hostname:
+                        holder.server_address = parsed.hostname
+                        if parsed.port:
+                            holder.server_port = parsed.port
+                        elif parsed.scheme == "http":
+                            holder.server_port = 80
+                        else:
+                            holder.server_port = 443
+                except Exception:
+                    pass
+
+            if not holder.server_address:
+                default_host, default_port = get_server_address_for_provider(provider)
+                if default_host:
+                    holder.server_address = default_host
+                    holder.server_port = default_port
+
+            if holder.server_address:
+                span.set_attribute(
+                    SemanticConvention.SERVER_ADDRESS, holder.server_address
+                )
+                span.set_attribute(
+                    SemanticConvention.SERVER_PORT, holder.server_port
+                )
 
         def _extract_from_generations(
             self,
@@ -1046,27 +1123,9 @@ def _create_callback_handler_class(
                 self.spans[run_id].prompts = prompts if prompts else []
                 self.spans[run_id].provider = provider
 
-                # Resolve server address from invocation_params or provider defaults
-                invocation_params = kwargs.get("invocation_params", {})
-                api_base = invocation_params.get("api_base") or invocation_params.get(
-                    "base_url"
+                self._resolve_and_set_server(
+                    run_id, span, provider, serialized, kwargs
                 )
-                if api_base:
-                    try:
-                        from urllib.parse import urlparse
-
-                        parsed = urlparse(api_base)
-                        self.spans[run_id].server_address = parsed.hostname or ""
-                        self.spans[run_id].server_port = parsed.port or 443
-                    except Exception:
-                        pass
-                if not self.spans[run_id].server_address:
-                    default_host, default_port = get_server_address_for_provider(
-                        provider
-                    )
-                    if default_host:
-                        self.spans[run_id].server_address = default_host
-                        self.spans[run_id].server_port = default_port
 
                 if prompts:
                     prompt_str = truncate_content("\n".join(prompts))
@@ -1133,27 +1192,9 @@ def _create_callback_handler_class(
                 self.spans[run_id].model_parameters = model_params
                 self.spans[run_id].provider = provider
 
-                # Resolve server address from invocation_params or provider defaults
-                invocation_params = kwargs.get("invocation_params", {})
-                api_base = invocation_params.get("api_base") or invocation_params.get(
-                    "base_url"
+                self._resolve_and_set_server(
+                    run_id, span, provider, serialized, kwargs
                 )
-                if api_base:
-                    try:
-                        from urllib.parse import urlparse
-
-                        parsed = urlparse(api_base)
-                        self.spans[run_id].server_address = parsed.hostname or ""
-                        self.spans[run_id].server_port = parsed.port or 443
-                    except Exception:
-                        pass
-                if not self.spans[run_id].server_address:
-                    default_host, default_port = get_server_address_for_provider(
-                        provider
-                    )
-                    if default_host:
-                        self.spans[run_id].server_address = default_host
-                        self.spans[run_id].server_port = default_port
 
                 # Always calculate prompt content for token estimation
                 if messages:
@@ -2476,9 +2517,9 @@ class LangChainInstrumentor(BaseInstrumentor):
 
         try:
             wrap_function_wrapper(
-                module="langchain_core.callbacks.manager",
-                name="BaseCallbackManager.__init__",
-                wrapper=_BaseCallbackManagerInitWrapper(handler_instance),
+                "langchain_core.callbacks.manager",
+                "BaseCallbackManager.__init__",
+                _BaseCallbackManagerInitWrapper(handler_instance),
             )
             logger.debug("Successfully wrapped BaseCallbackManager.__init__")
         except Exception as e:
@@ -2486,11 +2527,9 @@ class LangChainInstrumentor(BaseInstrumentor):
 
         try:
             wrap_function_wrapper(
-                module="langchain.agents",
-                name="create_agent",
-                wrapper=_wrap_create_agent(
-                    tracer, version, environment, application_name
-                ),
+                "langchain.agents",
+                "create_agent",
+                _wrap_create_agent(tracer, version, environment, application_name),
             )
             logger.debug("Successfully wrapped langchain.agents.create_agent")
         except Exception:
@@ -2509,9 +2548,9 @@ class LangChainInstrumentor(BaseInstrumentor):
         for method_name in ("embed_documents", "embed_query"):
             try:
                 wrap_function_wrapper(
-                    module="langchain_core.embeddings",
-                    name=f"Embeddings.{method_name}",
-                    wrapper=_wrap_embed(**embed_kwargs),
+                    "langchain_core.embeddings",
+                    f"Embeddings.{method_name}",
+                    _wrap_embed(**embed_kwargs),
                 )
                 logger.debug("Successfully wrapped Embeddings.%s", method_name)
             except Exception:
@@ -2520,9 +2559,9 @@ class LangChainInstrumentor(BaseInstrumentor):
         for method_name in ("aembed_documents", "aembed_query"):
             try:
                 wrap_function_wrapper(
-                    module="langchain_core.embeddings",
-                    name=f"Embeddings.{method_name}",
-                    wrapper=_wrap_embed_async(**embed_kwargs),
+                    "langchain_core.embeddings",
+                    f"Embeddings.{method_name}",
+                    _wrap_embed_async(**embed_kwargs),
                 )
                 logger.debug("Successfully wrapped Embeddings.%s", method_name)
             except Exception:

--- a/sdk/typescript/src/helpers.ts
+++ b/sdk/typescript/src/helpers.ts
@@ -151,6 +151,7 @@ const PROVIDER_DEFAULT_ENDPOINTS: Record<string, [string, number]> = {
   deepseek: ['api.deepseek.com', 443],
   x_ai: ['api.x.ai', 443],
   huggingface: ['api-inference.huggingface.co', 443],
+  cursor: ['api2.cursor.sh', 443],
 };
 
 export function getServerAddressForProvider(provider: string): [string, number] {

--- a/sdk/typescript/src/instrumentation/cursor-sdk/index.ts
+++ b/sdk/typescript/src/instrumentation/cursor-sdk/index.ts
@@ -1,0 +1,74 @@
+/**
+ * OpenLIT Cursor SDK Instrumentation
+ *
+ * Provides auto-instrumentation for @cursor/sdk including:
+ * - Agent.create() wrapping (create_agent spans + send() patching)
+ * - Agent.resume() wrapping (send() patching on resumed agents)
+ * - agent.send() wrapping (invoke_agent spans with streaming tool child spans)
+ *
+ * Agent.prompt() is covered automatically since it calls create() + send().
+ *
+ * OTel GenAI semantic convention compliant.
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+} from '@opentelemetry/instrumentation';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import { patchAgentCreate, patchAgentResume } from './wrapper';
+
+const SUPPORTED_VERSIONS = ['>=0.1.0'];
+
+export default class CursorSDKInstrumentation extends InstrumentationBase {
+  constructor(config: InstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-cursor-sdk`, '1.0.0', config);
+  }
+
+  protected init(): InstrumentationModuleDefinition | InstrumentationModuleDefinition[] | void {
+    const module = new InstrumentationNodeModuleDefinition(
+      '@cursor/sdk',
+      SUPPORTED_VERSIONS,
+      (moduleExports: any) => {
+        return this._patch(moduleExports);
+      },
+      (moduleExports: any) => {
+        this._unpatch(moduleExports);
+        return moduleExports;
+      },
+    );
+    return module;
+  }
+
+  public manualPatch(moduleExports: any): any {
+    return this._patch(moduleExports);
+  }
+
+  private _patch(moduleExports: any): any {
+    try {
+      const tracer = this.tracer;
+      const AgentClass = moduleExports.Agent;
+
+      if (!AgentClass) return moduleExports;
+
+      if (typeof AgentClass.create === 'function') {
+        const originalCreate = AgentClass.create;
+        AgentClass.create = patchAgentCreate(tracer)(originalCreate);
+      }
+
+      if (typeof AgentClass.resume === 'function') {
+        const originalResume = AgentClass.resume;
+        AgentClass.resume = patchAgentResume(tracer)(originalResume);
+      }
+
+    } catch { /* graceful degradation */ }
+    return moduleExports;
+  }
+
+  private _unpatch(_moduleExports: any): void {
+    // InstrumentationBase handles restoring originals on disable
+  }
+}

--- a/sdk/typescript/src/instrumentation/cursor-sdk/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/cursor-sdk/wrapper.ts
@@ -52,14 +52,14 @@ const CURSOR_STATUS_TO_FINISH_REASON: Record<string, string> = {
 // ---------------------------------------------------------------------------
 
 class AgentCreationRegistry {
-  private _contexts = new Map<string, SpanContext>();
+  private _contexts = new WeakMap<object, SpanContext>();
 
-  register(agentId: string, spanContext: SpanContext): void {
-    this._contexts.set(agentId, spanContext);
+  register(agent: object, spanContext: SpanContext): void {
+    this._contexts.set(agent, spanContext);
   }
 
-  get(agentId: string): SpanContext | undefined {
-    return this._contexts.get(agentId);
+  get(agent: object): SpanContext | undefined {
+    return this._contexts.get(agent);
   }
 }
 
@@ -425,7 +425,7 @@ function wrapSend(
     const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT} ${displayName}`;
     const requestModel = modelId || resolveModelId(options) || 'unknown';
 
-    const creationSpanCtx = agentRegistry.get(agentId);
+    const creationSpanCtx = agentRegistry.get(this);
     const links: Link[] = [];
     if (creationSpanCtx) {
       links.push({ context: creationSpanCtx });
@@ -737,8 +737,8 @@ export function patchAgentCreate(tracer: Tracer): (originalCreate: any) => any {
         const agentId = agent.agentId;
         if (agentId) {
           span.setAttribute(SemanticConvention.GEN_AI_AGENT_ID, agentId);
-          agentRegistry.register(agentId, span.spanContext());
         }
+        agentRegistry.register(agent, span.spanContext());
 
         const resolvedModel = agent.model?.id || modelId;
         if (resolvedModel) span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, resolvedModel);

--- a/sdk/typescript/src/instrumentation/cursor-sdk/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/cursor-sdk/wrapper.ts
@@ -1,0 +1,788 @@
+/**
+ * Cursor SDK wrapper -- OTel GenAI semantic convention compliant.
+ *
+ * Wraps Agent.create(), Agent.resume(), and agent.send()
+ * to produce `create_agent`, `invoke_agent`, and `execute_tool` spans.
+ *
+ * Agent.prompt() is NOT wrapped separately -- it internally calls
+ * create() + send(), so the patched versions handle it automatically
+ * without producing duplicate spans.
+ *
+ * Token usage is captured via onDelta injection (TurnEndedUpdate).
+ * Tool call spans are created from SDKMessage stream events.
+ * The `system` stream event provides resolved model and tool definitions.
+ */
+
+import {
+  Tracer,
+  Span,
+  SpanKind,
+  SpanStatusCode,
+  SpanContext,
+  context as otelContext,
+  trace,
+  Link,
+} from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from '../../semantic-convention';
+import OpenlitConfig from '../../config';
+import OpenLitHelper, {
+  applyCustomSpanAttributes,
+  getServerAddressForProvider,
+  setFrameworkLlmActive,
+  resetFrameworkLlmActive,
+} from '../../helpers';
+import { SDK_NAME, SDK_VERSION } from '../../constant';
+import Metrics from '../../otel/metrics';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const [SERVER_ADDRESS, SERVER_PORT] = getServerAddressForProvider('cursor');
+
+const CURSOR_STATUS_TO_FINISH_REASON: Record<string, string> = {
+  finished: 'stop',
+  error: 'error',
+  cancelled: 'cancelled',
+};
+
+// ---------------------------------------------------------------------------
+// Agent creation registry -- links invoke_agent back to create_agent
+// ---------------------------------------------------------------------------
+
+class AgentCreationRegistry {
+  private _contexts = new Map<string, SpanContext>();
+
+  register(agentId: string, spanContext: SpanContext): void {
+    this._contexts.set(agentId, spanContext);
+  }
+
+  get(agentId: string): SpanContext | undefined {
+    return this._contexts.get(agentId);
+  }
+}
+
+const agentRegistry = new AgentCreationRegistry();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateContent(content: string): string {
+  const maxLen = OpenlitConfig.maxContentLength;
+  if (maxLen != null && maxLen > 0 && content.length > maxLen) {
+    return content.slice(0, maxLen);
+  }
+  return content;
+}
+
+function mapRunStatusToFinishReason(status: string | undefined): string {
+  if (!status) return 'stop';
+  return CURSOR_STATUS_TO_FINISH_REASON[status] || status;
+}
+
+function resolveAgentName(options: any): string | null {
+  if (!options) return null;
+  const name = options.name;
+  if (name && typeof name === 'string' && name.trim()) return name.trim();
+  return null;
+}
+
+function resolveModelId(options: any): string | null {
+  if (!options?.model) return null;
+  const model = options.model;
+  if (typeof model === 'string') return model;
+  if (typeof model === 'object' && model.id) return String(model.id);
+  return null;
+}
+
+function setCommonSpanAttributes(span: Span): void {
+  span.setAttribute(ATTR_TELEMETRY_SDK_NAME, SDK_NAME);
+  span.setAttribute(SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT, OpenlitConfig.environment ?? 'default');
+  span.setAttribute(ATTR_SERVICE_NAME, OpenlitConfig.applicationName ?? 'default');
+  span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, SDK_VERSION);
+  span.setAttribute(SemanticConvention.SERVER_ADDRESS, SERVER_ADDRESS);
+  span.setAttribute(SemanticConvention.SERVER_PORT, SERVER_PORT);
+}
+
+// ---------------------------------------------------------------------------
+// Tool span tracker -- manages in-flight execute_tool spans from stream
+// ---------------------------------------------------------------------------
+
+class ToolSpanTracker {
+  private _tracer: Tracer;
+  private _parentSpan: Span;
+  private _captureContent: boolean;
+  private _inFlight = new Map<string, Span>();
+
+  constructor(tracer: Tracer, parentSpan: Span, captureContent: boolean) {
+    this._tracer = tracer;
+    this._parentSpan = parentSpan;
+    this._captureContent = captureContent;
+  }
+
+  startTool(toolName: string, callId: string, args?: unknown): void {
+    const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS} ${toolName}`;
+    const parentCtx = trace.setSpan(otelContext.active(), this._parentSpan);
+
+    const span = this._tracer.startSpan(spanName, {
+      kind: SpanKind.INTERNAL,
+      attributes: {
+        [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS,
+        [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_CURSOR,
+      },
+    }, parentCtx);
+
+    span.setAttribute(SemanticConvention.GEN_AI_TOOL_NAME, toolName);
+    span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ID, callId);
+    span.setAttribute(SemanticConvention.GEN_AI_TOOL_TYPE_OTEL, 'extension');
+
+    setCommonSpanAttributes(span);
+
+    if (this._captureContent && args != null) {
+      try {
+        const argsStr = typeof args === 'string' ? args : JSON.stringify(args);
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS, truncateContent(argsStr));
+      } catch { /* ignore */ }
+    }
+
+    applyCustomSpanAttributes(span);
+    this._inFlight.set(callId, span);
+  }
+
+  endTool(callId: string, result?: unknown, isError = false): void {
+    const span = this._inFlight.get(callId);
+    if (!span) return;
+    this._inFlight.delete(callId);
+
+    if (isError) {
+      span.setAttribute(SemanticConvention.ERROR_TYPE, 'ToolExecutionError');
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'tool execution failed' });
+    } else {
+      if (this._captureContent && result != null) {
+        try {
+          const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+          span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_RESULT, truncateContent(resultStr));
+        } catch { /* ignore */ }
+      }
+      span.setStatus({ code: SpanStatusCode.OK });
+    }
+
+    span.end();
+  }
+
+  endAll(): void {
+    for (const [, span] of this._inFlight) {
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+    }
+    this._inFlight.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Process SDKMessage stream events for tool spans and content capture
+// ---------------------------------------------------------------------------
+
+interface StreamState {
+  assistantText: string;
+  thinkingText: string;
+  toolCalls: Array<{ name: string; callId: string; args?: unknown; result?: unknown }>;
+  resolvedModel: string | null;
+  toolDefinitions: string[] | null;
+  runId: string | null;
+  firstContentTimeMs: number | null;
+}
+
+function processStreamEvent(
+  event: any,
+  toolTracker: ToolSpanTracker,
+  state: StreamState,
+): void {
+  if (!event || !event.type) return;
+
+  if (!state.runId && event.run_id) {
+    state.runId = event.run_id;
+  }
+
+  switch (event.type) {
+    case 'system': {
+      if (event.model) {
+        const modelId = typeof event.model === 'string' ? event.model : event.model?.id;
+        if (modelId) state.resolvedModel = String(modelId);
+      }
+      if (Array.isArray(event.tools) && event.tools.length > 0) {
+        state.toolDefinitions = event.tools.map(String);
+      }
+      break;
+    }
+    case 'tool_call': {
+      const callId = event.call_id;
+      const toolName = event.name || 'unknown';
+      const status = event.status;
+
+      if (status === 'running') {
+        toolTracker.startTool(toolName, callId, event.args);
+        state.toolCalls.push({ name: toolName, callId, args: event.args });
+      } else if (status === 'completed') {
+        toolTracker.endTool(callId, event.result, false);
+        const tc = state.toolCalls.find(t => t.callId === callId);
+        if (tc) tc.result = event.result;
+      } else if (status === 'error') {
+        toolTracker.endTool(callId, event.result, true);
+      }
+      break;
+    }
+    case 'assistant': {
+      if (state.firstContentTimeMs === null) {
+        state.firstContentTimeMs = Date.now();
+      }
+      const content = event.message?.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'text' && block.text) {
+            state.assistantText += block.text;
+          }
+        }
+      }
+      break;
+    }
+    case 'thinking': {
+      if (state.firstContentTimeMs === null) {
+        state.firstContentTimeMs = Date.now();
+      }
+      if (event.text) {
+        state.thinkingText += event.text;
+      }
+      break;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build OTel input/output messages
+// ---------------------------------------------------------------------------
+
+function buildInputMessages(message: string | any): string | null {
+  try {
+    if (typeof message === 'string') {
+      return JSON.stringify([{
+        role: 'user',
+        parts: [{ type: 'text', content: truncateContent(message) }],
+      }]);
+    }
+
+    const parts: any[] = [];
+    if (message?.text) {
+      parts.push({ type: 'text', content: truncateContent(message.text) });
+    }
+    if (Array.isArray(message?.images)) {
+      for (const img of message.images) {
+        parts.push({ type: 'image', mimeType: img.mimeType || 'image/png' });
+      }
+    }
+    if (parts.length === 0) return null;
+    return JSON.stringify([{ role: 'user', parts }]);
+  } catch { return null; }
+}
+
+function buildOutputMessages(state: StreamState, finishReason: string): string | null {
+  try {
+    const parts: any[] = [];
+
+    if (state.assistantText) {
+      parts.push({ type: 'text', content: truncateContent(state.assistantText) });
+    }
+
+    if (state.thinkingText) {
+      parts.push({ type: 'reasoning', content: truncateContent(state.thinkingText) });
+    }
+
+    for (const tc of state.toolCalls) {
+      const toolPart: any = {
+        type: 'tool_call',
+        id: tc.callId,
+        name: tc.name,
+      };
+      if (tc.args != null) {
+        toolPart.arguments = typeof tc.args === 'object' ? tc.args : {};
+      }
+      parts.push(toolPart);
+    }
+
+    if (parts.length === 0) return null;
+    return JSON.stringify([{ role: 'assistant', parts, finish_reason: finishReason }]);
+  } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// Emit inference event for invoke_agent spans
+// ---------------------------------------------------------------------------
+
+function emitInvokeAgentEvent(
+  span: Span,
+  agentId: string | null,
+  model: string | null,
+  responseModel: string | null,
+  finishReason: string,
+  inputTokens: number,
+  outputTokens: number,
+  inputMessagesJson: string | null,
+  outputMessagesJson: string | null,
+): void {
+  if (OpenlitConfig.disableEvents) return;
+
+  try {
+    const attributes: Record<string, any> = {
+      [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+      [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_CURSOR,
+      [SemanticConvention.SERVER_ADDRESS]: SERVER_ADDRESS,
+      [SemanticConvention.SERVER_PORT]: SERVER_PORT,
+    };
+
+    if (model) attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = model;
+    if (responseModel) attributes[SemanticConvention.GEN_AI_RESPONSE_MODEL] = responseModel;
+    if (agentId) attributes[SemanticConvention.GEN_AI_CONVERSATION_ID] = agentId;
+    if (finishReason) attributes[SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON] = [finishReason];
+    if (inputTokens) attributes[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] = inputTokens;
+    if (outputTokens) attributes[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] = outputTokens;
+
+    if (inputMessagesJson != null) {
+      attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES] = inputMessagesJson;
+    }
+    if (outputMessagesJson != null) {
+      attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = outputMessagesJson;
+    }
+
+    OpenLitHelper.emitInferenceEvent(span, attributes);
+  } catch { /* swallow */ }
+}
+
+// ---------------------------------------------------------------------------
+// Record metrics for invoke_agent spans
+// ---------------------------------------------------------------------------
+
+function recordInvokeAgentMetrics(
+  model: string | null,
+  inputTokens: number,
+  outputTokens: number,
+  cost: number,
+  duration: number,
+  errorType?: string,
+): void {
+  if (OpenlitConfig.disableMetrics) return;
+
+  try {
+    const attributes: Record<string, any> = {
+      [ATTR_TELEMETRY_SDK_NAME]: SDK_NAME,
+      [ATTR_SERVICE_NAME]: OpenlitConfig.applicationName ?? 'default',
+      [SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]: OpenlitConfig.environment ?? 'default',
+      [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_CURSOR,
+      [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+      [SemanticConvention.SERVER_ADDRESS]: SERVER_ADDRESS,
+      [SemanticConvention.SERVER_PORT]: SERVER_PORT,
+    };
+    if (model) attributes[SemanticConvention.GEN_AI_REQUEST_MODEL] = model;
+    if (errorType) attributes[SemanticConvention.ERROR_TYPE] = errorType;
+
+    if (Metrics.genaiClientOperationDuration) {
+      Metrics.genaiClientOperationDuration.record(duration, attributes);
+    }
+
+    if (inputTokens && Metrics.genaiClientUsageTokens) {
+      Metrics.genaiClientUsageTokens.record(inputTokens, {
+        ...attributes,
+        [SemanticConvention.GEN_AI_TOKEN_TYPE]: SemanticConvention.GEN_AI_TOKEN_TYPE_INPUT,
+      });
+    }
+    if (outputTokens && Metrics.genaiClientUsageTokens) {
+      Metrics.genaiClientUsageTokens.record(outputTokens, {
+        ...attributes,
+        [SemanticConvention.GEN_AI_TOKEN_TYPE]: SemanticConvention.GEN_AI_TOKEN_TYPE_OUTPUT,
+      });
+    }
+    if (cost && Metrics.genaiCost) {
+      Metrics.genaiCost.record(cost, attributes);
+    }
+  } catch { /* swallow */ }
+}
+
+// ---------------------------------------------------------------------------
+// wrapSend -- wraps agent.send() to produce invoke_agent spans
+// ---------------------------------------------------------------------------
+
+function wrapSend(
+  tracer: Tracer,
+  originalSend: any,
+  agentId: string,
+  agentName: string | null,
+  modelId: string | null,
+): any {
+  return function wrappedSend(this: any, message: any, options?: any) {
+    const captureContent = OpenlitConfig.captureMessageContent ?? true;
+    const displayName = agentName || agentId;
+    const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT} ${displayName}`;
+    const requestModel = modelId || resolveModelId(options) || 'unknown';
+
+    const creationSpanCtx = agentRegistry.get(agentId);
+    const links: Link[] = [];
+    if (creationSpanCtx) {
+      links.push({ context: creationSpanCtx });
+    }
+
+    // Start invoke_agent in the same trace as create_agent by using its
+    // span context as parent. This keeps both spans in one trace while
+    // the span link provides explicit correlation.
+    let parentCtx = otelContext.active();
+    if (creationSpanCtx) {
+      const remoteSpan = trace.wrapSpanContext(creationSpanCtx);
+      parentCtx = trace.setSpan(parentCtx, remoteSpan);
+    }
+
+    const span = tracer.startSpan(spanName, {
+      kind: SpanKind.CLIENT,
+      attributes: {
+        [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+        [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_CURSOR,
+        [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+        [SemanticConvention.SERVER_ADDRESS]: SERVER_ADDRESS,
+        [SemanticConvention.SERVER_PORT]: SERVER_PORT,
+      },
+      links,
+    }, parentCtx);
+
+    setCommonSpanAttributes(span);
+    span.setAttribute(SemanticConvention.GEN_AI_AGENT_ID, agentId);
+    span.setAttribute(SemanticConvention.GEN_AI_CONVERSATION_ID, agentId);
+    if (agentName) span.setAttribute(SemanticConvention.GEN_AI_AGENT_NAME, agentName);
+
+    if (captureContent) {
+      const inputJson = buildInputMessages(message);
+      if (inputJson) span.setAttribute(SemanticConvention.GEN_AI_INPUT_MESSAGES, inputJson);
+    }
+
+    applyCustomSpanAttributes(span);
+
+    const startTime = Date.now() / 1000;
+    const startTimeMs = Date.now();
+    const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+    const toolTracker = new ToolSpanTracker(tracer, span, captureContent);
+    const streamState: StreamState = {
+      assistantText: '',
+      thinkingText: '',
+      toolCalls: [],
+      resolvedModel: null,
+      toolDefinitions: null,
+      runId: null,
+      firstContentTimeMs: null,
+    };
+
+    const userOnDelta = options?.onDelta;
+    const mergedOptions = { ...options };
+    mergedOptions.onDelta = async (args: any) => {
+      try {
+        const update = args?.update;
+        if (update?.type === 'turn-ended' && update.usage) {
+          usage.inputTokens += update.usage.inputTokens || 0;
+          usage.outputTokens += update.usage.outputTokens || 0;
+          usage.cacheReadTokens += update.usage.cacheReadTokens || 0;
+          usage.cacheWriteTokens += update.usage.cacheWriteTokens || 0;
+        }
+      } catch { /* swallow */ }
+
+      if (userOnDelta) {
+        return userOnDelta(args);
+      }
+    };
+
+    const spanContext = trace.setSpan(otelContext.active(), span);
+
+    setFrameworkLlmActive();
+    let runPromise: Promise<any>;
+    try {
+      runPromise = otelContext.with(spanContext, () => {
+        return originalSend.call(this, message, mergedOptions);
+      });
+    } catch (e: any) {
+      resetFrameworkLlmActive();
+      OpenLitHelper.handleException(span, e);
+      span.end();
+      throw e;
+    }
+
+    return runPromise.then((run: any) => {
+      return createRunProxy(
+        run, tracer, span, startTime, startTimeMs, usage, toolTracker,
+        streamState, captureContent, agentId, agentName, requestModel, message,
+      );
+    }).catch((e: any) => {
+      resetFrameworkLlmActive();
+      OpenLitHelper.handleException(span, e);
+      recordInvokeAgentMetrics(
+        requestModel, 0, 0, 0,
+        (Date.now() / 1000) - startTime,
+        e?.constructor?.name || '_OTHER',
+      );
+      span.end();
+      throw e;
+    });
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createRunProxy -- proxies the Run to intercept stream() and wait()
+// ---------------------------------------------------------------------------
+
+function createRunProxy(
+  run: any,
+  tracer: Tracer,
+  span: Span,
+  startTime: number,
+  startTimeMs: number,
+  usage: { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheWriteTokens: number },
+  toolTracker: ToolSpanTracker,
+  streamState: StreamState,
+  captureContent: boolean,
+  agentId: string,
+  agentName: string | null,
+  requestModel: string,
+  message: any,
+): any {
+  let finalized = false;
+  let isStreamMode = false;
+
+  const finalizeSpan = (result?: any, error?: any) => {
+    if (finalized) return;
+    finalized = true;
+
+    resetFrameworkLlmActive();
+    toolTracker.endAll();
+
+    const duration = (Date.now() / 1000) - startTime;
+    const status = result?.status || run.status || 'finished';
+    const finishReason = mapRunStatusToFinishReason(status);
+    const responseModel = streamState.resolvedModel || result?.model?.id || run.model?.id || null;
+    const durationMs = result?.durationMs || run.durationMs;
+
+    if (responseModel) span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, responseModel);
+    span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [finishReason]);
+
+    const runId = streamState.runId || run.id;
+    if (runId) span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_ID, runId);
+
+    if (isStreamMode) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_STREAM, true);
+    }
+
+    if (usage.inputTokens) span.setAttribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, usage.inputTokens);
+    if (usage.outputTokens) span.setAttribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, usage.outputTokens);
+    if (usage.cacheReadTokens) span.setAttribute(SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, usage.cacheReadTokens);
+    if (usage.cacheWriteTokens) span.setAttribute(SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, usage.cacheWriteTokens);
+
+    const effectiveDuration = durationMs ? durationMs / 1000 : duration;
+    span.setAttribute(SemanticConvention.GEN_AI_CLIENT_OPERATION_DURATION, effectiveDuration);
+
+    if (isStreamMode && streamState.firstContentTimeMs !== null) {
+      const ttft = (streamState.firstContentTimeMs - startTimeMs) / 1000;
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK, ttft);
+    }
+
+    if (streamState.toolDefinitions && streamState.toolDefinitions.length > 0) {
+      span.setAttribute(SemanticConvention.GEN_AI_TOOL_DEFINITIONS, JSON.stringify(streamState.toolDefinitions));
+    }
+
+    const pricingInfo = OpenlitConfig.pricingInfo || {};
+    const effectiveModel = responseModel || requestModel;
+    const cost = effectiveModel
+      ? OpenLitHelper.getChatModelCost(effectiveModel, pricingInfo, usage.inputTokens, usage.outputTokens)
+      : 0;
+    if (cost) span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, cost);
+
+    let outputMessagesJson: string | null = null;
+    if (captureContent) {
+      const resultText = result?.result || run.result;
+      if (resultText && !streamState.assistantText) {
+        streamState.assistantText = resultText;
+      }
+      outputMessagesJson = buildOutputMessages(streamState, finishReason);
+      if (outputMessagesJson) {
+        span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, outputMessagesJson);
+      }
+    }
+
+    if (error) {
+      OpenLitHelper.handleException(span, error instanceof Error ? error : new Error(String(error)));
+    } else if (status === 'error') {
+      span.setAttribute(SemanticConvention.ERROR_TYPE, 'AgentError');
+      span.setStatus({ code: SpanStatusCode.ERROR, message: result?.result || 'agent error' });
+    } else {
+      span.setStatus({ code: SpanStatusCode.OK });
+    }
+
+    const inputMessagesJson = captureContent ? buildInputMessages(message) : null;
+    emitInvokeAgentEvent(
+      span, agentId, requestModel, responseModel, finishReason,
+      usage.inputTokens, usage.outputTokens, inputMessagesJson, outputMessagesJson,
+    );
+
+    recordInvokeAgentMetrics(
+      requestModel, usage.inputTokens, usage.outputTokens, cost, duration,
+      error ? (error.constructor?.name || '_OTHER') : (status === 'error' ? 'AgentError' : undefined),
+    );
+
+    span.end();
+  };
+
+  return new Proxy(run, {
+    get(target: any, prop: string | symbol, receiver: any) {
+      if (prop === 'stream') {
+        const originalStream = target.stream;
+        if (typeof originalStream !== 'function') return originalStream;
+
+        return function (...streamArgs: any[]) {
+          isStreamMode = true;
+          const generator = originalStream.apply(target, streamArgs);
+          return wrapAsyncGenerator(generator, toolTracker, streamState, finalizeSpan);
+        };
+      }
+
+      if (prop === 'wait') {
+        const originalWait = target.wait;
+        if (typeof originalWait !== 'function') return originalWait;
+
+        return function (...waitArgs: any[]) {
+          return originalWait.apply(target, waitArgs).then((result: any) => {
+            finalizeSpan(result);
+            return result;
+          }).catch((e: any) => {
+            finalizeSpan(undefined, e);
+            throw e;
+          });
+        };
+      }
+
+      if (prop === 'cancel') {
+        const originalCancel = target.cancel;
+        if (typeof originalCancel !== 'function') return originalCancel;
+
+        return function (...cancelArgs: any[]) {
+          return originalCancel.apply(target, cancelArgs).then((result: any) => {
+            finalizeSpan({ status: 'cancelled' });
+            return result;
+          });
+        };
+      }
+
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// wrapAsyncGenerator -- wraps run.stream() to intercept SDKMessage events
+// ---------------------------------------------------------------------------
+
+async function* wrapAsyncGenerator(
+  generator: AsyncGenerator<any>,
+  toolTracker: ToolSpanTracker,
+  streamState: StreamState,
+  finalizeSpan: (result?: any, error?: any) => void,
+): AsyncGenerator<any> {
+  try {
+    for await (const event of generator) {
+      try {
+        processStreamEvent(event, toolTracker, streamState);
+      } catch { /* swallow processing errors */ }
+      yield event;
+    }
+    finalizeSpan();
+  } catch (e: any) {
+    finalizeSpan(undefined, e);
+    throw e;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// patchAgentCreate -- wraps Agent.create() for create_agent spans
+// ---------------------------------------------------------------------------
+
+export function patchAgentCreate(tracer: Tracer): (originalCreate: any) => any {
+  return (originalCreate: any) => {
+    return async function wrappedCreate(this: any, options: any) {
+      const agentName = resolveAgentName(options);
+      const modelId = resolveModelId(options);
+      const displayName = agentName || 'cursor-agent';
+      const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT} ${displayName}`;
+
+      const span = tracer.startSpan(spanName, {
+        kind: SpanKind.CLIENT,
+        attributes: {
+          [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+          [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_CURSOR,
+          [SemanticConvention.SERVER_ADDRESS]: SERVER_ADDRESS,
+          [SemanticConvention.SERVER_PORT]: SERVER_PORT,
+        },
+      });
+
+      setCommonSpanAttributes(span);
+      if (agentName) span.setAttribute(SemanticConvention.GEN_AI_AGENT_NAME, agentName);
+      if (modelId) span.setAttribute(SemanticConvention.GEN_AI_REQUEST_MODEL, modelId);
+
+      applyCustomSpanAttributes(span);
+
+      try {
+        const agent = await originalCreate.call(this, options);
+
+        const agentId = agent.agentId;
+        if (agentId) {
+          span.setAttribute(SemanticConvention.GEN_AI_AGENT_ID, agentId);
+          agentRegistry.register(agentId, span.spanContext());
+        }
+
+        const resolvedModel = agent.model?.id || modelId;
+        if (resolvedModel) span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, resolvedModel);
+
+        span.setStatus({ code: SpanStatusCode.OK });
+        span.end();
+
+        if (typeof agent.send === 'function') {
+          const originalAgentSend = agent.send.bind(agent);
+          agent.send = wrapSend(tracer, originalAgentSend, agentId, agentName, resolvedModel);
+        }
+
+        return agent;
+      } catch (e: any) {
+        OpenLitHelper.handleException(span, e);
+        span.end();
+        throw e;
+      }
+    };
+  };
+}
+
+// ---------------------------------------------------------------------------
+// patchAgentResume -- wraps Agent.resume() to patch send() on resumed agents
+// ---------------------------------------------------------------------------
+
+export function patchAgentResume(tracer: Tracer): (originalResume: any) => any {
+  return (originalResume: any) => {
+    return async function wrappedResume(this: any, agentId: string, options?: any) {
+      const agentName = resolveAgentName(options);
+      const modelId = resolveModelId(options);
+
+      const agent = await originalResume.call(this, agentId, options);
+
+      const resolvedAgentId = agent.agentId || agentId;
+      const resolvedModel = agent.model?.id || modelId;
+
+      if (typeof agent.send === 'function') {
+        const originalAgentSend = agent.send.bind(agent);
+        agent.send = wrapSend(tracer, originalAgentSend, resolvedAgentId, agentName, resolvedModel);
+      }
+
+      return agent;
+    };
+  };
+}
+

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -26,6 +26,7 @@ import OpenAIAgentsInstrumentation from './openai-agents';
 import StrandsInstrumentation from './strands';
 import GoogleADKInstrumentation from './google-adk';
 import ClaudeAgentSDKInstrumentation from './claude-agent-sdk';
+import CursorSDKInstrumentation from './cursor-sdk';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -94,6 +95,7 @@ export default class Instrumentations {
     strands: new StrandsInstrumentation(),
     'google-adk': new GoogleADKInstrumentation(),
     'claude-agent-sdk': new ClaudeAgentSDKInstrumentation(),
+    'cursor-sdk': new CursorSDKInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -40,6 +40,8 @@ export default class SemanticConvention {
   static GEN_AI_TOKEN_TYPE_REASONING = 'reasoning';
   static GEN_AI_CLIENT_OPERATION_DURATION = 'gen_ai.client.operation.duration';
   static GEN_AI_CLIENT_OPERATION_TIME_TO_FIRST_CHUNK = 'gen_ai.client.operation.time_to_first_chunk';
+  /** OTel standard span attribute for TTFT */
+  static GEN_AI_RESPONSE_TIME_TO_FIRST_CHUNK = 'gen_ai.response.time_to_first_chunk';
   static GEN_AI_CLIENT_OPERATION_TIME_PER_OUTPUT_CHUNK = 'gen_ai.client.operation.time_per_output_chunk';
   static GEN_AI_CLIENT_TOKEN_USAGE = 'gen_ai.client.token.usage';
   static GEN_AI_SERVER_REQUEST_DURATION = 'gen_ai.server.request.duration';
@@ -77,6 +79,8 @@ export default class SemanticConvention {
 
   // GenAI Request (extended / OpenLIT)
   static GEN_AI_REQUEST_IS_STREAM = 'gen_ai.request.is_stream';
+  /** OTel standard: gen_ai.request.stream (replaces gen_ai.request.is_stream) */
+  static GEN_AI_REQUEST_STREAM = 'gen_ai.request.stream';
   static GEN_AI_REQUEST_USER = 'gen_ai.request.user';
   static GEN_AI_REQUEST_EMBEDDING_DIMENSION = 'gen_ai.request.embedding_dimension';
   static GEN_AI_REQUEST_TOOL_CHOICE = 'gen_ai.request.tool_choice';
@@ -226,6 +230,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_CLAUDE_AGENT_SDK = 'claude_agent_sdk';
   static GEN_AI_SYSTEM_GOOGLE_ADK = 'google_adk';
   static GEN_AI_SYSTEM_STRANDS = 'strands_agents';
+  static GEN_AI_SYSTEM_CURSOR = 'cursor';
 
   static GEN_AI_OPERATION_TYPE_CREATE_AGENT = 'create_agent';
 

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -2,7 +2,7 @@ import { Resource } from '@opentelemetry/resources';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 

--- a/sdk/typescript/test-cursor.ts
+++ b/sdk/typescript/test-cursor.ts
@@ -1,0 +1,45 @@
+import openlit from './src/index';
+import { Agent } from '@cursor/sdk';
+
+async function main() {
+  openlit.init({
+    captureMessageContent: true,
+  });
+
+  console.log('--- Agent.create() + agent.send() + stream ---');
+  const agent = await Agent.create({
+    apiKey: process.env.CURSOR_API_KEY!,
+    model: { id: 'composer-2' },
+    local: { cwd: process.cwd() },
+  });
+
+  const run = await agent.send('What is 2 + 2? Reply in one word.');
+
+  for await (const event of run.stream()) {
+    if (event.type === 'assistant') {
+      for (const block of event.message.content) {
+        if (block.type === 'text') process.stdout.write(block.text);
+      }
+    } else if (event.type === 'tool_call') {
+      console.log(`[tool] ${event.name} (${event.status})`);
+    }
+  }
+  console.log('\n');
+
+  console.log('--- Agent.prompt() one-shot ---');
+  const result = await Agent.prompt('What is 3 + 3? Reply in one word.', {
+    apiKey: process.env.CURSOR_API_KEY!,
+    model: { id: 'composer-2' },
+    local: { cwd: process.cwd() },
+  });
+  console.log('Result:', result.result);
+  console.log('Status:', result.status);
+
+  agent.close();
+
+  // Give the OTel exporter time to flush spans
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  console.log('\nDone. Check your OTel collector for spans.');
+}
+
+main().catch(console.error);


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add richer server and streaming metadata to LangChain spans and introduce Cursor SDK auto-instrumentation aligned with GenAI semantic conventions.

New Features:
- Resolve and attach server.address and server.port to LangChain spans using multiple possible API base fields so they are available on all spans, including errors.
- Expose additional GenAI semantic convention attributes (e.g., response.time_to_first_chunk, request.stream, new provider/system identifiers) for use across SDKs.
- Add Cursor SDK auto-instrumentation that traces agent creation, invocation, streaming, and tool execution with GenAI-compliant spans, events, and metrics.
- Register Cursor as a supported provider/instrumentation type with default server endpoint configuration.

Enhancements:
- Refactor LangChain instrumentation to centralize server resolution logic and simplify function wrapper registration call sites.
- Tidy controller-mode defaults logic formatting in the Python SDK for readability.

Tests:
- Add a Node test script exercising Cursor Agent.create, send/stream, and prompt flows to validate the new instrumentation paths.