### PR TITLE
feat: Make otel-gpu-collector contributions easier

### DIFF
--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -201,11 +201,20 @@ jobs:
         id: version
         run: echo "version=${GITHUB_REF#refs/tags/otel-gpu-collector-}" >> $GITHUB_OUTPUT
 
+      # GHCR requires lowercase image names, but github.repository_owner keeps
+      # the owner's original case (e.g. OpenLIT). Expressions have no tolower(),
+      # so lowercase it here with tr (POSIX, no bash-version dependency).
+      - name: Lowercase image name
+        id: image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: echo "name=$(echo "$IMAGE_NAME" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
       - name: Extract Docker metadata
         id: meta
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
           tags: |
             type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}

--- a/.github/workflows/otel-gpu-collector-release.yml
+++ b/.github/workflows/otel-gpu-collector-release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: openlit/otel-gpu-collector
+  IMAGE_NAME: ${{ github.repository_owner }}/otel-gpu-collector
   BINARY_NAME: opentelemetry-gpu-collector
 
 permissions:

--- a/.github/workflows/otel-gpu-collector-tests.yml
+++ b/.github/workflows/otel-gpu-collector-tests.yml
@@ -5,10 +5,12 @@ on:
     branches: ["main"]
     paths:
       - 'opentelemetry-gpu-collector/**'
+      - '.github/workflows/otel-gpu-collector-tests.yml'
   pull_request:
     branches: ["main"]
     paths:
       - 'opentelemetry-gpu-collector/**'
+      - '.github/workflows/otel-gpu-collector-tests.yml'
 
 permissions:
   contents: read

--- a/opentelemetry-gpu-collector/.gitignore
+++ b/opentelemetry-gpu-collector/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-openlit-collector
+opentelemetry-gpu-collector
 
 # Generated eBPF Go bindings (output of go generate / bpf2go).
 # bpf2go output stems are always "<linux>_<clang>" (clang = bpfel|bpfeb).


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**[1227](https://github.com/openlit/openlit/issues/1227)**:

### Change description:

1. Use the repository owner's container registry (so otel-gpu-collector-release works in forks)
2. Run otel-gpu-collector-tests when the action itself changes
3. Ignore the correct binary build

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Update otel-gpu-collector workflows and ignore rules to improve contributor experience and support forked repositories.

Enhancements:
- Use the repository owner’s container registry namespace for otel-gpu-collector image publishing to support forks.
- Trigger otel-gpu-collector test workflow when its own GitHub Actions workflow file changes.
- Adjust the otel-gpu-collector .gitignore to ignore the correct built binary artifact.