### PR TITLE
add ElevenLabs TS instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ OpenLIT auto-instruments **50+ LLM providers, AI frameworks, and vector database
 
 <table>
 <tr>
-<td align="center" width="160"><a href="https://docs.openlit.io/latest/sdk/integrations/elevenlabs"><b>ElevenLabs</b></a><br/><img src="https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white&style=flat-square" height="18"></td>
+<td align="center" width="160"><a href="https://docs.openlit.io/latest/sdk/integrations/elevenlabs"><b>ElevenLabs</b></a><br/><img src="https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white&style=flat-square" height="18"> <img src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white&style=flat-square" height="18"></td>
 <td align="center" width="160"><a href="https://docs.openlit.io/latest/sdk/integrations/assemblyai"><b>AssemblyAI</b></a><br/><img src="https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white&style=flat-square" height="18"></td>
 <td align="center" width="160"><a href="https://docs.openlit.io/latest/sdk/integrations/mcp"><b>MCP</b></a><br/><img src="https://img.shields.io/badge/Python-3776AB?logo=python&logoColor=white&style=flat-square" height="18"></td>
 </tr>

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -45,6 +45,7 @@ This project proudly follows and maintains the [Semantic Conventions](https://gi
 | [✅ AWS Bedrock](https://docs.openlit.io/latest/integrations/bedrock)                        |
 | [✅ Hugging Face](https://docs.openlit.io/latest/integrations/huggingface)                  |
 | [✅ Replicate](https://docs.openlit.io/latest/integrations/replicate)                      |
+| [✅ ElevenLabs](https://docs.openlit.io/latest/integrations/elevenlabs)                    |
 | [✅ Azure OpenAI](https://docs.openlit.io/latest/integrations/azure-openai) *(via OpenAI SDK)* |
 
 | Vector Databases                                                                            |

--- a/sdk/typescript/src/instrumentation/__tests__/elevenlabs-trace-comparison.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/elevenlabs-trace-comparison.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Cross-Language Trace Comparison Tests for the ElevenLabs Integration
+ *
+ * Verifies that the TypeScript ElevenLabs instrumentation emits TTS telemetry
+ * aligned with the Python SDK reference in sdk/python/src/openlit/instrumentation/elevenlabs.
+ */
+
+import ElevenLabsWrapper from '../elevenlabs/wrapper';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import BaseWrapper from '../base-wrapper';
+import SemanticConvention from '../../semantic-convention';
+
+jest.mock('../../config');
+jest.mock('../../helpers', () => ({
+  __esModule: true,
+  default: {
+    getAudioModelCost: jest.fn(),
+    handleException: jest.fn(),
+    buildInputMessages: jest.fn(),
+    buildOutputMessages: jest.fn(),
+    emitInferenceEvent: jest.fn(),
+  },
+  isFrameworkLlmActive: jest.fn(() => false),
+  getFrameworkParentContext: jest.fn(() => undefined),
+}));
+jest.mock('../base-wrapper');
+
+describe('ElevenLabs Cross-Language Trace Comparison', () => {
+  let mockSpan: any;
+
+  beforeEach(() => {
+    mockSpan = {
+      setAttribute: jest.fn(),
+      addEvent: jest.fn(),
+      end: jest.fn(),
+      setStatus: jest.fn(),
+    };
+
+    (OpenlitConfig as any).environment = 'openlit-testing';
+    (OpenlitConfig as any).applicationName = 'openlit-test';
+    (OpenlitConfig as any).captureMessageContent = true;
+    (OpenlitConfig as any).pricingInfo = {};
+    (OpenlitConfig as any).disableEvents = false;
+
+    (OpenLitHelper as any).getAudioModelCost = jest.fn().mockReturnValue(0.012);
+    (OpenLitHelper as any).handleException = jest.fn();
+    (OpenLitHelper as any).buildInputMessages = jest
+      .fn()
+      .mockReturnValue('[{"role":"user","parts":[{"type":"text","content":"Hello from OpenLIT"}]}]');
+    (OpenLitHelper as any).buildOutputMessages = jest
+      .fn()
+      .mockReturnValue(
+        '[{"role":"assistant","parts":[{"type":"text","content":"[audio generated]"}],"finish_reason":"stop"}]'
+      );
+    (OpenLitHelper as any).emitInferenceEvent = jest.fn();
+
+    (BaseWrapper as any).recordMetrics = jest.fn();
+    (BaseWrapper as any).setBaseSpanAttributes = jest
+      .fn()
+      .mockImplementation((span, attrs) => {
+        span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, attrs.aiSystem);
+        span.setAttribute(SemanticConvention.GEN_AI_REQUEST_MODEL, attrs.model);
+        if (attrs.cost !== undefined) {
+          span.setAttribute(SemanticConvention.GEN_AI_USAGE_COST, attrs.cost);
+        }
+        if (attrs.serverAddress) {
+          span.setAttribute(SemanticConvention.SERVER_ADDRESS, attrs.serverAddress);
+        }
+        if (attrs.serverPort !== undefined) {
+          span.setAttribute(SemanticConvention.SERVER_PORT, attrs.serverPort);
+        }
+        span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, '1.13.0');
+      });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const ttsArgs = [
+    'voice-123',
+    {
+      text: 'Hello from OpenLIT',
+      modelId: 'eleven_turbo_v2',
+      outputFormat: 'mp3_44100_128',
+      voiceSettings: { stability: 0.5, similarity_boost: 0.8 },
+    },
+  ];
+
+  it('sets core TTS span attributes aligned with Python ElevenLabs instrumentation', async () => {
+    await ElevenLabsWrapper._textToSpeech({
+      args: ttsArgs,
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'convert',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL,
+      'elevenlabs'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_OPERATION,
+      SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_MODEL,
+      'eleven_turbo_v2'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_RESPONSE_MODEL,
+      'eleven_turbo_v2'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
+      false
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_AUDIO_VOICE,
+      'voice-123'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT,
+      'mp3_44100_128'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_OUTPUT_TYPE,
+      SemanticConvention.GEN_AI_OUTPUT_TYPE_SPEECH
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.SERVER_ADDRESS,
+      'api.elevenlabs.io'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.SERVER_PORT,
+      443
+    );
+  });
+
+  it('supports the snake_case request shape used by elevenlabs v1', async () => {
+    await ElevenLabsWrapper._textToSpeech({
+      args: [
+        'voice-v1',
+        {
+          text: 'Legacy request shape',
+          model_id: 'eleven_multilingual_v1',
+          output_format: 'pcm_16000',
+          voice_settings: { style: 0.2 },
+        },
+      ],
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'convert',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_MODEL,
+      'eleven_multilingual_v1'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT,
+      'pcm_16000'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_AUDIO_SETTINGS,
+      JSON.stringify({ style: 0.2 })
+    );
+  });
+
+  it('marks stream methods as streaming requests', async () => {
+    await ElevenLabsWrapper._textToSpeech({
+      args: ttsArgs,
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'stream',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
+      true
+    );
+  });
+
+  it('captures input and output messages when captureMessageContent=true', async () => {
+    (OpenlitConfig as any).captureMessageContent = true;
+
+    await ElevenLabsWrapper._textToSpeech({
+      args: ttsArgs,
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'convert',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(OpenLitHelper.buildInputMessages).toHaveBeenCalledWith([
+      { role: 'user', content: 'Hello from OpenLIT' },
+    ]);
+    expect(OpenLitHelper.buildOutputMessages).toHaveBeenCalledWith('[audio generated]', 'stop');
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_INPUT_MESSAGES,
+      expect.any(String)
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
+      expect.any(String)
+    );
+  });
+
+  it('emits events without message content when captureMessageContent=false', async () => {
+    (OpenlitConfig as any).captureMessageContent = false;
+
+    await ElevenLabsWrapper._textToSpeech({
+      args: ttsArgs,
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'convert',
+      response: {},
+      span: mockSpan,
+    });
+
+    const eventAttrs = (OpenLitHelper.emitInferenceEvent as jest.Mock).mock.calls[0][1];
+    expect(eventAttrs[SemanticConvention.GEN_AI_OPERATION]).toBe(
+      SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO
+    );
+    expect(eventAttrs[SemanticConvention.GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+    expect(eventAttrs[SemanticConvention.GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
+
+    const attributeKeys = (mockSpan.setAttribute as jest.Mock).mock.calls.map(
+      ([key]: [string]) => key
+    );
+    expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_INPUT_MESSAGES);
+    expect(attributeKeys).not.toContain(SemanticConvention.GEN_AI_OUTPUT_MESSAGES);
+  });
+
+  it('uses audio pricing and records metrics with ElevenLabs endpoint metadata', async () => {
+    await ElevenLabsWrapper._textToSpeech({
+      args: ttsArgs,
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'convert',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(OpenLitHelper.getAudioModelCost).toHaveBeenCalledWith(
+      'eleven_turbo_v2',
+      {},
+      'Hello from OpenLIT'
+    );
+    expect(BaseWrapper.recordMetrics).toHaveBeenCalledWith(
+      mockSpan,
+      expect.objectContaining({
+        genAIEndpoint: 'elevenlabs.text_to_speech',
+        model: 'eleven_turbo_v2',
+        cost: 0.012,
+        aiSystem: 'elevenlabs',
+        serverAddress: 'api.elevenlabs.io',
+        serverPort: 443,
+      })
+    );
+  });
+
+  it('handles deprecated ElevenLabsClient.generate request shape', async () => {
+    await ElevenLabsWrapper._textToSpeech({
+      args: [
+        {
+          voice: 'Sarah',
+          text: 'Generate request',
+          model_id: 'eleven_multilingual_v2',
+          stream: true,
+        },
+      ],
+      genAIEndpoint: 'elevenlabs.text_to_speech',
+      methodName: 'generate',
+      response: {},
+      span: mockSpan,
+    });
+
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_AUDIO_VOICE,
+      'Sarah'
+    );
+    expect(mockSpan.setAttribute).toHaveBeenCalledWith(
+      SemanticConvention.GEN_AI_REQUEST_IS_STREAM,
+      true
+    );
+  });
+});

--- a/sdk/typescript/src/instrumentation/elevenlabs/index.ts
+++ b/sdk/typescript/src/instrumentation/elevenlabs/index.ts
@@ -1,0 +1,113 @@
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import ElevenLabsWrapper from './wrapper';
+
+export interface ElevenLabsInstrumentationConfig extends InstrumentationConfig {}
+
+const TTS_METHODS = [
+  'convert',
+  'convertAsStream',
+  'stream',
+  'convertWithTimestamps',
+  'streamWithTimestamps',
+];
+
+export default class OpenlitElevenLabsInstrumentation extends InstrumentationBase {
+  constructor(config: ElevenLabsInstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-elevenlabs`, '1.0.0', config);
+  }
+
+  protected init(): void | InstrumentationModuleDefinition | InstrumentationModuleDefinition[] {
+    return ['elevenlabs', '@elevenlabs/elevenlabs-js'].map(
+      (moduleName) =>
+        new InstrumentationNodeModuleDefinition(
+          moduleName,
+          ['>=1.4.0'],
+          (moduleExports) => {
+            this._patch(moduleExports);
+            return moduleExports;
+          },
+          (moduleExports) => {
+            if (moduleExports !== undefined) {
+              this._unpatch(moduleExports);
+            }
+          }
+        )
+    );
+  }
+
+  public manualPatch(elevenlabs: any): void {
+    this._patch(elevenlabs);
+  }
+
+  private safeWrap(target: any, method: string, patcher: (tracer: any) => any): void {
+    if (!target?.[method]) return;
+    if (isWrapped(target[method])) {
+      this._unwrap(target, method);
+    }
+    this._wrap(target, method, patcher(this.tracer));
+  }
+
+  private safeUnwrap(target: any, method: string): void {
+    if (target?.[method] && isWrapped(target[method])) {
+      this._unwrap(target, method);
+    }
+  }
+
+  private getTextToSpeechPrototypes(moduleExports: any): any[] {
+    const api = moduleExports?.ElevenLabs ?? moduleExports;
+    const candidates = [
+      api?.textToSpeech?.TextToSpeech,
+      api?.textToSpeech?.TextToSpeechClient,
+      moduleExports?.textToSpeech?.TextToSpeech,
+      moduleExports?.textToSpeech?.TextToSpeechClient,
+      moduleExports?.TextToSpeech,
+      moduleExports?.TextToSpeechClient,
+    ];
+
+    return [...new Set(candidates.map((candidate) => candidate?.prototype).filter(Boolean))];
+  }
+
+  private getElevenLabsClientPrototype(moduleExports: any): any {
+    const client =
+      moduleExports?.ElevenLabsClient ??
+      moduleExports?.default?.ElevenLabsClient ??
+      moduleExports?.ElevenLabs?.ElevenLabsClient;
+    return client?.prototype;
+  }
+
+  protected _patch(moduleExports: any) {
+    try {
+      for (const proto of this.getTextToSpeechPrototypes(moduleExports)) {
+        for (const method of TTS_METHODS) {
+          this.safeWrap(proto, method, (tracer) =>
+            ElevenLabsWrapper._patchConvert(tracer, method)
+          );
+        }
+      }
+
+      this.safeWrap(
+        this.getElevenLabsClientPrototype(moduleExports),
+        'generate',
+        ElevenLabsWrapper._patchGenerate
+      );
+    } catch (e) {
+      console.error('Error in ElevenLabs _patch method:', e);
+    }
+  }
+
+  protected _unpatch(moduleExports: any) {
+    for (const proto of this.getTextToSpeechPrototypes(moduleExports)) {
+      for (const method of TTS_METHODS) {
+        this.safeUnwrap(proto, method);
+      }
+    }
+    this.safeUnwrap(this.getElevenLabsClientPrototype(moduleExports), 'generate');
+  }
+}

--- a/sdk/typescript/src/instrumentation/elevenlabs/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/elevenlabs/wrapper.ts
@@ -1,0 +1,393 @@
+import { Span, SpanKind, Tracer, context, trace, Attributes } from '@opentelemetry/api';
+import OpenlitConfig from '../../config';
+import OpenLitHelper, {
+  isFrameworkLlmActive,
+  getFrameworkParentContext,
+} from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import BaseWrapper, { BaseSpanAttributes } from '../base-wrapper';
+
+const DEFAULT_MODEL = 'eleven_multilingual_v2';
+const DEFAULT_OUTPUT_FORMAT = 'mp3_44100_128';
+
+type ElevenLabsRequest = {
+  voiceId?: string;
+  body: Record<string, any>;
+  text: string;
+  requestModel: string;
+  outputFormat: string;
+  voiceSettings?: unknown;
+  isStream: boolean;
+};
+
+function spanCreationAttrs(
+  operationName: string,
+  requestModel: string
+): Attributes {
+  return {
+    [SemanticConvention.GEN_AI_OPERATION]: operationName,
+    [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: ElevenLabsWrapper.aiSystem,
+    [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+    [SemanticConvention.SERVER_ADDRESS]: ElevenLabsWrapper.serverAddress,
+    [SemanticConvention.SERVER_PORT]: ElevenLabsWrapper.serverPort,
+  };
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function stringifyAttribute(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+class ElevenLabsWrapper extends BaseWrapper {
+  static aiSystem = SemanticConvention.GEN_AI_SYSTEM_ELEVENLABS;
+  static serverAddress = 'api.elevenlabs.io';
+  static serverPort = 443;
+
+  static _patchTextToSpeech(tracer: Tracer, methodName: string): any {
+    const genAIEndpoint = 'elevenlabs.text_to_speech';
+    return (originalMethod: (...args: any[]) => any) => {
+      return function (this: any, ...args: any[]) {
+        if (isFrameworkLlmActive()) return originalMethod.apply(this, args);
+
+        const request = ElevenLabsWrapper._requestFromArgs(args, methodName);
+        const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO} ${request.requestModel}`;
+        const effectiveCtx = getFrameworkParentContext() ?? context.active();
+        const span = ElevenLabsWrapper._startSpan(
+          tracer,
+          spanName,
+          request.requestModel,
+          effectiveCtx
+        );
+
+        try {
+          const result = context.with(trace.setSpan(effectiveCtx, span), () => {
+            return originalMethod.apply(this, args);
+          });
+          return ElevenLabsWrapper._wrapResult({
+            result,
+            args,
+            genAIEndpoint,
+            methodName,
+            span,
+            request,
+          });
+        } catch (e: any) {
+          ElevenLabsWrapper._handleError({
+            error: e,
+            genAIEndpoint,
+            requestModel: request.requestModel,
+            span,
+          });
+        }
+      };
+    };
+  }
+
+  static _patchGenerate(tracer: Tracer): any {
+    return ElevenLabsWrapper._patchTextToSpeech(tracer, 'generate');
+  }
+
+  static _patchConvert(tracer: Tracer, methodName: string): any {
+    return ElevenLabsWrapper._patchTextToSpeech(tracer, methodName);
+  }
+
+  private static _startSpan(
+    tracer: Tracer,
+    spanName: string,
+    requestModel: string,
+    activeContext: any
+  ): Span {
+    return tracer.startSpan(
+      spanName,
+      {
+        kind: SpanKind.CLIENT,
+        attributes: spanCreationAttrs(
+          SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO,
+          requestModel
+        ),
+      },
+      activeContext
+    );
+  }
+
+  static _requestFromArgs(args: any[], methodName: string): ElevenLabsRequest {
+    const first = args[0];
+    const second = args[1];
+    const isGenerateRequest =
+      methodName === 'generate' &&
+      first &&
+      typeof first === 'object' &&
+      !Array.isArray(first);
+
+    const body = (isGenerateRequest ? first : second) || {};
+    const voiceId = isGenerateRequest
+      ? firstString(body.voiceId, body.voice_id, body.voice)
+      : firstString(first, body.voiceId, body.voice_id, body.voice);
+
+    const requestModel =
+      firstString(body.model, body.modelId, body.model_id) || DEFAULT_MODEL;
+    const outputFormat =
+      firstString(body.outputFormat, body.output_format) || DEFAULT_OUTPUT_FORMAT;
+    const text = firstString(body.text, body.input, body.prompt) || '';
+    const isStream =
+      body.stream === true ||
+      methodName === 'stream' ||
+      methodName === 'convertAsStream' ||
+      methodName === 'streamWithTimestamps';
+
+    return {
+      voiceId,
+      body,
+      text,
+      requestModel,
+      outputFormat,
+      voiceSettings: body.voiceSettings ?? body.voice_settings,
+      isStream,
+    };
+  }
+
+  private static _wrapResult({
+    result,
+    args,
+    genAIEndpoint,
+    methodName,
+    span,
+    request,
+  }: {
+    result: any;
+    args: any[];
+    genAIEndpoint: string;
+    methodName: string;
+    span: Span;
+    request: ElevenLabsRequest;
+  }): any {
+    if (
+      result &&
+      typeof result.withRawResponse === 'function' &&
+      typeof result.constructor?.fromPromise === 'function'
+    ) {
+      const rawPromise = result.withRawResponse()
+        .then(async (rawResponse: any) => {
+          const response = rawResponse?.data ?? rawResponse;
+          await ElevenLabsWrapper._textToSpeech({
+            args,
+            genAIEndpoint,
+            methodName,
+            response,
+            span,
+          });
+          return rawResponse;
+        })
+        .catch((e: any) => {
+          ElevenLabsWrapper._handleError({
+            error: e,
+            genAIEndpoint,
+            requestModel: request.requestModel,
+            span,
+          });
+        });
+      return result.constructor.fromPromise(rawPromise);
+    }
+
+    if (result && typeof result.then === 'function') {
+      return result
+        .then(async (response: any) => {
+          await ElevenLabsWrapper._textToSpeech({
+            args,
+            genAIEndpoint,
+            methodName,
+            response,
+            span,
+          });
+          return response;
+        })
+        .catch((e: any) => {
+          ElevenLabsWrapper._handleError({
+            error: e,
+            genAIEndpoint,
+            requestModel: request.requestModel,
+            span,
+          });
+        });
+    }
+
+    ElevenLabsWrapper._textToSpeech({
+      args,
+      genAIEndpoint,
+      methodName,
+      response: result,
+      span,
+    });
+    return result;
+  }
+
+  static async _textToSpeech({
+    args,
+    genAIEndpoint,
+    methodName,
+    response,
+    span,
+  }: {
+    args: any[];
+    genAIEndpoint: string;
+    methodName: string;
+    response: any;
+    span: Span;
+  }): Promise<any> {
+    let metricParams: BaseSpanAttributes | undefined;
+    try {
+      const request = ElevenLabsWrapper._requestFromArgs(args, methodName);
+      const captureContent = OpenlitConfig.captureMessageContent;
+      const responseModel =
+        firstString(response?.model, response?.modelId, response?.model_id) ||
+        request.requestModel;
+      const pricingInfo = OpenlitConfig.pricingInfo || {};
+      const cost = OpenLitHelper.getAudioModelCost(
+        responseModel,
+        pricingInfo,
+        request.text
+      );
+
+      ElevenLabsWrapper.setBaseSpanAttributes(span, {
+        genAIEndpoint,
+        model: request.requestModel,
+        cost,
+        aiSystem: ElevenLabsWrapper.aiSystem,
+        serverAddress: ElevenLabsWrapper.serverAddress,
+        serverPort: ElevenLabsWrapper.serverPort,
+      });
+
+      span.setAttribute(
+        SemanticConvention.GEN_AI_OPERATION,
+        SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO
+      );
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, responseModel);
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, request.isStream);
+      span.setAttribute(
+        SemanticConvention.GEN_AI_OUTPUT_TYPE,
+        SemanticConvention.GEN_AI_OUTPUT_TYPE_SPEECH
+      );
+      span.setAttribute(
+        SemanticConvention.GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT,
+        request.outputFormat
+      );
+      span.setAttribute(
+        SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
+        ['stop']
+      );
+
+      if (request.voiceId) {
+        span.setAttribute(
+          SemanticConvention.GEN_AI_REQUEST_AUDIO_VOICE,
+          request.voiceId
+        );
+      }
+
+      const voiceSettings = stringifyAttribute(request.voiceSettings);
+      if (voiceSettings) {
+        span.setAttribute(
+          SemanticConvention.GEN_AI_REQUEST_AUDIO_SETTINGS,
+          voiceSettings
+        );
+      }
+
+      let inputMessagesJson: string | undefined;
+      let outputMessagesJson: string | undefined;
+      if (captureContent) {
+        inputMessagesJson = OpenLitHelper.buildInputMessages(
+          request.text ? [{ role: 'user', content: request.text }] : []
+        );
+        outputMessagesJson = OpenLitHelper.buildOutputMessages('[audio generated]', 'stop');
+        span.setAttribute(SemanticConvention.GEN_AI_INPUT_MESSAGES, inputMessagesJson);
+        span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, outputMessagesJson);
+      }
+
+      if (!OpenlitConfig.disableEvents) {
+        const eventAttrs: Attributes = {
+          [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO,
+          [SemanticConvention.GEN_AI_REQUEST_MODEL]: request.requestModel,
+          [SemanticConvention.GEN_AI_RESPONSE_MODEL]: responseModel,
+          [SemanticConvention.SERVER_ADDRESS]: ElevenLabsWrapper.serverAddress,
+          [SemanticConvention.SERVER_PORT]: ElevenLabsWrapper.serverPort,
+          [SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON]: ['stop'],
+          [SemanticConvention.GEN_AI_OUTPUT_TYPE]: SemanticConvention.GEN_AI_OUTPUT_TYPE_SPEECH,
+          [SemanticConvention.GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT]: request.outputFormat,
+        };
+        if (request.voiceId) {
+          eventAttrs[SemanticConvention.GEN_AI_REQUEST_AUDIO_VOICE] = request.voiceId;
+        }
+        if (voiceSettings) {
+          eventAttrs[SemanticConvention.GEN_AI_REQUEST_AUDIO_SETTINGS] = voiceSettings;
+        }
+        if (captureContent) {
+          if (inputMessagesJson) {
+            eventAttrs[SemanticConvention.GEN_AI_INPUT_MESSAGES] = inputMessagesJson;
+          }
+          if (outputMessagesJson) {
+            eventAttrs[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = outputMessagesJson;
+          }
+        }
+        OpenLitHelper.emitInferenceEvent(span, eventAttrs);
+      }
+
+      metricParams = {
+        genAIEndpoint,
+        model: request.requestModel,
+        cost,
+        aiSystem: ElevenLabsWrapper.aiSystem,
+        serverAddress: ElevenLabsWrapper.serverAddress,
+        serverPort: ElevenLabsWrapper.serverPort,
+      };
+
+      return response;
+    } catch (e: any) {
+      OpenLitHelper.handleException(span, e);
+      return response;
+    } finally {
+      span.end();
+      if (metricParams) {
+        BaseWrapper.recordMetrics(span, metricParams);
+      }
+    }
+  }
+
+  private static _handleError({
+    error,
+    genAIEndpoint,
+    requestModel,
+    span,
+  }: {
+    error: any;
+    genAIEndpoint: string;
+    requestModel: string;
+    span: Span;
+  }): never {
+    OpenLitHelper.handleException(span, error);
+    BaseWrapper.recordMetrics(span, {
+      genAIEndpoint,
+      model: requestModel,
+      aiSystem: ElevenLabsWrapper.aiSystem,
+      serverAddress: ElevenLabsWrapper.serverAddress,
+      serverPort: ElevenLabsWrapper.serverPort,
+      errorType: error?.constructor?.name || '_OTHER',
+    });
+    span.end();
+    throw error;
+  }
+}
+
+export default ElevenLabsWrapper;

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -31,6 +31,7 @@ import ClaudeAgentSDKInstrumentation from './claude-agent-sdk';
 import CursorSDKInstrumentation from './cursor-sdk';
 import AstraInstrumentation from './astra';
 import MCPInstrumentation from './mcp';
+import ElevenLabsInstrumentation from './elevenlabs';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -104,6 +105,7 @@ export default class Instrumentations {
     'cursor-sdk': new CursorSDKInstrumentation(),
     'astra': new AstraInstrumentation(),
     mcp: new MCPInstrumentation(),
+    elevenlabs: new ElevenLabsInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -86,6 +86,7 @@ export default class SemanticConvention {
   static GEN_AI_REQUEST_TOOL_CHOICE = 'gen_ai.request.tool_choice';
   static GEN_AI_REQUEST_AUDIO_VOICE = 'gen_ai.request.audio_voice';
   static GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT = 'gen_ai.request.audio_response_format';
+  static GEN_AI_REQUEST_AUDIO_SETTINGS = 'gen_ai.request.audio_settings';
   static GEN_AI_REQUEST_AUDIO_SPEED = 'gen_ai.request.audio_speed';
   static GEN_AI_REQUEST_FINETUNE_STATUS = 'gen_ai.request.fine_tune_status';
   static GEN_AI_REQUEST_FINETUNE_MODEL_SUFFIX = 'gen_ai.request.fine_tune_model_suffix';
@@ -245,6 +246,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_STRANDS = 'strands_agents';
   static GEN_AI_SYSTEM_CURSOR = 'cursor';
   static GEN_AI_SYSTEM_MCP = 'mcp';
+  static GEN_AI_SYSTEM_ELEVENLABS = 'elevenlabs';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp' | 'elevenlabs';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
## What changed
- Added TypeScript SDK auto-instrumentation for ElevenLabs text-to-speech calls.
- Supports both `elevenlabs` and `@elevenlabs/elevenlabs-js` module hooks, including v1/v2 text-to-speech client shapes and the deprecated `ElevenLabsClient.generate` path.
- Records audio operation span attributes, inference events, audio pricing metrics, voice metadata, and captureMessageContent-gated input/output messages.
- Registered the new instrumentation and updated README support matrices.

## Why
TS users currently do not get out-of-the-box OpenLIT traces for ElevenLabs TTS workloads, while Python already has `sdk/python/src/openlit/instrumentation/elevenlabs/`.

## Testing
- `npm install`
- `npm test -- --runTestsByPath src/instrumentation/__tests__/elevenlabs-trace-comparison.test.ts`
- `npm run build`
- `npm run lint`
- `npm test`

Closes #1250

## Summary by Sourcery

Add TypeScript auto-instrumentation support for ElevenLabs text-to-speech APIs and integrate it into the existing OpenLIT instrumentation suite.

New Features:
- Introduce ElevenLabs TypeScript SDK auto-instrumentation for text-to-speech operations, including legacy and current client shapes.
- Record ElevenLabs audio span attributes, inference events, pricing metrics, and optional input/output message content for TTS calls.

Enhancements:
- Extend semantic conventions and instrumentation type definitions to cover ElevenLabs as an AI system and audio-specific request settings.

Documentation:
- Update top-level and TypeScript SDK READMEs to advertise ElevenLabs TypeScript integration support.

Tests:
- Add trace comparison tests for ElevenLabs TypeScript instrumentation to align behavior with existing implementations.