### PR TITLE
fix: Detect arch for ebpf tracer on aarch64/arm64

### DIFF
--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.go
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target bpfel gpuevent ./bpf/gpuevent.c -- -I./bpf -D__TARGET_ARCH_x86
+//go:generate sh tracer.sh
 
 // Tracer manages eBPF programs for CUDA runtime interception.
 type Tracer struct {

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ARCH=$(uname -m | sed 's/x86_64/x86/;s/aarch64/arm64/')
+go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target bpfel gpuevent ./bpf/gpuevent.c -- -I./bpf -D__TARGET_ARCH_${ARCH}


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**[1209](https://github.com/openlit/openlit/issues/1209)**:

### Change description:

Auto-detects and sets correct architecture for aarch64/arm64 machines.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Build:
- Replace the hardcoded bpf2go go:generate directive with a shell script that infers the architecture (x86 or arm64) from uname and passes the appropriate __TARGET_ARCH define to bpf2go.