### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/src/client/src/lib/platform/openground/ai-sdk-adapter.ts
+++ b/src/client/src/lib/platform/openground/ai-sdk-adapter.ts
@@ -74,6 +74,14 @@ export class AISdkAdapter {
 			baseURL: 'https://openai-proxy.replicate.com/v1',
 			apiKey
 		}),
+		astraflow: (apiKey: string) => createOpenAI({
+			baseURL: 'https://api-us-ca.umodelverse.ai/v1',
+			apiKey
+		}),
+		astraflow_cn: (apiKey: string) => createOpenAI({
+			baseURL: 'https://api.modelverse.cn/v1',
+			apiKey
+		}),
 	};
 
 	/**
@@ -85,7 +93,8 @@ export class AISdkAdapter {
 		const validProviders = [
 			'openai', 'anthropic', 'google', 'mistral', 'cohere',
 			'groq', 'perplexity', 'azure', 'together', 'fireworks',
-			'deepseek', 'xai', 'huggingface', 'replicate'
+			'deepseek', 'xai', 'huggingface', 'replicate',
+			'astraflow', 'astraflow_cn'
 		];
 		
 		// Check against allowlist first
@@ -192,7 +201,8 @@ export class AISdkAdapter {
 		return [
 			'openai', 'anthropic', 'google', 'mistral', 'cohere',
 			'groq', 'perplexity', 'azure', 'together', 'fireworks',
-			'deepseek', 'xai', 'huggingface', 'replicate'
+			'deepseek', 'xai', 'huggingface', 'replicate',
+			'astraflow', 'astraflow_cn'
 		];
 	}
 

--- a/src/client/src/lib/platform/providers/default-models.ts
+++ b/src/client/src/lib/platform/providers/default-models.ts
@@ -135,6 +135,22 @@ export const DEFAULT_PROVIDERS: DefaultProviderEntry[] = [
 			topP: { min: 0, max: 1, step: 0.01, default: 0.9, description: "Nucleus sampling threshold" },
 		},
 	},
+	{
+		providerId: "astraflow", displayName: "Astraflow", description: "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (global endpoint)", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
+	{
+		providerId: "astraflow_cn", displayName: "Astraflow (China)", description: "Astraflow by UCloud — OpenAI-compatible platform supporting 200+ models (China endpoint)", requiresVault: true,
+		configSchema: {
+			temperature: { min: 0, max: 2, step: 0.1, default: 1, description: "Sampling temperature" },
+			maxTokens: { min: 1, max: 16000, step: 1, default: 1000, description: "Maximum tokens to generate" },
+			topP: { min: 0, max: 1, step: 0.1, default: 1, description: "Nucleus sampling threshold" },
+		},
+	},
 ];
 
 export const DEFAULT_MODELS_BY_PROVIDER: Record<string, DefaultModelEntry[]> = {
@@ -556,6 +572,74 @@ export const DEFAULT_MODELS_BY_PROVIDER: Record<string, DefaultModelEntry[]> = {
 			inputPricePerMToken: 0.3,
 			outputPricePerMToken: 1.0,
 			capabilities: ["streaming"],
+		},
+	],
+	astraflow: [
+		{
+			id: "deepseek-v3",
+			displayName: "DeepSeek V3",
+			contextWindow: 128000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["streaming"],
+		},
+		{
+			id: "gpt-4o",
+			displayName: "GPT-4o",
+			contextWindow: 128000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
+		},
+		{
+			id: "claude-3-5-sonnet-20241022",
+			displayName: "Claude 3.5 Sonnet",
+			contextWindow: 200000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
+		},
+		{
+			id: "gemini-2.0-flash",
+			displayName: "Gemini 2.0 Flash",
+			contextWindow: 1000000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
+		},
+	],
+	astraflow_cn: [
+		{
+			id: "deepseek-v3",
+			displayName: "DeepSeek V3",
+			contextWindow: 128000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["streaming"],
+		},
+		{
+			id: "gpt-4o",
+			displayName: "GPT-4o",
+			contextWindow: 128000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
+		},
+		{
+			id: "claude-3-5-sonnet-20241022",
+			displayName: "Claude 3.5 Sonnet",
+			contextWindow: 200000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
+		},
+		{
+			id: "gemini-2.0-flash",
+			displayName: "Gemini 2.0 Flash",
+			contextWindow: 1000000,
+			inputPricePerMToken: 0.0,
+			outputPricePerMToken: 0.0,
+			capabilities: ["function-calling", "vision", "streaming"],
 		},
 	],
 };


### PR DESCRIPTION
> [!IMPORTANT]
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider in OpenLIT's OpenGround playground and provider registry.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it uses the OpenAI-compatible API, the integration is a minimal `baseURL` + `apiKey` configuration — no new SDK dependency required.

**Files changed:**

**`src/client/src/lib/platform/openground/ai-sdk-adapter.ts`**
- Added `astraflow` factory: `createOpenAI({ baseURL: 'https://api-us-ca.umodelverse.ai/v1', apiKey })` (global endpoint)
- Added `astraflow_cn` factory: `createOpenAI({ baseURL: 'https://api.modelverse.cn/v1', apiKey })` (China endpoint)
- Added both provider IDs to the security **allowlist** in `getProviderFactory()`
- Added both provider IDs to `getSupportedProviders()` return value

**`src/client/src/lib/platform/providers/default-models.ts`**
- Added `astraflow` and `astraflow_cn` entries to `DEFAULT_PROVIDERS` with description and full `configSchema`
- Added `astraflow` and `astraflow_cn` seed models to `DEFAULT_MODELS_BY_PROVIDER` (DeepSeek V3, GPT-4o, Claude 3.5 Sonnet, Gemini 2.0 Flash)

**Provider details:**

| | Global | China |
|---|---|---|
| **Provider ID** | `astraflow` | `astraflow_cn` |
| **Base URL** | `https://api-us-ca.umodelverse.ai/v1` | `https://api.modelverse.cn/v1` |
| **Env var** | `ASTRAFLOW_API_KEY` | `ASTRAFLOW_CN_API_KEY` |
| **Website** | https://astraflow.ucloud-global.com | https://astraflow.ucloud.cn |

**Architecture notes:**
- Provider metadata is DB-driven (seeded from `DEFAULT_PROVIDERS` on first run); no schema migrations needed
- Users configure their API key via the existing Vault flow — same UX as every other provider
- Zero new dependencies: reuses the existing `@ai-sdk/openai` `createOpenAI` adapter, identical to how `groq`, `together`, `fireworks`, `deepseek`, `xai`, `huggingface`, and `replicate` are integrated

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [ ] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add Astraflow as a new OpenAI-compatible LLM provider, including global and China endpoints, and expose it through the OpenGround AI SDK adapter and default provider registry.

New Features:
- Introduce Astraflow global and China providers with vault-based configuration and parameter schema in the default providers list.
- Seed default Astraflow models (DeepSeek V3, GPT-4o, Claude 3.5 Sonnet, Gemini 2.0 Flash) with capabilities metadata for both global and China endpoints.
- Register Astraflow providers in the AI SDK adapter with appropriate base URLs and include them in the supported provider allowlist.