### PR TITLE
fix: preserve newlines in trace detail text

### DIFF
--- a/src/client/src/__tests__/components/request/attributes-tab.test.tsx
+++ b/src/client/src/__tests__/components/request/attributes-tab.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { AttrRow } from '@/components/(playground)/request/components/attributes-tab';
+
+describe('AttrRow', () => {
+  it('preserves newlines in trace text values', () => {
+    render(<AttrRow label="Prompt" value={'first line\nsecond line'} mono />);
+
+    const value = screen.getByText(/first line/);
+
+    expect(value.textContent).toBe('first line\nsecond line');
+    expect(value).toHaveClass('whitespace-pre-wrap');
+    expect(value).toHaveClass('break-words');
+    expect(value).toHaveClass('font-mono');
+  });
+});

--- a/src/client/src/__tests__/components/request/attributes-tab.test.tsx
+++ b/src/client/src/__tests__/components/request/attributes-tab.test.tsx
@@ -9,7 +9,17 @@ describe('AttrRow', () => {
 
     expect(value.textContent).toBe('first line\nsecond line');
     expect(value).toHaveClass('whitespace-pre-wrap');
-    expect(value).toHaveClass('break-words');
+    expect(value).toHaveClass('break-all');
     expect(value).toHaveClass('font-mono');
+  });
+
+  it('keeps word wrapping readable for non-mono text', () => {
+    render(<AttrRow label="Summary" value="first line\nsecond line" />);
+
+    const value = screen.getByText(/first line/);
+
+    expect(value).toHaveClass('whitespace-pre-wrap');
+    expect(value).toHaveClass('break-words');
+    expect(value).not.toHaveClass('font-mono');
   });
 });

--- a/src/client/src/__tests__/helpers/client/trace.test.ts
+++ b/src/client/src/__tests__/helpers/client/trace.test.ts
@@ -587,4 +587,26 @@ describe('extractTextFromMessages (via normalizeTrace)', () => {
     const result = normalizeTrace(trace);
     expect(result.response).toBe('My response');
   });
+
+  it('preserves multiline prompt text from message content', () => {
+    const messages = JSON.stringify([
+      {
+        role: 'user',
+        parts: [
+          {
+            type: 'text',
+            content: 'First line\nSecond line\n\nFinal paragraph',
+          },
+        ],
+      },
+    ]);
+    const trace = {
+      SpanId: 's', Timestamp: '2024-01-15T10:30:00.000Z',
+      SpanAttributes: { 'gen_ai.input.messages': messages },
+    } as any;
+
+    const result = normalizeTrace(trace);
+
+    expect(result.prompt).toBe('First line\nSecond line\n\nFinal paragraph');
+  });
 });

--- a/src/client/src/components/(playground)/request/components/attributes-tab.tsx
+++ b/src/client/src/components/(playground)/request/components/attributes-tab.tsx
@@ -108,7 +108,7 @@ export function AttrRow({ label, value, mono = false, className = "" }: { label:
 				{label}
 			</span>
 			<span
-				className={`text-xs text-stone-800 dark:text-stone-200 break-all leading-relaxed min-w-0 ${
+				className={`text-xs text-stone-800 dark:text-stone-200 whitespace-pre-wrap break-words leading-relaxed min-w-0 ${
 					mono ? "font-mono" : ""
 				}`}
 			>

--- a/src/client/src/components/(playground)/request/components/attributes-tab.tsx
+++ b/src/client/src/components/(playground)/request/components/attributes-tab.tsx
@@ -102,13 +102,14 @@ function safeStringify(val: unknown): string {
 
 export function AttrRow({ label, value, mono = false, className = "" }: { label: string; value: unknown; mono?: boolean; className?: string }) {
 	const displayValue = safeStringify(value);
+	const valueWrapping = mono ? "break-all" : "break-words";
 	return (
 		<div className={`flex items-start gap-3 px-4 py-2 border-b border-stone-100 dark:border-stone-800/60 last:border-0 hover:bg-stone-50 dark:hover:bg-stone-800/30 transition-colors ${className}`}>
 			<span className="w-44 shrink-0 text-xs text-stone-500 dark:text-stone-400 pt-px leading-relaxed break-all">
 				{label}
 			</span>
 			<span
-				className={`text-xs text-stone-800 dark:text-stone-200 whitespace-pre-wrap break-words leading-relaxed min-w-0 ${
+				className={`text-xs text-stone-800 dark:text-stone-200 whitespace-pre-wrap ${valueWrapping} leading-relaxed min-w-0 ${
 					mono ? "font-mono" : ""
 				}`}
 			>


### PR DESCRIPTION
## Summary
- Preserve multiline formatting in request detail trace text rows by rendering values with `whitespace-pre-wrap` and word wrapping.
- Add a component regression for `AttrRow` so prompt/response text keeps raw `\n` characters in the DOM.
- Add helper coverage for multiline `gen_ai.input.messages` extraction, which feeds the prompt/response fields shown in trace details.

Fixes #1159.

## Validation
- `npm test -- --runTestsByPath src/__tests__/helpers/client/trace.test.ts src/__tests__/components/request/attributes-tab.test.tsx --runInBand`
- `npm run lint -- --file 'src/components/(playground)/request/components/attributes-tab.tsx' --file src/__tests__/helpers/client/trace.test.ts --file src/__tests__/components/request/attributes-tab.test.tsx`
- `git diff --check`

## Summary by Sourcery

Preserve multiline trace detail text formatting in the playground request attributes view and extend test coverage for multiline prompt extraction and rendering.

Bug Fixes:
- Ensure prompt text extracted from gen_ai.input.messages preserves newline characters in the normalized trace data.
- Render attribute row values with preserved newlines and proper word wrapping in the request attributes tab.

Tests:
- Add regression tests for AttrRow rendering to ensure raw newline characters are preserved in the DOM for prompt/response text.
- Add helper test coverage for multiline gen_ai.input.messages extraction feeding prompt/response fields in trace details.