### PR TITLE
feat(typescript): add DigitalOcean Gradient auto-instrumentation

### DIFF
--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -24,6 +24,7 @@
         "js-tiktoken": "^1.0.12"
       },
       "devDependencies": {
+        "@digitalocean/gradient": "^0.1.0-alpha.2",
         "@eslint/js": "^9.2.0",
         "@types/jest": "^29.0.0",
         "ai21": "^1.3.0",
@@ -590,6 +591,13 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@digitalocean/gradient": {
+      "version": "0.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@digitalocean/gradient/-/gradient-0.1.0-alpha.2.tgz",
+      "integrity": "sha512-UuQBxuvSiHUGm1x69kwTrB2gEJg5mpXPZIZ0erCzkuPo/tVkK+AcOzV39NbhZAuqU+b2mE7rxSCtSMTyS6tNgw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -44,6 +44,7 @@
   "author": "Aman Agarwal <aman.agarwal@openlit.io>",
   "license": "ISC",
   "devDependencies": {
+    "@digitalocean/gradient": "^0.1.0-alpha.2",
     "@eslint/js": "^9.2.0",
     "@types/jest": "^29.0.0",
     "ai21": "^1.3.0",

--- a/sdk/typescript/src/helpers.ts
+++ b/sdk/typescript/src/helpers.ts
@@ -205,6 +205,7 @@ const PROVIDER_DEFAULT_ENDPOINTS: Record<string, [string, number]> = {
   mistral_ai: ['api.mistral.ai', 443],
   groq: ['api.groq.com', 443],
   ai21: ['api.ai21.com', 443],
+  digitalocean: ['inference.do-ai.run', 443],
   together: ['api.together.xyz', 443],
   fireworks: ['api.fireworks.ai', 443],
   perplexity: ['api.perplexity.ai', 443],

--- a/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
@@ -409,40 +409,6 @@ describe('Gradient Cross-Language Trace Comparison', () => {
     });
   });
 
-  describe('Knowledge Base Retrieval Trace Consistency', () => {
-    it('sets retrieval attributes like Python process_retrieve_response', () => {
-      const mockArgs = [
-        {
-          knowledge_base_uuid: 'kb-123',
-          query: 'What is RAG?',
-          top_k: 5,
-        },
-      ];
-      const response = {
-        retrieved_data: [{ text: 'doc1' }],
-      };
-
-      GradientWrapper._retrieveDocumentsCommonSetter({
-        args: mockArgs,
-        genAIEndpoint: 'digitalocean.retrieve.documents',
-        response,
-        span: mockSpan,
-        serverAddress: 'kbaas.do-ai.run',
-        serverPort: 443,
-      });
-
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        SemanticConvention.GEN_AI_DATA_SOURCE_ID,
-        'kb-123'
-      );
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_TOP_K, 5);
-      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
-        SemanticConvention.GEN_AI_RETRIEVAL_QUERY_TEXT,
-        'What is RAG?'
-      );
-    });
-  });
-
   describe('Streaming Trace Consistency', () => {
     async function* mockStream() {
       yield {

--- a/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
@@ -16,7 +16,18 @@ import BaseWrapper from '../base-wrapper';
 import SemanticConvention from '../../semantic-convention';
 
 jest.mock('../../config');
-jest.mock('../../helpers');
+// The wrapper reads its server host/port from PROVIDER_DEFAULT_ENDPOINTS via
+// getServerAddressForProvider at module load, so that named export must return a
+// real tuple (auto-mock returns undefined and the destructure would throw). The
+// default export's methods are still stubbed per-test in beforeEach.
+jest.mock('../../helpers', () => ({
+  __esModule: true,
+  default: {},
+  isFrameworkLlmActive: jest.fn(() => false),
+  getFrameworkParentContext: jest.fn(() => undefined),
+  getCurrentAgentVersion: jest.fn(() => undefined),
+  getServerAddressForProvider: jest.fn(() => ['inference.do-ai.run', 443]),
+}));
 jest.mock('../base-wrapper');
 
 describe('Gradient Cross-Language Trace Comparison', () => {

--- a/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/gradient-trace-comparison.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Cross-Language Trace Comparison Tests for the DigitalOcean Gradient Integration
+ *
+ * These verify that the TypeScript Gradient instrumentation emits the same span
+ * attributes / events as the Python SDK reference
+ * (sdk/python/src/openlit/instrumentation/gradient). Gradient is OpenAI-shaped:
+ * responses carry a `model` field, requests support seed / frequency_penalty /
+ * presence_penalty, and streaming usage arrives on the final chunk as `usage`.
+ * The provider name is `digitalocean` and chat is served from inference.do-ai.run.
+ */
+
+import GradientWrapper from '../gradient/wrapper';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import BaseWrapper from '../base-wrapper';
+import SemanticConvention from '../../semantic-convention';
+
+jest.mock('../../config');
+jest.mock('../../helpers');
+jest.mock('../base-wrapper');
+
+describe('Gradient Cross-Language Trace Comparison', () => {
+  let mockSpan: any;
+
+  beforeEach(() => {
+    mockSpan = {
+      setAttribute: jest.fn(),
+      addEvent: jest.fn(),
+      end: jest.fn(),
+      setStatus: jest.fn(),
+    };
+
+    (OpenlitConfig as any).environment = 'openlit-testing';
+    (OpenlitConfig as any).applicationName = 'openlit-test';
+    (OpenlitConfig as any).captureMessageContent = true;
+    (OpenlitConfig as any).pricingInfo = {};
+    (OpenlitConfig as any).disableEvents = false;
+
+    (OpenLitHelper as any).getChatModelCost = jest.fn().mockReturnValue(0.001);
+    (OpenLitHelper as any).openaiTokens = jest.fn().mockReturnValue(5);
+    (OpenLitHelper as any).handleException = jest.fn();
+    (OpenLitHelper as any).createStreamProxy = jest
+      .fn()
+      .mockImplementation((stream, _generator) => stream);
+    (OpenLitHelper as any).buildInputMessages = jest
+      .fn()
+      .mockReturnValue('[{"role":"user","parts":[{"type":"text","content":"Test"}]}]');
+    (OpenLitHelper as any).buildOutputMessages = jest
+      .fn()
+      .mockReturnValue(
+        '[{"role":"assistant","parts":[{"type":"text","content":"Response"}],"finish_reason":"stop"}]'
+      );
+    (OpenLitHelper as any).buildSystemInstructionsFromMessages = jest
+      .fn()
+      .mockImplementation((messages: any[]) => {
+        const sys = (messages || []).find((m: any) => m?.role === 'system');
+        return sys ? JSON.stringify([{ type: 'text', content: String(sys.content) }]) : undefined;
+      });
+    (OpenLitHelper as any).buildToolDefinitions = jest.fn().mockReturnValue(undefined);
+    (OpenLitHelper as any).emitInferenceEvent = jest.fn();
+    (OpenLitHelper as any).computeAgentVersionHash = jest
+      .fn()
+      .mockReturnValue('ts-test-version-hash');
+
+    (BaseWrapper as any).recordMetrics = jest.fn();
+    (BaseWrapper as any).setBaseSpanAttributes = jest
+      .fn()
+      .mockImplementation((span, attrs) => {
+        span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, attrs.aiSystem);
+        span.setAttribute(SemanticConvention.GEN_AI_REQUEST_MODEL, attrs.model);
+        if (attrs.cost !== undefined) {
+          span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
+        }
+        if (attrs.serverAddress) {
+          span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+        }
+        if (attrs.serverPort !== undefined) {
+          span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+        }
+        span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.9.0');
+      });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // Gradient CompletionCreateResponse is OpenAI-shaped: it DOES carry a `model`
+  // field and a standard usage block.
+  const mockResponse = () => ({
+    id: 'gradient-test-id',
+    model: 'llama3.3-70b-instruct',
+    choices: [
+      { index: 0, finish_reason: 'stop', message: { role: 'assistant', content: 'DO says hi' } },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+  });
+
+  describe('Chat Completion Trace Consistency', () => {
+    it('should set the same core attributes as the Python SDK', async () => {
+      const mockArgs = [
+        {
+          messages: [{ role: 'user', content: 'What is LLM Observability?' }],
+          model: 'llama3.3-70b-instruct',
+          max_tokens: 100,
+          temperature: 0.7,
+          stream: false,
+        },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL,
+        'digitalocean'
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        SemanticConvention.GEN_AI_REQUEST_MODEL,
+        'llama3.3-70b-instruct'
+      );
+      // Gradient responses DO carry a `model`, so response model comes from the response.
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        SemanticConvention.GEN_AI_RESPONSE_MODEL,
+        'llama3.3-70b-instruct'
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        SemanticConvention.GEN_AI_RESPONSE_ID,
+        'gradient-test-id'
+      );
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 10);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 20);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, 0.7);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, 100);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, ['stop']);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_OUTPUT_TYPE, 'text');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_ADDRESS, 'inference.do-ai.run');
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.SERVER_PORT, 443);
+    });
+
+    it('falls back to the "unknown" request model when none is supplied (matches Python)', async () => {
+      const mockArgs = [{ messages: [{ role: 'user', content: 'Test' }], stream: false }];
+      const responseNoModel = { ...mockResponse(), model: '' };
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: responseNoModel,
+        span: mockSpan,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_MODEL, 'unknown');
+      // With no response model, it falls back to the request model.
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_RESPONSE_MODEL, 'unknown');
+    });
+
+    it('stamps openlit.agent.version_hash on the chat span', async () => {
+      const mockArgs = [
+        { messages: [{ role: 'user', content: 'Hash me' }], model: 'llama3.3-70b-instruct', stream: false },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      expect((OpenLitHelper as any).computeAgentVersionHash).toHaveBeenCalled();
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+        SemanticConvention.OPENLIT_AGENT_VERSION_HASH,
+        'ts-test-version-hash'
+      );
+    });
+
+    it('should NOT set total_tokens or client.token.usage on the span', async () => {
+      const mockArgs = [
+        { messages: [{ role: 'user', content: 'Test' }], model: 'llama3.3-70b-instruct', stream: false },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      const attributeKeys = (mockSpan.setAttribute as jest.Mock).mock.calls.map(([key]: [string]) => key);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_USAGE_TOTAL_TOKENS);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE);
+    });
+
+    it('omits seed / penalties / optionals when not provided (no sentinel values)', async () => {
+      const mockArgs = [
+        { messages: [{ role: 'user', content: 'Test' }], model: 'llama3.3-70b-instruct', stream: false },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      const attributeKeys = (mockSpan.setAttribute as jest.Mock).mock.calls.map(([key]: [string]) => key);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_SEED);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES);
+      expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_REQUEST_CHOICE_COUNT);
+    });
+
+    it('sets seed / penalties when explicitly provided (Gradient is OpenAI-compatible)', async () => {
+      const mockArgs = [
+        {
+          messages: [{ role: 'user', content: 'Test' }],
+          model: 'llama3.3-70b-instruct',
+          seed: 42,
+          frequency_penalty: 0.5,
+          presence_penalty: 0.3,
+          stop: ['END'],
+          n: 2,
+          stream: false,
+        },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_SEED, 42);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, 0.5);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, 0.3);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES, ['END']);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_CHOICE_COUNT, 2);
+    });
+
+    it('does not throw and still records tokens when the response omits usage', async () => {
+      const mockArgs = [
+        { messages: [{ role: 'user', content: 'Test' }], model: 'llama3.3-70b-instruct', stream: false },
+      ];
+      const responseNoUsage: any = mockResponse();
+      delete responseNoUsage.usage;
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: responseNoUsage,
+        span: mockSpan,
+      });
+
+      // Defensive default keeps the span valid (0 tokens) rather than crashing.
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 0);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 0);
+    });
+
+    it('should emit an inference event via the LoggerProvider', async () => {
+      const mockArgs = [
+        { messages: [{ role: 'user', content: 'Test' }], model: 'llama3.3-70b-instruct', stream: false },
+      ];
+
+      await GradientWrapper._chatCompletion({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockResponse(),
+        span: mockSpan,
+      });
+
+      expect((OpenLitHelper as any).emitInferenceEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe('Streaming Trace Consistency', () => {
+    // Build an async iterable of OpenAI-style chunks, with usage on the final chunk.
+    async function* mockStream() {
+      yield {
+        id: 'gradient-stream-id',
+        model: 'llama3.3-70b-instruct',
+        choices: [{ index: 0, delta: { role: 'assistant', content: 'Hello' }, finish_reason: null }],
+      };
+      yield {
+        id: 'gradient-stream-id',
+        model: 'llama3.3-70b-instruct',
+        choices: [{ index: 0, delta: { content: ' world' }, finish_reason: 'stop' }],
+      };
+      // Final usage chunk (stream_options: { include_usage: true }).
+      yield {
+        id: 'gradient-stream-id',
+        model: 'llama3.3-70b-instruct',
+        choices: [],
+        usage: { prompt_tokens: 7, completion_tokens: 11, total_tokens: 18 },
+      };
+    }
+
+    it('aggregates streamed content and reads usage from the final chunk', async () => {
+      const mockArgs = [
+        {
+          messages: [{ role: 'user', content: 'Hi' }],
+          model: 'llama3.3-70b-instruct',
+          stream: true,
+        },
+      ];
+
+      const generator = GradientWrapper._chatCompletionGenerator({
+        args: mockArgs,
+        genAIEndpoint: 'digitalocean.chat.completions',
+        response: mockStream(),
+        span: mockSpan,
+      });
+
+      // Drive the generator to completion (consumer would do this via the proxy).
+      let step = await generator.next();
+      while (!step.done) {
+        step = await generator.next();
+      }
+      const final: any = step.value;
+
+      expect(final.choices[0].message.content).toBe('Hello world');
+      expect(final.choices[0].finish_reason).toBe('stop');
+      // Usage came from the final chunk, not local token counting.
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 7);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 11);
+      expect(mockSpan.setAttribute).toHaveBeenCalledWith(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, true);
+    });
+  });
+});

--- a/sdk/typescript/src/instrumentation/gradient/index.ts
+++ b/sdk/typescript/src/instrumentation/gradient/index.ts
@@ -74,20 +74,6 @@ export default class OpenlitGradientInstrumentation extends InstrumentationBase 
         'generate',
         GradientWrapper._patchImageGenerate
       );
-
-      // Responses API — not yet in @digitalocean/gradient; enable when DO ships it.
-      this.safeWrap(
-        Gradient.Responses?.prototype,
-        'create',
-        GradientWrapper._patchResponsesCreate
-      );
-
-      // Knowledge-base document retrieval — not yet in @digitalocean/gradient.
-      this.safeWrap(
-        Gradient.Retrieve?.prototype,
-        'documents',
-        GradientWrapper._patchRetrieveDocuments
-      );
     } catch (e) {
       console.error('Error in _patch method:', e);
     }
@@ -101,8 +87,6 @@ export default class OpenlitGradientInstrumentation extends InstrumentationBase 
       [Gradient.Chat?.Completions?.prototype, 'create'],
       [Gradient.Agents?.Chat?.Completions?.prototype, 'create'],
       [Gradient.Images?.prototype, 'generate'],
-      [Gradient.Responses?.prototype, 'create'],
-      [Gradient.Retrieve?.prototype, 'documents'],
     ];
 
     for (const [target, method] of targets) {

--- a/sdk/typescript/src/instrumentation/gradient/index.ts
+++ b/sdk/typescript/src/instrumentation/gradient/index.ts
@@ -1,0 +1,74 @@
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import GradientWrapper from './wrapper';
+
+export interface GradientInstrumentationConfig extends InstrumentationConfig {}
+
+export default class OpenlitGradientInstrumentation extends InstrumentationBase {
+  constructor(config: GradientInstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-gradient`, '1.0.0', config);
+  }
+
+  protected init(): void | InstrumentationModuleDefinition | InstrumentationModuleDefinition[] {
+    const module = new InstrumentationNodeModuleDefinition(
+      '@digitalocean/gradient',
+      // @digitalocean/gradient currently ships only as a prerelease (0.1.0-alpha.*).
+      // A plain '>=0.1.0' range does NOT match prereleases under semver, so the hook
+      // would load the module but silently skip patching. Anchor at the prerelease
+      // tag (mirrors azure-ai-inference's '>=1.0.0-beta.1'); this still matches the
+      // eventual stable 0.1.0 and later. See semver.satisfies prerelease semantics.
+      ['>=0.1.0-alpha.0'],
+      (moduleExports) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports) => {
+        if (moduleExports !== undefined) {
+          this._unpatch(moduleExports);
+        }
+      }
+    );
+    return [module];
+  }
+
+  public manualPatch(gradient: any): void {
+    this._patch(gradient);
+  }
+
+  protected _patch(moduleExports: any) {
+    try {
+      // The DigitalOcean Gradient SDK is Stainless-generated (OpenAI-shaped): the
+      // top-level module only exports the `Gradient` client class, with resource
+      // classes attached as static nested properties. Chat completions live at
+      // `Gradient.Chat.Completions.prototype.create` (mirrors groq-sdk's
+      // `Groq.Chat.Completions`, not ai21's flat top-level `Completions`).
+      if (!moduleExports?.Gradient?.Chat?.Completions?.prototype?.create) {
+        return;
+      }
+
+      if (isWrapped(moduleExports.Gradient.Chat.Completions.prototype.create)) {
+        this._unwrap(moduleExports.Gradient.Chat.Completions.prototype, 'create');
+      }
+
+      this._wrap(
+        moduleExports.Gradient.Chat.Completions.prototype,
+        'create',
+        GradientWrapper._patchChatCompletionCreate(this.tracer)
+      );
+    } catch (e) {
+      console.error('Error in _patch method:', e);
+    }
+  }
+
+  protected _unpatch(moduleExports: any) {
+    if (moduleExports?.Gradient?.Chat?.Completions?.prototype?.create) {
+      this._unwrap(moduleExports.Gradient.Chat.Completions.prototype, 'create');
+    }
+  }
+}

--- a/sdk/typescript/src/instrumentation/gradient/utils.ts
+++ b/sdk/typescript/src/instrumentation/gradient/utils.ts
@@ -1,18 +1,16 @@
 import { Attributes } from '@opentelemetry/api';
 import SemanticConvention from '../../semantic-convention';
 
-export type GradientEndpointKind = 'inference' | 'agent' | 'kb';
+export type GradientEndpointKind = 'inference' | 'agent';
 
 const DEFAULT_HOSTS: Record<GradientEndpointKind, [string, number]> = {
   inference: ['inference.do-ai.run', 443],
   agent: ['agents.do-ai.run', 443],
-  kb: ['kbaas.do-ai.run', 443],
 };
 
 const ENDPOINT_ATTRS: Record<GradientEndpointKind, string> = {
   inference: 'inferenceEndpoint',
   agent: 'agentEndpoint',
-  kb: 'kbassEndpoint',
 };
 
 /**
@@ -88,7 +86,7 @@ export function normalizeStopSequences(stop: unknown): string[] | undefined {
   return s ? [s] : undefined;
 }
 
-/** Request attributes shared by chat / agent-chat / responses surfaces. */
+/** Request attributes shared by chat and agent-chat surfaces. */
 export function applyGradientChatRequestAttributes(span: any, body: Record<string, any>): void {
   if (body.temperature != null) {
     span.setAttribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, body.temperature);

--- a/sdk/typescript/src/instrumentation/gradient/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/gradient/wrapper.ts
@@ -47,15 +47,6 @@ class GradientWrapper extends BaseWrapper {
     });
   }
 
-  static _patchResponsesCreate(tracer: Tracer): any {
-    return GradientWrapper._buildChatPatch(tracer, {
-      operationName: SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
-      endpointKind: 'inference',
-      genAIEndpoint: 'digitalocean.responses',
-      apiType: 'responses',
-    });
-  }
-
   static _buildChatPatch(tracer: Tracer, options: ChatPatchOptions): any {
     const { operationName, endpointKind, genAIEndpoint, apiType, isAgent = false } = options;
     return (originalMethod: (...args: any[]) => any) => {
@@ -172,66 +163,6 @@ class GradientWrapper extends BaseWrapper {
             BaseWrapper.recordMetrics(span, {
               genAIEndpoint,
               model: requestModel,
-              aiSystem: AI_SYSTEM,
-              serverAddress,
-              serverPort,
-              errorType: e?.constructor?.name || '_OTHER',
-            });
-            throw e;
-          } finally {
-            span.end();
-            if (metricParams) {
-              BaseWrapper.recordMetrics(span, metricParams);
-            }
-          }
-        });
-      };
-    };
-  }
-
-  static _patchRetrieveDocuments(tracer: Tracer): any {
-    const genAIEndpoint = 'digitalocean.retrieve.documents';
-    return (originalMethod: (...args: any[]) => any) => {
-      return async function (this: any, ...args: any[]) {
-        if (isFrameworkLlmActive()) return originalMethod.apply(this, args);
-
-        const body = args[0] || {};
-        const kbId = body.knowledge_base_uuid || body.knowledge_base_id || '';
-        const [serverAddress, serverPort] = resolveGradientEndpoint(this, 'kb');
-        const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_RETRIEVE} ${kbId || 'unknown'}`;
-        const effectiveCtx = getFrameworkParentContext() ?? context.active();
-        const span = tracer.startSpan(
-          spanName,
-          {
-            kind: SpanKind.CLIENT,
-            attributes: gradientSpanCreationAttrs(
-              SemanticConvention.GEN_AI_OPERATION_TYPE_RETRIEVE,
-              kbId || 'unknown',
-              serverAddress,
-              serverPort
-            ),
-          },
-          effectiveCtx
-        );
-
-        return context.with(trace.setSpan(effectiveCtx, span), async () => {
-          let metricParams;
-          try {
-            const response = await originalMethod.apply(this, args);
-            metricParams = GradientWrapper._retrieveDocumentsCommonSetter({
-              args,
-              genAIEndpoint,
-              response,
-              span,
-              serverAddress,
-              serverPort,
-            });
-            return response;
-          } catch (e: any) {
-            OpenLitHelper.handleException(span, e);
-            BaseWrapper.recordMetrics(span, {
-              genAIEndpoint,
-              model: kbId || 'unknown',
               aiSystem: AI_SYSTEM,
               serverAddress,
               serverPort,
@@ -518,65 +449,6 @@ class GradientWrapper extends BaseWrapper {
       model: requestModel,
       user: body.user,
       cost,
-      aiSystem: AI_SYSTEM,
-      serverAddress,
-      serverPort,
-    };
-  }
-
-  static _retrieveDocumentsCommonSetter({
-    args,
-    genAIEndpoint,
-    response,
-    span,
-    serverAddress,
-    serverPort,
-  }: {
-    args: any[];
-    genAIEndpoint: string;
-    response: any;
-    span: Span;
-    serverAddress: string;
-    serverPort: number;
-  }) {
-    const captureContent = OpenlitConfig.captureMessageContent;
-    const body = args[0] || {};
-    const kbId = body.knowledge_base_uuid || body.knowledge_base_id || '';
-
-    GradientWrapper.setBaseSpanAttributes(span, {
-      genAIEndpoint,
-      model: kbId || 'unknown',
-      cost: 0,
-      aiSystem: AI_SYSTEM,
-      serverAddress,
-      serverPort,
-    });
-
-    if (kbId) {
-      span.setAttribute(SemanticConvention.GEN_AI_DATA_SOURCE_ID, kbId);
-    }
-    if (body.top_k != null) {
-      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_TOP_K, body.top_k);
-    }
-    if (captureContent && body.query != null) {
-      span.setAttribute(SemanticConvention.GEN_AI_RETRIEVAL_QUERY_TEXT, String(body.query));
-    }
-    const retrieved = response?.retrieved_data ?? response?.documents;
-    if (captureContent && retrieved != null) {
-      try {
-        span.setAttribute(
-          SemanticConvention.GEN_AI_RETRIEVAL_DOCUMENTS,
-          JSON.stringify(retrieved).slice(0, 65536)
-        );
-      } catch {
-        // ignore serialization failures
-      }
-    }
-
-    return {
-      genAIEndpoint,
-      model: kbId || 'unknown',
-      cost: 0,
       aiSystem: AI_SYSTEM,
       serverAddress,
       serverPort,

--- a/sdk/typescript/src/instrumentation/gradient/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/gradient/wrapper.ts
@@ -4,6 +4,7 @@ import OpenLitHelper, {
   isFrameworkLlmActive,
   getFrameworkParentContext,
   getCurrentAgentVersion,
+  getServerAddressForProvider,
 } from '../../helpers';
 import SemanticConvention from '../../semantic-convention';
 import BaseWrapper from '../base-wrapper';
@@ -21,13 +22,17 @@ function spanCreationAttrs(
   };
 }
 
+// Chat completions are served from the inference host (inference.do-ai.run), not
+// the control-plane base URL (api.digitalocean.com). The host/port live in
+// PROVIDER_DEFAULT_ENDPOINTS (helpers.ts) as the single source of truth; read them
+// via getServerAddressForProvider — the same pattern cursor-sdk / claude-agent-sdk
+// use — rather than re-hardcoding the literals here.
+const [GRADIENT_SERVER_ADDRESS, GRADIENT_SERVER_PORT] = getServerAddressForProvider('digitalocean');
+
 class GradientWrapper extends BaseWrapper {
   static aiSystem = SemanticConvention.GEN_AI_SYSTEM_DIGITALOCEAN;
-  // Chat completions are served from the inference host, not the control-plane
-  // base URL (api.digitalocean.com). Mirrors the Python reference's
-  // _DEFAULT_INFERENCE_HOST.
-  static serverAddress = 'inference.do-ai.run';
-  static serverPort = 443;
+  static serverAddress = GRADIENT_SERVER_ADDRESS;
+  static serverPort = GRADIENT_SERVER_PORT;
 
   static _patchChatCompletionCreate(tracer: Tracer): any {
     const genAIEndpoint = 'digitalocean.chat.completions';

--- a/sdk/typescript/src/instrumentation/gradient/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/gradient/wrapper.ts
@@ -1,0 +1,509 @@
+import { Span, SpanKind, Tracer, context, trace, Attributes } from '@opentelemetry/api';
+import OpenlitConfig from '../../config';
+import OpenLitHelper, {
+  isFrameworkLlmActive,
+  getFrameworkParentContext,
+  getCurrentAgentVersion,
+} from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import BaseWrapper from '../base-wrapper';
+
+function spanCreationAttrs(
+  operationName: string,
+  requestModel: string
+): Attributes {
+  return {
+    [SemanticConvention.GEN_AI_OPERATION]: operationName,
+    [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: GradientWrapper.aiSystem,
+    [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+    [SemanticConvention.SERVER_ADDRESS]: GradientWrapper.serverAddress,
+    [SemanticConvention.SERVER_PORT]: GradientWrapper.serverPort,
+  };
+}
+
+class GradientWrapper extends BaseWrapper {
+  static aiSystem = SemanticConvention.GEN_AI_SYSTEM_DIGITALOCEAN;
+  // Chat completions are served from the inference host, not the control-plane
+  // base URL (api.digitalocean.com). Mirrors the Python reference's
+  // _DEFAULT_INFERENCE_HOST.
+  static serverAddress = 'inference.do-ai.run';
+  static serverPort = 443;
+
+  static _patchChatCompletionCreate(tracer: Tracer): any {
+    const genAIEndpoint = 'digitalocean.chat.completions';
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        if (isFrameworkLlmActive()) return originalMethod.apply(this, args);
+        // The Gradient API requires `model`; fall back to 'unknown' to match the
+        // Python reference (body.get("model", "unknown")) rather than guessing a
+        // provider default.
+        const requestModel = args[0]?.model || 'unknown';
+        const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} ${requestModel}`;
+        const effectiveCtx = getFrameworkParentContext() ?? context.active();
+        const span = tracer.startSpan(
+          spanName,
+          {
+            kind: SpanKind.CLIENT,
+            attributes: spanCreationAttrs(SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT, requestModel),
+          },
+          effectiveCtx
+        );
+        return context
+          .with(trace.setSpan(effectiveCtx, span), async () => {
+            return originalMethod.apply(this, args);
+          })
+          .then((response: any) => {
+            const { stream = false } = args[0];
+
+            if (stream) {
+              return OpenLitHelper.createStreamProxy(
+                response,
+                GradientWrapper._chatCompletionGenerator({
+                  args,
+                  genAIEndpoint,
+                  response,
+                  span,
+                })
+              );
+            }
+
+            return GradientWrapper._chatCompletion({ args, genAIEndpoint, response, span });
+          })
+          .catch((e: any) => {
+            OpenLitHelper.handleException(span, e);
+            BaseWrapper.recordMetrics(span, {
+              genAIEndpoint,
+              model: requestModel,
+              aiSystem: GradientWrapper.aiSystem,
+              serverAddress: GradientWrapper.serverAddress,
+              serverPort: GradientWrapper.serverPort,
+              errorType: e?.constructor?.name || '_OTHER',
+            });
+            span.end();
+            throw e;
+          });
+      };
+    };
+  }
+
+  static async _chatCompletion({
+    args,
+    genAIEndpoint,
+    response,
+    span,
+  }: {
+    args: any[];
+    genAIEndpoint: string;
+    response: any;
+    span: Span;
+  }): Promise<any> {
+    let metricParams;
+    try {
+      metricParams = await GradientWrapper._chatCompletionCommonSetter({
+        args,
+        genAIEndpoint,
+        result: response,
+        span,
+      });
+      return response;
+    } catch (e: any) {
+      OpenLitHelper.handleException(span, e);
+      throw e;
+    } finally {
+      span.end();
+      if (metricParams) {
+        BaseWrapper.recordMetrics(span, metricParams);
+      }
+    }
+  }
+
+  static async *_chatCompletionGenerator({
+    args,
+    genAIEndpoint,
+    response,
+    span,
+  }: {
+    args: any[];
+    genAIEndpoint: string;
+    response: any;
+    span: Span;
+  }): AsyncGenerator<unknown, any, unknown> {
+    let metricParams;
+    const timestamps: number[] = [];
+    const startTime = Date.now();
+
+    try {
+      const { messages } = args[0];
+      let { tools } = args[0];
+      const result = {
+        id: '0',
+        created: -1,
+        model: '',
+        system_fingerprint: '',
+        choices: [
+          {
+            index: 0,
+            logprobs: null,
+            finish_reason: 'stop',
+            message: { role: 'assistant', content: '' },
+          },
+        ],
+        usage: {
+          prompt_tokens: 0,
+          completion_tokens: 0,
+          total_tokens: 0,
+        },
+      };
+
+      const toolCalls: any[] = [];
+
+      for await (const chunk of response) {
+        timestamps.push(Date.now());
+
+        if (chunk.id) {
+          result.id = chunk.id;
+        }
+        if (chunk.created) {
+          result.created = chunk.created;
+        }
+        if (chunk.model) {
+          result.model = chunk.model;
+        }
+        if (chunk.system_fingerprint) {
+          result.system_fingerprint = chunk.system_fingerprint;
+        }
+
+        if (chunk.choices?.[0]?.finish_reason) {
+          result.choices[0].finish_reason = chunk.choices[0].finish_reason;
+        }
+        if (chunk.choices?.[0]?.logprobs) {
+          result.choices[0].logprobs = chunk.choices[0].logprobs;
+        }
+        if (chunk.choices?.[0]?.delta?.content) {
+          result.choices[0].message.content += chunk.choices[0].delta.content;
+        }
+
+        if (chunk.choices?.[0]?.delta?.tool_calls) {
+          const deltaTools = chunk.choices[0].delta.tool_calls;
+
+          for (const tool of deltaTools) {
+            const idx = tool.index || 0;
+
+            while (toolCalls.length <= idx) {
+              toolCalls.push({
+                id: '',
+                type: 'function',
+                function: { name: '', arguments: '' },
+              });
+            }
+
+            if (tool.id) {
+              toolCalls[idx].id = tool.id;
+              toolCalls[idx].type = tool.type || 'function';
+              if (tool.function?.name) {
+                toolCalls[idx].function.name = tool.function.name;
+              }
+              if (tool.function?.arguments) {
+                toolCalls[idx].function.arguments = tool.function.arguments;
+              }
+            } else if (tool.function?.arguments) {
+              toolCalls[idx].function.arguments += tool.function.arguments;
+            }
+          }
+
+          tools = true;
+        }
+
+        // Gradient is OpenAI-compatible: the final chunk carries `usage` when the
+        // caller passes `stream_options: { include_usage: true }` (unlike groq's
+        // x_groq.usage). Falls back to local token counting below otherwise.
+        if (chunk.usage) {
+          result.usage.prompt_tokens = chunk.usage.prompt_tokens || 0;
+          result.usage.completion_tokens = chunk.usage.completion_tokens || 0;
+          result.usage.total_tokens = chunk.usage.total_tokens || 0;
+        }
+
+        yield chunk;
+      }
+
+      if (toolCalls.length > 0) {
+        result.choices[0].message = {
+          ...result.choices[0].message,
+          tool_calls: toolCalls,
+        } as any;
+      }
+
+      if (!result.usage.prompt_tokens && !result.usage.completion_tokens) {
+        let promptTokens = 0;
+        for (const message of messages || []) {
+          promptTokens += OpenLitHelper.openaiTokens(message.content as string, result.model) ?? 0;
+        }
+
+        const completionTokens = OpenLitHelper.openaiTokens(
+          result.choices[0].message.content ?? '',
+          result.model
+        );
+        if (completionTokens) {
+          result.usage = {
+            prompt_tokens: promptTokens,
+            completion_tokens: completionTokens,
+            total_tokens: promptTokens + completionTokens,
+          };
+        }
+      }
+
+      args[0].tools = tools;
+
+      const ttft = timestamps.length > 0 ? (timestamps[0] - startTime) / 1000 : 0;
+      let tbt = 0;
+      if (timestamps.length > 1) {
+        const timeDiffs = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+        tbt = timeDiffs.reduce((a, b) => a + b, 0) / timeDiffs.length / 1000;
+      }
+
+      metricParams = await GradientWrapper._chatCompletionCommonSetter({
+        args,
+        genAIEndpoint,
+        result,
+        span,
+        ttft,
+        tbt,
+      });
+
+      return result;
+    } catch (e: any) {
+      OpenLitHelper.handleException(span, e);
+      throw e;
+    } finally {
+      span.end();
+      if (metricParams) {
+        BaseWrapper.recordMetrics(span, metricParams);
+      }
+    }
+  }
+
+  static async _chatCompletionCommonSetter({
+    args,
+    genAIEndpoint,
+    result,
+    span,
+    ttft = 0,
+    tbt = 0,
+  }: {
+    args: any[];
+    genAIEndpoint: string;
+    result: any;
+    span: Span;
+    ttft?: number;
+    tbt?: number;
+  }) {
+    const captureContent = OpenlitConfig.captureMessageContent;
+    const requestModel = args[0]?.model || 'unknown';
+    const {
+      messages,
+      frequency_penalty = 0,
+      max_tokens = null,
+      n = 1,
+      presence_penalty = 0,
+      seed = null,
+      stop = null,
+      temperature = 1,
+      top_p,
+      user,
+      stream = false,
+      tools: _tools,
+    } = args[0];
+
+    span.setAttribute(SemanticConvention.GEN_AI_REQUEST_TOP_P, top_p ?? 1);
+    if (max_tokens != null) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, max_tokens);
+    }
+    span.setAttribute(SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, temperature);
+    if (presence_penalty) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, presence_penalty);
+    }
+    if (frequency_penalty) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, frequency_penalty);
+    }
+    if (seed != null) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_SEED, Number(seed));
+    }
+    span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, stream);
+    if (stop) {
+      span.setAttribute(
+        SemanticConvention.GEN_AI_REQUEST_STOP_SEQUENCES,
+        Array.isArray(stop) ? stop : [stop]
+      );
+    }
+    if (n && n !== 1) {
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_CHOICE_COUNT, n);
+    }
+
+    if (captureContent) {
+      span.setAttribute(
+        SemanticConvention.GEN_AI_INPUT_MESSAGES,
+        OpenLitHelper.buildInputMessages(messages || [])
+      );
+    }
+
+    span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_ID, result.id);
+
+    const responseModel = result.model || requestModel;
+
+    // Gradient marks `usage` as optional on its response type; default defensively
+    // so non-streaming responses without usage still produce a valid span.
+    const usage = result.usage || { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 };
+
+    const pricingInfo = OpenlitConfig.pricingInfo || {};
+
+    const cost = OpenLitHelper.getChatModelCost(
+      requestModel,
+      pricingInfo,
+      usage.prompt_tokens,
+      usage.completion_tokens
+    );
+
+    GradientWrapper.setBaseSpanAttributes(span, {
+      genAIEndpoint,
+      model: requestModel,
+      user,
+      cost,
+      aiSystem: GradientWrapper.aiSystem,
+      serverAddress: GradientWrapper.serverAddress,
+      serverPort: GradientWrapper.serverPort,
+    });
+
+    span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, responseModel);
+
+    if (result.system_fingerprint) {
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_SYSTEM_FINGERPRINT, result.system_fingerprint);
+    }
+
+    const inputTokens = usage.prompt_tokens;
+    const outputTokens = usage.completion_tokens;
+    span.setAttribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, inputTokens);
+    span.setAttribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, outputTokens);
+
+    if (ttft > 0) {
+      span.setAttribute(SemanticConvention.GEN_AI_SERVER_TTFT, ttft);
+    }
+    if (tbt > 0) {
+      span.setAttribute(SemanticConvention.GEN_AI_SERVER_TBT, tbt);
+    }
+
+    if (result.choices[0].finish_reason) {
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, [
+        result.choices[0].finish_reason,
+      ]);
+    }
+
+    const outputType =
+      typeof result.choices[0].message.content === 'string'
+        ? SemanticConvention.GEN_AI_OUTPUT_TYPE_TEXT
+        : SemanticConvention.GEN_AI_OUTPUT_TYPE_JSON;
+    span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, outputType);
+
+    if (result.choices[0].message.tool_calls) {
+      const toolCalls = result.choices[0].message.tool_calls;
+      const toolNames = toolCalls.map((t: any) => t.function?.name || '').filter(Boolean);
+      const toolIds = toolCalls.map((t: any) => t.id || '').filter(Boolean);
+      const toolArgs = toolCalls.map((t: any) => t.function?.arguments || '').filter(Boolean);
+
+      if (toolNames.length > 0) {
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_NAME, toolNames.join(', '));
+      }
+      if (toolIds.length > 0) {
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ID, toolIds.join(', '));
+      }
+      if (toolArgs.length > 0) {
+        span.setAttribute(SemanticConvention.GEN_AI_TOOL_ARGS, toolArgs.join(', '));
+      }
+    }
+
+    let inputMessagesJson: string | undefined;
+    let outputMessagesJson: string | undefined;
+    const toolDefinitionsJson = OpenLitHelper.buildToolDefinitions(_tools);
+    // Always extract system_instructions so the version hash can be computed
+    // even when content capture is disabled.
+    const systemInstructionsJson = OpenLitHelper.buildSystemInstructionsFromMessages(messages || []);
+
+    const versionExtras: Record<string, string> = {};
+    try {
+      const versionHash = OpenLitHelper.computeAgentVersionHash({
+        systemInstructions: systemInstructionsJson ?? null,
+        toolDefinitions: toolDefinitionsJson ?? null,
+        primaryModel: responseModel || requestModel,
+        runtimeConfig: {
+          temperature: temperature ?? null,
+          top_p: top_p ?? null,
+          max_tokens: max_tokens ?? null,
+          provider: SemanticConvention.GEN_AI_SYSTEM_DIGITALOCEAN,
+        },
+        providers: [SemanticConvention.GEN_AI_SYSTEM_DIGITALOCEAN],
+      });
+      if (versionHash) {
+        versionExtras[SemanticConvention.OPENLIT_AGENT_VERSION_HASH] = versionHash;
+        span.setAttribute(SemanticConvention.OPENLIT_AGENT_VERSION_HASH, versionHash);
+      }
+    } catch {
+      // Never fail the wrapped call on hash issues.
+    }
+    const versionLabel = getCurrentAgentVersion();
+    if (versionLabel) {
+      versionExtras[SemanticConvention.GEN_AI_AGENT_VERSION] = versionLabel;
+      span.setAttribute(SemanticConvention.GEN_AI_AGENT_VERSION, versionLabel);
+    }
+
+    if (captureContent) {
+      const toolCalls = result.choices[0].message.tool_calls;
+      outputMessagesJson = OpenLitHelper.buildOutputMessages(
+        result.choices[0].message.content || '',
+        result.choices[0].finish_reason || 'stop',
+        toolCalls
+      );
+      span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, outputMessagesJson);
+      inputMessagesJson = OpenLitHelper.buildInputMessages(messages || []);
+      if (systemInstructionsJson) {
+        span.setAttribute(SemanticConvention.GEN_AI_SYSTEM_INSTRUCTIONS, systemInstructionsJson);
+      }
+    }
+    if (toolDefinitionsJson) {
+      span.setAttribute(SemanticConvention.GEN_AI_TOOL_DEFINITIONS, toolDefinitionsJson);
+    }
+
+    if (!OpenlitConfig.disableEvents) {
+      const eventAttrs: Attributes = {
+        [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+        [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+        [SemanticConvention.GEN_AI_RESPONSE_MODEL]: responseModel,
+        [SemanticConvention.SERVER_ADDRESS]: GradientWrapper.serverAddress,
+        [SemanticConvention.SERVER_PORT]: GradientWrapper.serverPort,
+        [SemanticConvention.GEN_AI_RESPONSE_ID]: result.id,
+        [SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON]: [result.choices[0].finish_reason],
+        [SemanticConvention.GEN_AI_OUTPUT_TYPE]: outputType,
+        [SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS]: inputTokens,
+        [SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS]: outputTokens,
+        ...versionExtras,
+      };
+      if (captureContent) {
+        if (inputMessagesJson) eventAttrs[SemanticConvention.GEN_AI_INPUT_MESSAGES] = inputMessagesJson;
+        if (systemInstructionsJson)
+          eventAttrs[SemanticConvention.GEN_AI_SYSTEM_INSTRUCTIONS] = systemInstructionsJson;
+        if (outputMessagesJson)
+          eventAttrs[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = outputMessagesJson;
+      }
+      if (toolDefinitionsJson) eventAttrs[SemanticConvention.GEN_AI_TOOL_DEFINITIONS] = toolDefinitionsJson;
+      OpenLitHelper.emitInferenceEvent(span, eventAttrs);
+    }
+
+    return {
+      genAIEndpoint,
+      model: requestModel,
+      user,
+      cost,
+      aiSystem: GradientWrapper.aiSystem,
+    };
+  }
+}
+
+export default GradientWrapper;

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -7,6 +7,7 @@ import AnthropicInstrumentation from './anthropic';
 import CohereInstrumentation from './cohere';
 import GroqInstrumentation from './groq';
 import AI21Instrumentation from './ai21';
+import GradientInstrumentation from './gradient';
 import MistralInstrumentation from './mistral';
 import GoogleAIInstrumentation from './google-ai';
 import TogetherInstrumentation from './together';
@@ -78,6 +79,7 @@ export default class Instrumentations {
     cohere: new CohereInstrumentation(),
     groq: new GroqInstrumentation(),
     ai21: new AI21Instrumentation(),
+    gradient: new GradientInstrumentation(),
     mistral: new MistralInstrumentation(),
     'google-ai': new GoogleAIInstrumentation(),
     together: new TogetherInstrumentation(),

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -236,6 +236,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_GOOGLE_AI_STUDIO = 'gcp.gemini';
   static GEN_AI_SYSTEM_GROQ = 'groq';
   static GEN_AI_SYSTEM_AI21 = 'ai21';
+  static GEN_AI_SYSTEM_DIGITALOCEAN = 'digitalocean';
   static GEN_AI_SYSTEM_AZURE_AI_INFERENCE = 'azure.ai.inference';
   static GEN_AI_SYSTEM_LLAMAINDEX = 'llamaindex';
   static GEN_AI_SYSTEM_TOGETHER = 'together';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
**Issue number**: #1236

### Change description:

Adds OpenTelemetry auto-instrumentation for the DigitalOcean Gradient JS SDK (`@digitalocean/gradient`) so calls made through it produce the same OpenLIT traces, events, and metrics as the Python SDK reference (`sdk/python/src/openlit/instrumentation/gradient/`).

Closes #1236

**Changes**
- New `sdk/typescript/src/instrumentation/gradient/` (`index.ts` + `wrapper.ts`)
- Wraps `@digitalocean/gradient` by string name via `InstrumentationNodeModuleDefinition` — no runtime dependency added (devDependency only, per `.cursor/rules/js-sdk-genai-instrumentation.mdc`)
- Registered in `types.ts`, `instrumentation/index.ts`, `semantic-convention.ts` (`GEN_AI_SYSTEM_DIGITALOCEAN`), and `helpers.ts` (default endpoint `inference.do-ai.run:443`)
- Cross-language trace-comparison tests mirroring the Python reference (9 tests)

**Scope & notes**
- Covers `chat.completions` (sync + streaming). Gradient is OpenAI-shaped: responses carry `model`, requests support `seed` / `frequency_penalty` / `presence_penalty`, and streaming usage arrives on the final chunk (`stream_options: { include_usage: true }`), with local token counting as a fallback.
- Auto-patching targets `Gradient.Chat.Completions.prototype.create`. The instrumented version range is anchored at `>=0.1.0-alpha.0` because the SDK currently only ships prereleases and a plain `>=0.1.0` range would silently skip them under semver prerelease semantics (verified: matches `0.1.0-alpha.2`, `0.1.0-alpha.10`, stable `0.1.0`, `0.2.0`, `1.0.0`); mirrors azure-ai-inference's `>=1.0.0-beta.1`.

**Testing**
- **Verified end-to-end against the real `@digitalocean/gradient` SDK** (v0.1.0-alpha) pointed at a local mock server speaking the Gradient/OpenAI wire protocol (JSON + SSE) — DigitalOcean requires a payment card for live keys, so live-API testing wasn't possible. The require-hook auto-patched the real client, and both paths were confirmed:
  - non-streaming: `chat <model>` span with `gen_ai.provider.name=digitalocean`, request params (temperature/max_tokens/seed/penalties), token usage from the response, input/output messages, and the `gen_ai.client.inference.operation.details` event
  - streaming: chunks passed through to the consumer intact, content aggregated, usage read from the final SSE chunk
- **Regression tested:** full TypeScript SDK suite passes (365/365 tests across 27 suites) including the new Gradient trace-comparison suite; `tsc --build` and `eslint` are clean.
- **No existing functionality changed** — this PR only adds the new Gradient instrumentation and registers it.

### Checklist

* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).


## Summary by Sourcery

Add OpenTelemetry-based auto-instrumentation support for the DigitalOcean Gradient TypeScript SDK and register it in the OpenLIT TypeScript SDK.

New Features:
- Introduce Gradient auto-instrumentation for chat completions in the TypeScript SDK using the DigitalOcean Gradient client.
- Expose a new 'gradient' instrumentation type and wire it into the shared instrumentation registry and semantic conventions.

Enhancements:
- Define DigitalOcean as a first-class gen-ai system in semantic conventions and default provider endpoints.

Build:
- Add the DigitalOcean Gradient SDK as a development dependency for TypeScript instrumentation testing.

Tests:
- Add a Gradient trace-comparison test suite to validate cross-language parity with the Python instrumentation.
