### PR TITLE
ci(otel-gpu-collector): enable CGO for linux release binaries

### DIFF
--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -88,6 +88,16 @@ jobs:
             | sudo tar -xz -C /usr/local/bin/
           sudo chmod +x /usr/local/bin/bpftool
 
+      # NVIDIA NVML (github.com/NVIDIA/go-nvml) uses cgo+dlopen to load
+      # libnvidia-ml.so at runtime, so the linux release binaries must be built
+      # with CGO_ENABLED=1. Cross-compiling linux/arm64 from an amd64 runner
+      # additionally needs an aarch64 C toolchain.
+      - name: Install aarch64 cross-compiler (linux/arm64 only)
+        if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Generate eBPF objects (linux targets only)
         if: matrix.goos == 'linux'
         working-directory: opentelemetry-gpu-collector
@@ -103,7 +113,10 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarm }}
-          CGO_ENABLED: "0"
+          # Linux ships NVML via go-nvml (cgo+dlopen); darwin/windows have no
+          # NVML at all and fall through to the stub, so CGO is unnecessary.
+          CGO_ENABLED: ${{ matrix.goos == 'linux' && '1' || '0' }}
+          CC: ${{ (matrix.goos == 'linux' && matrix.goarch == 'arm64') && 'aarch64-linux-gnu-gcc' || '' }}
         run: |
           OUTPUT="${{ env.BINARY_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goarm && format('-armv{0}', matrix.goarm) || '' }}${{ matrix.ext }}"
           go build -trimpath -ldflags "-s -w -X main.Version=${{ steps.version.outputs.version }}" \

--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -96,7 +96,7 @@ jobs:
         if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install --no-install-recommends -y gcc-aarch64-linux-gnu
 
       - name: Generate eBPF objects (linux targets only)
         if: matrix.goos == 'linux'


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Enable CGO for Linux otel-gpu-collector release builds and configure cross-compilation for linux/arm64 in the release workflow.

CI:
- Install an aarch64 cross-compiler in the otel-gpu-collector release workflow when building linux/arm64 binaries.
- Set CGO_ENABLED for otel-gpu-collector builds only on Linux targets and configure CC for linux/arm64 in the release workflow.