### PR TITLE
fix: trace log detail view now respects newlines in span content

### DIFF
--- a/src/client/src/components/(playground)/observability/log-detail-page.tsx
+++ b/src/client/src/components/(playground)/observability/log-detail-page.tsx
@@ -71,7 +71,7 @@ function ContextPill({ label, value }: { label: string; value?: unknown }) {
 				{label}
 			</div>
 			<div
-				className="max-w-64 truncate font-mono text-xs text-stone-900 dark:text-stone-100"
+				className="max-w-64 whitespace-pre-wrap break-words font-mono text-xs text-stone-900 dark:text-stone-100"
 				title={displayValue}
 			>
 				{displayValue}

--- a/src/client/src/components/(playground)/request/components/trace-improvement-view.tsx
+++ b/src/client/src/components/(playground)/request/components/trace-improvement-view.tsx
@@ -201,7 +201,7 @@ function MarkdownText({ content }: { content: string }) {
 			<ReactMarkdown
 				components={{
 					p({ children }) {
-						return <p className="my-1.5 text-sm leading-relaxed text-stone-800 dark:text-stone-100">{children}</p>;
+						return <p className="my-1.5 text-sm leading-relaxed text-stone-800 dark:text-stone-100 whitespace-pre-wrap">{children}</p>;
 					},
 					ul({ children }) {
 						return <ul className="my-1.5 list-disc space-y-1 pl-5 text-sm text-stone-800 dark:text-stone-100">{children}</ul>;


### PR DESCRIPTION
## Summary
- Added whitespace-pre-wrap CSS class to trace/span detail view containers so newlines in log content are displayed correctly
- Changed ContextPill value display from `truncate` to `whitespace-pre-wrap break-words` in log detail page to preserve newlines in the Body field
- Added whitespace-pre-wrap to markdown paragraph rendering in trace improvement view for AI analysis text
- Matches existing pattern used in message-bubble.tsx and attribute-grid.tsx

Fixes #1159

## Root Cause
The original fix for this issue was in PR #558 which added whitespace-pre-wrap to code blocks in `request-details.tsx`. That file was removed during a refactor of the observability UI. While most content rendering paths already have whitespace-pre-wrap (attribute-grid.tsx ValueCell, message bubbles), the ContextPill component and markdown paragraphs were still using `truncate` which collapses newlines.

## Test Plan
- [x] Log detail page Body field now displays newlines in multi-line log messages
- [x] AI analysis markdown paragraphs now preserve intended line breaks

## Summary by Sourcery

Preserve multiline content formatting in observability log and trace views by respecting newlines in rendered text.

Enhancements:
- Update log detail ContextPill rendering to wrap and preserve newlines instead of truncating values.
- Allow AI analysis markdown paragraphs in the trace improvement view to preserve line breaks via whitespace-aware styling.