### PR TITLE
Fix: decrypt vault value in OpenGround config path

### DIFF
--- a/src/client/src/lib/platform/providers/config.ts
+++ b/src/client/src/lib/platform/providers/config.ts
@@ -1,6 +1,7 @@
 import { dataCollector } from "@/lib/platform/common";
 import getMessage from "@/constants/messages";
 import Sanitizer from "@/utils/sanitizer";
+import { decryptValue } from "@/utils/crypto";
 import { OPENLIT_VAULT_TABLE_NAME } from "@/lib/platform/vault/table-details";
 import { OPENLIT_PROVIDERS_TABLE_NAME } from "./table-details";
 
@@ -122,7 +123,7 @@ export async function getOpenGroundConfigWithSecret(
 		return {
 			data: {
 				...config,
-				apiKey: vaultRecord.value,
+				apiKey: decryptValue(vaultRecord.value),
 				vaultKey: vaultRecord.key,
 			},
 		};


### PR DESCRIPTION
Fixes #1266

## Summary

`getOpenGroundConfigWithSecret` was returning the raw encrypted vault value (`enc:v1:...`) as the API key, causing all OpenGround provider calls to fail with auth errors.

### Change

```diff
+import { decryptValue } from "@/utils/crypto";
 ...
-        apiKey: vaultRecord.value,
+        apiKey: decryptValue(vaultRecord.value),
```

`decryptValue` short-circuits on non-`enc:v1:` prefixed values so this is safe for both encrypted and legacy plaintext rows.

## Summary by Sourcery

Bug Fixes:
- Fix OpenGround provider authentication failures by decrypting encrypted vault API key values before use.