### PR TITLE
ci(otel-gpu-collector): install libc6-dev-arm64-cross for cross-cgo b…

### DIFF
--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -91,12 +91,18 @@ jobs:
       # NVIDIA NVML (github.com/NVIDIA/go-nvml) uses cgo+dlopen to load
       # libnvidia-ml.so at runtime, so the linux release binaries must be built
       # with CGO_ENABLED=1. Cross-compiling linux/arm64 from an amd64 runner
-      # additionally needs an aarch64 C toolchain.
+      # additionally needs an aarch64 C toolchain plus the target libc headers.
+      #
+      # libc6-dev-arm64-cross provides /usr/aarch64-linux-gnu/include (including
+      # bits/libc-header-start.h). It is only a Recommends of gcc-aarch64-linux-gnu,
+      # so we list it explicitly to stay safe under --no-install-recommends.
       - name: Install aarch64 cross-compiler (linux/arm64 only)
         if: matrix.goos == 'linux' && matrix.goarch == 'arm64'
         run: |
           sudo apt-get update -q
-          sudo apt-get install --no-install-recommends -y gcc-aarch64-linux-gnu
+          sudo apt-get install --no-install-recommends -y \
+            gcc-aarch64-linux-gnu \
+            libc6-dev-arm64-cross
 
       - name: Generate eBPF objects (linux targets only)
         if: matrix.goos == 'linux'


### PR DESCRIPTION
…uild

> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

CI:
- Install gcc-aarch64-linux-gnu and libc6-dev-arm64-cross in the otel-gpu-collector release workflow for linux/arm64 cross-compilation.