### PR TITLE
feat: add Nix flake and Devbox support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ logs/
 **certs/index.txt
 **.csr
 sdk/typescript-test/
+
+# Nix build result symlinks
+/result
+/result-*

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ flowchart TB;
    docker compose up -d
    ```
 
-   Or run the OpenLit helper directly:
+   Or run the OpenLIT helper directly:
 
    ```shell
    nix run github:openlit/openlit -- help
@@ -114,7 +114,7 @@ flowchart TB;
    For a reproducible development environment:
 
    ```shell
-   # Install devbox if not already installed
+   # Install Devbox if not already installed
    curl -fsSL https://get.jetify.dev/devbox | bash
 
    # Clone and enter the environment

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ flowchart TB;
    nix develop
 
    # Start services with Docker
-   docker compose up -d
+   docker-compose up -d
    ```
 
    Or run the OpenLIT helper directly:
@@ -123,7 +123,7 @@ flowchart TB;
    devbox shell
 
    # Start services
-   docker compose up -d
+   docker-compose up -d
    ```
 
 ### Step 2: Install OpenLIT SDK

--- a/README.md
+++ b/README.md
@@ -89,6 +89,43 @@ flowchart TB;
 
 > For instructions on installing in Kubernetes using Helm, refer to the [Kubernetes Helm installation guide](https://docs.openlit.io/latest/openlit/installation#kubernetes).
 
+3. Self-host using Nix (Flakes)
+
+   For users who already have Nix with flakes enabled:
+
+   ```shell
+   # Clone and enter the development shell
+   git clone git@github.com:openlit/openlit.git
+   cd openlit
+   nix develop
+
+   # Start services with Docker
+   docker compose up -d
+   ```
+
+   Or run the OpenLit helper directly:
+
+   ```shell
+   nix run github:openlit/openlit -- help
+   ```
+
+4. Self-host using Devbox
+
+   For a reproducible development environment:
+
+   ```shell
+   # Install devbox if not already installed
+   curl -fsSL https://get.jetify.dev/devbox | bash
+
+   # Clone and enter the environment
+   git clone git@github.com:openlit/openlit.git
+   cd openlit
+   devbox shell
+
+   # Start services
+   docker compose up -d
+   ```
+
 ### Step 2: Install OpenLIT SDK
 
 Open your command line or terminal and run:

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.12.0/.schema/devbox.schema.json",
+  "packages": [
+    "go",
+    "nodejs_20",
+    "docker",
+    "docker-compose",
+    "golangci-lint",
+    "git"
+  ],
+  "shell": {
+    "init_hook": [
+      "echo 'Welcome to the OpenLit devbox environment!'",
+      "echo 'Available commands:'",
+      "echo '  devbox run build-client    - Build Next.js client'",
+      "echo '  devbox run build-server    - Build Go opamp-server'",
+      "echo '  devbox run start           - Start Docker services'",
+      "echo '  devbox run stop            - Stop Docker services'",
+      "echo '  devbox run test            - Run Go tests'"
+    ],
+    "scripts": {
+      "build-client": [
+        "cd src/client && npm install && npx prisma generate && npm run build"
+      ],
+      "build-server": [
+        "cd src/opamp-server && go build -o opamp-server ."
+      ],
+      "build-controller": [
+        "cd openlit-controller && go build -o openlit-controller ."
+      ],
+      "build-gpu-collector": [
+        "cd opentelemetry-gpu-collector && go build -o opentelemetry-gpu-collector ."
+      ],
+      "start": [
+        "docker-compose up -d"
+      ],
+      "stop": [
+        "docker-compose stop"
+      ],
+      "test": [
+        "cd src/opamp-server && go test ./...",
+        "cd openlit-controller && go test ./...",
+        "cd opentelemetry-gpu-collector && go test ./...",
+        "cd sdk/go && go test ./..."
+      ],
+      "dev-client": [
+        "cd src/client && npm run dev"
+      ]
+    }
+  }
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779786838,
+        "narHash": "sha256-0geHoGiR5f8qiXg+gO4rSF6Up6Var+kKqiOv9AO/uUc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f44f7788c891fbe5542177df78374f8cdab10e8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -76,17 +76,28 @@
             echo "For full documentation, visit: https://github.com/openlit/openlit"
           }
 
+          require_compose_file() {
+            if [ ! -f docker-compose.yml ] && [ ! -f docker-compose.yaml ]; then
+              echo "Error: docker-compose.yml not found in the current directory." >&2
+              echo "       Run this command from the repository root where docker-compose.yml is located." >&2
+              exit 1
+            fi
+          }
+
           case "''${1:-help}" in
             start)
+              require_compose_file
               echo "Starting OpenLIT services..."
-              "''${pkgs.docker-compose}/bin/docker-compose" up -d
+              "${pkgs.docker-compose}/bin/docker-compose" up -d
               ;;
             stop)
+              require_compose_file
               echo "Stopping OpenLIT services..."
-              "''${pkgs.docker-compose}/bin/docker-compose" stop
+              "${pkgs.docker-compose}/bin/docker-compose" stop
               ;;
             status)
-              "''${pkgs.docker-compose}/bin/docker-compose" ps
+              require_compose_file
+              "${pkgs.docker-compose}/bin/docker-compose" ps
               ;;
             build)
               echo "Building OpenLIT components..."

--- a/flake.nix
+++ b/flake.nix
@@ -119,7 +119,7 @@
               fi
 
               cd src/client
-              npm run dev
+              exec npm run dev
               ;;
             version)
               echo "OpenLit (nix flake development build)"

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           pname = "openlit-opamp-server";
           version = "0.0.1";
           src = ./src/opamp-server;
-          vendorHash = pkgs.lib.fakeHash;
+          vendorHash = "sha256-7rQ0+jV8v/W16Lx9KRVLoEhOfrKtKRxdUXuYCpuoMRo=";
           doCheck = false;
           meta = {
             description = "OpenLit OpAMP Server";
@@ -30,7 +30,7 @@
           pname = "openlit-controller";
           version = "0.0.1";
           src = ./openlit-controller;
-          vendorHash = pkgs.lib.fakeHash;
+          vendorHash = "sha256-YohapHEkKf5q5+bl9AvqAQyNwGWE8CEe3losEZF5wXA=";
           doCheck = false;
           meta = {
             description = "OpenLit Controller";
@@ -44,7 +44,7 @@
           pname = "openlit-gpu-collector";
           version = "0.0.1";
           src = ./opentelemetry-gpu-collector;
-          vendorHash = pkgs.lib.fakeHash;
+          vendorHash = "sha256-I1iyIw9Qoa1qS55IqvN/qssDYRBre2tIHo9DkfRX+AI=";
           doCheck = false;
           meta = {
             description = "OpenLit OpenTelemetry GPU Collector";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,207 @@
+{
+  description = "OpenLit - Open-source LLM Observability Platform";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # Go packages
+        opamp-server = pkgs.buildGoModule {
+          pname = "openlit-opamp-server";
+          version = "0.0.1";
+          src = ./src/opamp-server;
+          vendorHash = pkgs.lib.fakeHash;
+          doCheck = false;
+          meta = {
+            description = "OpenLit OpAMP Server";
+            homepage = "https://github.com/openlit/openlit";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "opamp-server";
+          };
+        };
+
+        openlit-controller = pkgs.buildGoModule {
+          pname = "openlit-controller";
+          version = "0.0.1";
+          src = ./openlit-controller;
+          vendorHash = pkgs.lib.fakeHash;
+          doCheck = false;
+          meta = {
+            description = "OpenLit Controller";
+            homepage = "https://github.com/openlit/openlit";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "openlit-controller";
+          };
+        };
+
+        gpu-collector = pkgs.buildGoModule {
+          pname = "openlit-gpu-collector";
+          version = "0.0.1";
+          src = ./opentelemetry-gpu-collector;
+          vendorHash = pkgs.lib.fakeHash;
+          doCheck = false;
+          meta = {
+            description = "OpenLit OpenTelemetry GPU Collector";
+            homepage = "https://github.com/openlit/openlit";
+            license = pkgs.lib.licenses.asl20;
+            mainProgram = "opentelemetry-gpu-collector";
+          };
+        };
+
+        # Helper script for Docker-based workflow
+        openlit-cli = pkgs.writeShellScriptBin "openlit" ''
+          #!${pkgs.runtimeShell}
+          set -euo pipefail
+
+          usage() {
+            echo "OpenLit - Open-source LLM Observability Platform"
+            echo ""
+            echo "Usage: openlit <command>"
+            echo ""
+            echo "Commands:"
+            echo "  start       Start OpenLit services with docker-compose"
+            echo "  stop        Stop OpenLit services"
+            echo "  status      Show service status"
+            echo "  build       Build all components"
+            echo "  dev-client  Start Next.js client dev server"
+            echo "  version     Show version information"
+            echo "  help        Show this help message"
+            echo ""
+            echo "For full documentation, visit: https://github.com/openlit/openlit"
+          }
+
+          case "''${1:-help}" in
+            start)
+              echo "Starting OpenLit services..."
+              docker-compose up -d
+              ;;
+            stop)
+              echo "Stopping OpenLit services..."
+              docker-compose stop
+              ;;
+            status)
+              docker-compose ps
+              ;;
+            build)
+              echo "Building OpenLit components..."
+              echo "Note: Use 'nix build .#<package>' for individual components"
+              echo "Available packages: opamp-server, openlit-controller, gpu-collector"
+              ;;
+            dev-client)
+              echo "Starting client dev server..."
+              cd src/client && npm run dev
+              ;;
+            version)
+              echo "OpenLit (nix flake development build)"
+              ;;
+            help|--help|-h)
+              usage
+              ;;
+            *)
+              echo "Unknown command: $1"
+              usage
+              exit 1
+              ;;
+          esac
+        '';
+      in
+      {
+        packages = {
+          default = openlit-cli;
+          opamp-server = opamp-server;
+          controller = openlit-controller;
+          gpu-collector = gpu-collector;
+          openlit = openlit-cli;
+        };
+
+        apps = {
+          default = {
+            type = "app";
+            program = "${openlit-cli}/bin/openlit";
+          };
+          opamp-server = {
+            type = "app";
+            program = "${opamp-server}/bin/opamp-server";
+          };
+          controller = {
+            type = "app";
+            program = "${openlit-controller}/bin/openlit-controller";
+          };
+          gpu-collector = {
+            type = "app";
+            program = "${gpu-collector}/bin/opentelemetry-gpu-collector";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          name = "openlit-devshell";
+
+          buildInputs = with pkgs; [
+            # Go toolchain
+            go
+            golangci-lint
+            gopls
+
+            # Node.js toolchain
+            nodejs_20
+            npm
+
+            # Docker / container tools
+            docker
+            docker-compose
+
+            # General development
+            git
+            jq
+            curl
+          ];
+
+          shellHook = ''
+            echo "OpenLit Development Shell"
+            echo "========================="
+            echo ""
+            echo "Available commands:"
+            echo "  go version              - Check Go version"
+            echo "  node --version          - Check Node.js version"
+            echo "  docker --version        - Check Docker version"
+            echo ""
+            echo "Project structure:"
+            echo "  src/opamp-server/       - Go OpAMP server"
+            echo "  src/client/             - Next.js client"
+            echo "  openlit-controller/     - Go controller"
+            echo "  opentelemetry-gpu-collector/ - Go GPU collector"
+            echo "  sdk/go/                 - Go SDK"
+            echo ""
+            echo "Quick start:"
+            echo "  docker-compose up -d    - Start all services"
+            echo "  cd src/client && npm run dev - Start client dev server"
+            echo ""
+            echo "Nix flake outputs:"
+            echo "  nix run .               - Run OpenLit helper"
+            echo "  nix build .#opamp-server - Build OpAMP server"
+            echo "  nix develop             - Enter this dev shell"
+            echo ""
+          '';
+        };
+
+        overlays.default = final: prev: {
+          openlit = openlit-cli;
+          openlit-opamp-server = opamp-server;
+          openlit-controller = openlit-controller;
+          openlit-gpu-collector = gpu-collector;
+        };
+
+        checks = {
+          opamp-server = opamp-server;
+          controller = openlit-controller;
+          gpu-collector = gpu-collector;
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -78,24 +78,36 @@
 
           case "''${1:-help}" in
             start)
-              echo "Starting OpenLit services..."
-              docker-compose up -d
+              echo "Starting OpenLIT services..."
+              "''${pkgs.docker-compose}/bin/docker-compose" up -d
               ;;
             stop)
-              echo "Stopping OpenLit services..."
-              docker-compose stop
+              echo "Stopping OpenLIT services..."
+              "''${pkgs.docker-compose}/bin/docker-compose" stop
               ;;
             status)
-              docker-compose ps
+              "''${pkgs.docker-compose}/bin/docker-compose" ps
               ;;
             build)
-              echo "Building OpenLit components..."
+              echo "Building OpenLIT components..."
               echo "Note: Use 'nix build .#<package>' for individual components"
               echo "Available packages: opamp-server, openlit-controller, gpu-collector"
               ;;
             dev-client)
               echo "Starting client dev server..."
-              cd src/client && npm run dev
+
+              if [ ! -d src/client ]; then
+                echo "Error: src/client directory not found. Client dev server cannot be started." >&2
+                exit 1
+              fi
+
+              if ! command -v npm >/dev/null 2>&1; then
+                echo "Error: npm is not installed or not found in PATH. Please install npm to run the client dev server." >&2
+                exit 1
+              fi
+
+              cd src/client
+              npm run dev
               ;;
             version)
               echo "OpenLit (nix flake development build)"

--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,8 @@
               fi
 
               if ! command -v npm >/dev/null 2>&1; then
-                echo "Error: npm is not installed or not found in PATH. Please install npm to run the client dev server." >&2
+                echo "Error: npm is not available. The 'dev-client' command is intended for the development shell." >&2
+                echo "       Run 'nix develop' or 'devbox shell' first, or install npm manually." >&2
                 exit 1
               fi
 


### PR DESCRIPTION
## What

Adds a multi-OS Nix package manager flake.nix so the project can be installed and run directly from GitHub

**Issue number**: Closes #1211 


```bash
nix run github:openlit/openlit -- help
nix profile install github:openlit/openlit
```
Named outputs for individual Go components:
```bash
nix run github:openlit/openlit#opamp-server
nix run github:openlit/openlit#controller
nix run github:openlit/openlit#gpu-collector
```
Adds devbox.json for reproducible development environments:
```bash
devbox shell
devbox run build-server
devbox run build-client
```


## Why
The project currently requires users to clone the repository and build from source. For users who already have Nix installed, a flake provides:

- Pure / Hermetic builds — every input (compiler, libraries, system dependencies) is pinned in flake.lock. If it builds today, it builds in ten years.
- Reproducible — the exact same derivation always produces the exact same output bit-for-bit. No "works on my machine."
- Idempotent installs — running nix profile install twice is a no-op. The system reaches the declared state and stays there.
- Rollback-able — nix profile rollback restores the previous profile generation instantly. Broken update? One command back.
- Declarative — the entire build is a single expression (flake.nix). No imperative apt install, brew install, make dance.
- One-command install / run — nix run github:owner/repo with no clone or manual build steps.
- Cross-platform — same invocation on macOS (Apple Silicon & Intel) and Linux. The flake handles platform-specific dependencies.
- Atomic upgrades / downgrades — profiles are switched atomically. No half-upgraded state.
- Clean uninstall — nix profile remove leaves no residue. No orphaned global packages.


### Change description:
- flake.nix: Nix flake with packages.default, apps.default, devShells.default, overlays.default, and named outputs for Go components
- flake.lock: Generated lock file pinning all flake inputs
- devbox.json: Devbox configuration for reproducible development environments
- .gitignore: Added Nix build result symlinks (/result, /result-*)
- README.md: Added "Self-host using Nix (Flakes)" and "Self-host using Devbox" install instructions

## Testing
Verified locally:
```bash
nix run . -- help
nix build .#opamp-server
nix build .#controller
nix build .#gpu-collector
nix develop
```
All three Go components build successfully on aarch64-darwin.

## Notes
- The flake uses nixpkgs-unstable and flake-utils for broad platform support.
- No breaking changes to existing build paths.
- The `vendorHash` values for Go modules were computed via nix build and are pinned in the second commit.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add Nix flake and Devbox-based workflows for reproducible, cross-platform installation and development of OpenLIT.

New Features:
- Introduce a Nix flake providing packages, apps, dev shells, overlays, and checks for core OpenLIT Go components and a helper CLI.
- Add a Devbox configuration to provision a reproducible development environment with required toolchains and Docker tooling.

Build:
- Add Nix flake and lockfile to define hermetic builds and named outputs for Go services and a helper CLI.

Documentation:
- Document Nix flake and Devbox workflows for self-hosting and local development in the README.