### PR TITLE
fix: Support ARM64 builds with native Linux runners

### DIFF
--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -168,10 +168,80 @@ jobs:
             dist/*
           generate_release_notes: true
 
-  # ── 4. Docker multi-arch image → GHCR ─────────────────────────────────────
+  # ── 4. Docker image build per-arch on native runners → GHCR (by digest) ────
+  # Built natively (no QEMU) so each arch's /sys/kernel/btf/vmlinux matches the
+  # target arch — required because the eBPF objects are generated from the host
+  # kernel BTF and are architecture-specific.
+  docker-build:
+    name: Docker build (${{ matrix.platform }})
+    needs: test
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Prepare platform pair
+        run: echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
+        env:
+          platform: ${{ matrix.platform }}
+
+      - uses: actions/checkout@v4
+
+      - name: Docker labels
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log into GHCR
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./opentelemetry-gpu-collector/
+          file: ./opentelemetry-gpu-collector/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ── 5. Merge per-arch digests into a multi-arch manifest, tag, sign ────────
   docker:
     name: Docker
-    needs: test
+    needs: docker-build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -179,13 +249,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      - name: Download digests
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -211,31 +283,31 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
             type=raw,value=latest
         env:
-          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
 
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: ./opentelemetry-gpu-collector/
-          file: ./opentelemetry-gpu-collector/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          annotations: |
-            ${{ steps.meta.outputs.annotations }},
-            io.artifacthub.package.logo-url=https://github.com/openlit/.github/blob/main/profile/assets/favicon.png?raw=true,
-            io.artifacthub.package.readme-url=https://github.com/openlit/openlit/blob/main/opentelemetry-gpu-collector/README.md,
-            io.artifacthub.package.license=Apache-2.0,
-            org.opencontainers.image.vendor=OpenLIT,
-            io.artifacthub.package.maintainers=[{'name':'OpenLIT','email':'developers@openlit.io'}],
-            io.artifacthub.package.keywords='Monitoring, Observability, GPUs, NVIDIA, OpenTelemetry, Metrics, LLMs, AI'
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          # Index-level annotations: those from metadata-action plus ArtifactHub metadata.
+          annotations=()
+          while IFS= read -r a; do
+            [ -n "$a" ] && annotations+=(--annotation "$a")
+          done <<< '${{ steps.meta.outputs.annotations }}'
+          annotations+=(
+            --annotation "index:io.artifacthub.package.logo-url=https://github.com/openlit/.github/blob/main/profile/assets/favicon.png?raw=true"
+            --annotation "index:io.artifacthub.package.readme-url=https://github.com/openlit/openlit/blob/main/opentelemetry-gpu-collector/README.md"
+            --annotation "index:io.artifacthub.package.license=Apache-2.0"
+            --annotation "index:org.opencontainers.image.vendor=OpenLIT"
+            --annotation "index:io.artifacthub.package.maintainers=[{'name':'OpenLIT','email':'developers@openlit.io'}]"
+            --annotation "index:io.artifacthub.package.keywords=Monitoring, Observability, GPUs, NVIDIA, OpenTelemetry, Metrics, LLMs, AI"
+          )
+          docker buildx imagetools create "${annotations[@]}" \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
 
       - name: Sign the published Docker image
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
-        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+        run: |
+          digest="$(docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}" --format '{{json .Manifest}}' | jq -r .digest)"
+          echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${digest}

--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: openlit/otel-gpu-collector
+  IMAGE_NAME: ${{ github.repository_owner }}/otel-gpu-collector
   BINARY_NAME: opentelemetry-gpu-collector
 
 permissions:

--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -50,23 +50,40 @@ jobs:
   build-binaries:
     name: Build binaries (${{ matrix.goos }}/${{ matrix.goarch }})
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
+        # linux targets build on a native runner: go-nvml is cgo-only, and the
+        # eBPF objects are generated from the host kernel BTF + uname arch, so
+        # they must be produced on the matching architecture (no QEMU / cross).
+        # darwin/windows use the nvidia_stub.go, have no eBPF, and cross-compile
+        # cleanly on amd64 with cgo disabled.
         include:
           - goos: linux
+            runner: ubuntu-24.04
             goarch: amd64
+            cgo: "1"
           - goos: linux
+            runner: ubuntu-24.04-arm
             goarch: arm64
+            cgo: "1"
           - goos: darwin
+            runner: ubuntu-latest
             goarch: amd64
+            cgo: "0"
           - goos: darwin
+            runner: ubuntu-latest
             goarch: arm64
+            cgo: "0"
           - goos: windows
+            runner: ubuntu-latest
             goarch: amd64
+            cgo: "0"
             ext: .exe
           - goos: windows
+            runner: ubuntu-latest
             goarch: arm64
+            cgo: "0"
             ext: .exe
 
     steps:
@@ -82,9 +99,11 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y clang llvm libbpf-dev
+          # Static bpftool matching the runner architecture.
+          BPFTOOL_ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
           BPFTOOL_VERSION=$(curl -fsSL https://api.github.com/repos/libbpf/bpftool/releases/latest \
             | jq -r .tag_name)
-          curl -fsSL "https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_VERSION}/bpftool-${BPFTOOL_VERSION}-amd64.tar.gz" \
+          curl -fsSL "https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_VERSION}/bpftool-${BPFTOOL_VERSION}-${BPFTOOL_ARCH}.tar.gz" \
             | sudo tar -xz -C /usr/local/bin/
           sudo chmod +x /usr/local/bin/bpftool
 
@@ -103,7 +122,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
-          CGO_ENABLED: "0"
+          CGO_ENABLED: ${{ matrix.cgo }}
         run: |
           OUTPUT="${{ env.BINARY_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-armv{0}', matrix.goarm) || '' }}${{ matrix.ext }}"
           go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.version }}" \

--- a/.github/workflows/otel-gpu-collector-tests.yml
+++ b/.github/workflows/otel-gpu-collector-tests.yml
@@ -5,10 +5,12 @@ on:
     branches: ["main"]
     paths:
       - 'opentelemetry-gpu-collector/**'
+      - '.github/workflows/otel-gpu-collector-tests.yml'
   pull_request:
     branches: ["main"]
     paths:
       - 'opentelemetry-gpu-collector/**'
+      - '.github/workflows/otel-gpu-collector-tests.yml'
 
 permissions:
   contents: read

--- a/opentelemetry-gpu-collector/.gitignore
+++ b/opentelemetry-gpu-collector/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-openlit-collector
+opentelemetry-gpu-collector
 
 # Generated eBPF Go bindings (output of go generate / bpf2go)
 internal/ebpf/gpuevent_bpfel*.go

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.go
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target bpfel gpuevent ./bpf/gpuevent.c -- -I./bpf -D__TARGET_ARCH_x86
+//go:generate sh tracer.sh
 
 // Tracer manages eBPF programs for CUDA runtime interception.
 type Tracer struct {

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+ARCH=$(uname -m | sed 's/x86_64/x86/;s/aarch64/arm64/')
+go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target bpfel gpuevent ./bpf/gpuevent.c -- -I./bpf -D__TARGET_ARCH_${ARCH}


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**[1214](https://github.com/openlit/openlit/issues/1214)**:

### Change description:

Use native Linux runners for build and docker build actions.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Support native, per-architecture builds and images for the otel GPU collector, including proper ARM64 support and arch-aware eBPF generation.

Bug Fixes:
- Ensure bpftool and eBPF objects are built against the correct host architecture to avoid mismatches on ARM64 and other platforms.

Enhancements:
- Switch otel GPU collector Docker and binary builds to run on native Linux runners per architecture instead of QEMU-based multi-arch builds.
- Generate Docker images per-architecture by digest and later assemble them into a multi-arch manifest with appropriate metadata and signing.
- Derive the container image name from the GitHub repository owner to support publishing from forks.
- Make CGO usage configurable per target platform so Linux builds can use cgo while other targets cross-compile cleanly.
- Introduce an architecture-aware tracer.sh helper to drive bpf2go, replacing the hard-coded x86 go:generate directive.
- Trigger otel GPU collector tests when the workflow file itself changes.

Build:
- Rework the otel GPU collector release workflow to build binaries and Docker images on native runners for amd64 and arm64, and to create a signed multi-arch manifest from per-arch digests.

CI:
- Update the otel GPU collector test workflow paths so CI runs when workflow definitions change.

Deployment:
- Adjust container publishing flow to push per-arch images to GHCR and then create and sign a multi-arch manifest with consistent annotations and tags.