### PR TITLE
fix: restore Agents page link in UI sidebar

### DIFF
--- a/src/client/src/constants/sidebar.tsx
+++ b/src/client/src/constants/sidebar.tsx
@@ -11,6 +11,7 @@ import {
 	LayoutDashboard,
 	MonitorCog,
 	MonitorPlay,
+	Radar,
 	SettingsIcon,
 	SlidersHorizontal,
 } from "lucide-react";
@@ -60,12 +61,12 @@ export const SIDEBAR_ITEMS: SidebarItemProps[] = [
 			link: "/telemetry",
 			type: "action",
 		},
-		// {
-		// 	icon: <Radar className={ICON_CLASSES} />,
-		// 	text: "Agents",
-		// 	link: "/agents",
-		// 	type: "action",
-		// },
+		{
+			icon: <Radar className={ICON_CLASSES} />,
+			text: "Agents",
+			link: "/agents",
+			type: "action",
+		},
 		{
 			icon: <OpenTelemetrySvg className={ICON_CLASSES} />,
 			text: "Fleet Hub",


### PR DESCRIPTION
Fixes #1195

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [ ] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [ ] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Bug Fixes:
- Re-enable the Agents sidebar navigation item so the Agents page is accessible from the UI again.