### PR TITLE
fix: preserve newlines in trace attribute values

### DIFF
--- a/src/client/src/components/(playground)/request/components/attributes-tab.tsx
+++ b/src/client/src/components/(playground)/request/components/attributes-tab.tsx
@@ -108,7 +108,7 @@ export function AttrRow({ label, value, mono = false, className = "" }: { label:
 				{label}
 			</span>
 			<span
-				className={`text-xs text-stone-800 dark:text-stone-200 break-all leading-relaxed min-w-0 ${
+				className={`text-xs text-stone-800 dark:text-stone-200 whitespace-pre-wrap break-all leading-relaxed min-w-0 ${
 					mono ? "font-mono" : ""
 				}`}
 			>


### PR DESCRIPTION
## Problem

When viewing a trace request in the playground, prompt and response text loses all newlines — multiline content is displayed as one continuous run. Confirmed in the browser: adding `whitespace-pre-wrap` to the value span (or any ancestor) fixes the rendering.

The original fix from #558 lived in `request-details.tsx` directly, but the long-text fields (`prompt`, `response`, `revisedPrompt`, `systemInstructions`, `contentReasoning`, `toolArgs`, `dbQueryText`, …) are now rendered through the shared `AttrRow` component, whose value `<span>` only had `break-all leading-relaxed` and no whitespace-preserving rule.

Fixes #1159 (regression of #540).

## Solution

Add `whitespace-pre-wrap` to the value `<span>` in `AttrRow`. This restores newline rendering for every consumer of `AttrRow`:

- `request-details.tsx` — `CODE_ITEM_DISPLAY_KEYS` (prompt / response / etc.)
- `attributes-tab.tsx` — grouped span attributes and custom rows
- `span-attributes-tab.tsx` — same grouped/custom rows

Short scalar values (model name, finish reason, token counts, etc.) are unaffected because they contain no newlines or runs of whitespace.

## Testing

1. Open the playground at `/requests`.
2. Open a span whose prompt or response contains newlines (any multi-line chat completion).
3. The `Prompt` and `Response` sections now render with the original line breaks.
4. Span / custom attribute rows with single-line values look identical to before.

## Summary by Sourcery

Bug Fixes:
- Restore newline and whitespace rendering for multiline trace attributes (e.g., prompts and responses) in the playground views that use the shared AttrRow component.