### PR TITLE
fix: arm64 native build

### DIFF
--- a/.github/workflows/otel-gpu-collector-tests.yml
+++ b/.github/workflows/otel-gpu-collector-tests.yml
@@ -100,3 +100,44 @@ jobs:
           GOOS: windows
           GOARCH: amd64
         run: go build ./...
+
+  # Native arm64 build. The above `Test` only cross-compiles arm64,
+  # so it never exercises arm64 eBPF generation: tracer.sh on an
+  # arm64 host dumps arm64 kernel BTF into vmlinux.h and compiles
+  # the BPF object against it. This job validates that path end to
+  # end on a native arm64 runner.
+  test-arm64:
+    name: Test (arm64 native)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: opentelemetry-gpu-collector/go.mod
+          cache-dependency-path: opentelemetry-gpu-collector/go.sum
+
+      - name: Install eBPF build dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y clang llvm libbpf-dev
+          # Download static bpftool binary from libbpf/bpftool releases — avoids
+          # linux-tools-$(uname -r) which fails on azure/custom kernels.
+          BPFTOOL_VERSION=$(curl -fsSL https://api.github.com/repos/libbpf/bpftool/releases/latest \
+            | jq -r .tag_name)
+          curl -fsSL "https://github.com/libbpf/bpftool/releases/download/${BPFTOOL_VERSION}/bpftool-${BPFTOOL_VERSION}-arm64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin/
+          sudo chmod +x /usr/local/bin/bpftool
+          bpftool version
+
+      - name: Generate eBPF objects
+        working-directory: opentelemetry-gpu-collector
+        run: make setup-bpf generate
+
+      - name: Run tests
+        working-directory: opentelemetry-gpu-collector
+        run: go test ./...
+
+      - name: Build linux/arm64 (native eBPF path)
+        working-directory: opentelemetry-gpu-collector
+        run: go build ./...

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.go
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.go
@@ -19,7 +19,8 @@ import (
 	"github.com/cilium/ebpf/ringbuf"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -target amd64,arm64 gpuevent ./bpf/gpuevent.c -- -I./bpf
+// tracer.sh picks the bpf2go target arches from the host arch.
+//go:generate ./tracer.sh
 
 // Tracer manages eBPF programs for CUDA runtime interception.
 type Tracer struct {

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
@@ -13,11 +13,12 @@
 
 set -e
 
-case "$(uname -m)" in
-	x86_64)  targets=amd64,arm64 ;;
-	aarch64) targets=arm64 ;;
-	*)       targets="$(go env GOARCH)" ;;
-esac
+goarch="$(go env GOARCH)"
+if [ "$goarch" = amd64 ]; then
+	targets=amd64,arm64
+else
+	targets="$goarch"
+fi
 
 exec go run github.com/cilium/ebpf/cmd/bpf2go -cc clang \
 	-target "$targets" gpuevent ./bpf/gpuevent.c -- -I./bpf

--- a/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
+++ b/opentelemetry-gpu-collector/internal/ebpf/tracer.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Host-arch-aware bpf2go wrapper, invoked by the //go:generate
+# directive in tracer.go.
+#
+# setup-bpf dumps the *host* kernel BTF into a single vmlinux.h,
+# which is inherently single-arch. libbpf's arm64 register path
+# reads a separate `struct user_pt_regs` (which the setup-bpf
+# shim in Makefile supplies), so an x86 host can cross-generate
+# arm64. The x86 path reads members straight off `struct pt_regs`
+# so an arm64 host cannot generate the x86 object. Derive the
+# target list from the host arch accordingly.
+
+set -e
+
+case "$(uname -m)" in
+	x86_64)  targets=amd64,arm64 ;;
+	aarch64) targets=arm64 ;;
+	*)       targets="$(go env GOARCH)" ;;
+esac
+
+exec go run github.com/cilium/ebpf/cmd/bpf2go -cc clang \
+	-target "$targets" gpuevent ./bpf/gpuevent.c -- -I./bpf


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**[1251](https://github.com/openlit/openlit/issues/1251)**:

### Change description:

Selects eBPF architecture(s) based on the host architecture. On amd64 hosts where cross-compiling arm64 is made to work do both. On arm64 where cross-compilation to amd64 is not made to work only build native.

Adds a native arm64 runner to validate the arm64 native build.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Adjust eBPF code generation and CI to support native arm64 builds based on host architecture.

Enhancements:
- Replace static bpf2go target list with a host-architecture-aware wrapper script for generating eBPF objects.

CI:
- Add a native arm64 GitHub Actions job to build, test, and validate eBPF generation for the GPU collector on arm64 runners.