### PR TITLE
[codex] Normalize LangGraph output roles

### DIFF
--- a/sdk/python/src/openlit/instrumentation/langgraph/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/utils.py
@@ -36,6 +36,16 @@ OPERATION_MAP = {
     "node_execute": SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
 }
 
+MESSAGE_ROLE_MAP = {
+    "system": "system",
+    "human": "user",
+    "user": "user",
+    "ai": "assistant",
+    "assistant": "assistant",
+    "tool": "tool",
+    "function": "tool",
+}
+
 
 def set_server_address_and_port(instance, provider_name=None):
     """
@@ -75,6 +85,15 @@ def set_server_address_and_port(instance, provider_name=None):
 def ensure_no_none_values(attributes):
     """Filter out None values from attributes dict."""
     return {k: v for k, v in attributes.items() if v is not None}
+
+
+def normalize_message_role(role):
+    """Map framework-native message roles to OTel GenAI roles."""
+    if role is None:
+        return "unknown"
+
+    normalized_role = str(role).strip().lower()
+    return MESSAGE_ROLE_MAP.get(normalized_role, normalized_role)
 
 
 def extract_messages_from_input(input_data):
@@ -147,13 +166,17 @@ def get_message_role(message):
         str: Role string
     """
     if hasattr(message, "role"):
-        return message.role
+        return normalize_message_role(message.role)
     elif hasattr(message, "type"):
-        return message.type
+        return normalize_message_role(message.type)
     elif hasattr(message, "__class__"):
         # Extract role from class name (e.g., HumanMessage -> human)
         class_name = message.__class__.__name__
-        return class_name.replace("Message", "").lower()
+        for suffix in ("MessageChunk", "Message"):
+            if class_name.endswith(suffix):
+                class_name = class_name[: -len(suffix)]
+                break
+        return normalize_message_role(class_name)
     return "unknown"
 
 
@@ -288,7 +311,7 @@ def extract_llm_info_from_result(span, state, result):
                 if hasattr(last_msg, "content"):
                     content = get_message_content(last_msg)
                     role = get_message_role(last_msg)
-                    if content:
+                    if role == "assistant" and content:
                         otel_msg = [
                             {"role": role, "content": truncate_content(content)}
                         ]
@@ -600,6 +623,8 @@ def _process_invoke_response(span, response, capture_message_content):
                     for msg in messages:
                         content = get_message_content(msg)
                         role = get_message_role(msg)
+                        if role != "assistant":
+                            continue
                         entry = {"role": role}
                         if content:
                             entry["content"] = truncate_content(content)

--- a/sdk/python/src/openlit/instrumentation/langgraph/utils.py
+++ b/sdk/python/src/openlit/instrumentation/langgraph/utils.py
@@ -93,7 +93,7 @@ def normalize_message_role(role):
         return "unknown"
 
     normalized_role = str(role).strip().lower()
-    return MESSAGE_ROLE_MAP.get(normalized_role, normalized_role)
+    return MESSAGE_ROLE_MAP.get(normalized_role, "unknown")
 
 
 def extract_messages_from_input(input_data):
@@ -178,6 +178,26 @@ def get_message_role(message):
                 break
         return normalize_message_role(class_name)
     return "unknown"
+
+
+def build_assistant_output_messages(messages):
+    """Return OTel output messages for assistant-role entries only."""
+    if not isinstance(messages, list):
+        messages = [messages]
+
+    otel_messages = []
+    for msg in messages:
+        role = get_message_role(msg)
+        if role != "assistant":
+            continue
+
+        entry = {"role": role}
+        content = get_message_content(msg)
+        if content:
+            entry["content"] = truncate_content(content)
+        otel_messages.append(entry)
+
+    return otel_messages
 
 
 def set_graph_attributes(span, nodes=None, edges=None):
@@ -308,17 +328,12 @@ def extract_llm_info_from_result(span, state, result):
                                 SemanticConvention.GEN_AI_RESPONSE_ID, metadata["id"]
                             )
 
-                if hasattr(last_msg, "content"):
-                    content = get_message_content(last_msg)
-                    role = get_message_role(last_msg)
-                    if role == "assistant" and content:
-                        otel_msg = [
-                            {"role": role, "content": truncate_content(content)}
-                        ]
-                        span.set_attribute(
-                            SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
-                            json.dumps(otel_msg),
-                        )
+                otel_messages = build_assistant_output_messages(output_messages)
+                if otel_messages:
+                    span.set_attribute(
+                        SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
+                        json.dumps(otel_messages),
+                    )
 
                 # Extract usage_metadata (alternative location)
                 if hasattr(last_msg, "usage_metadata"):
@@ -619,16 +634,7 @@ def _process_invoke_response(span, response, capture_message_content):
                 )
 
                 if capture_message_content:
-                    otel_msgs = []
-                    for msg in messages:
-                        content = get_message_content(msg)
-                        role = get_message_role(msg)
-                        if role != "assistant":
-                            continue
-                        entry = {"role": role}
-                        if content:
-                            entry["content"] = truncate_content(content)
-                        otel_msgs.append(entry)
+                    otel_msgs = build_assistant_output_messages(messages)
                     if otel_msgs:
                         span.set_attribute(
                             SemanticConvention.GEN_AI_OUTPUT_MESSAGES,

--- a/sdk/python/tests/test_langgraph_utils.py
+++ b/sdk/python/tests/test_langgraph_utils.py
@@ -36,6 +36,7 @@ def test_get_message_role_normalizes_langchain_roles():
     assert get_message_role(TypedMessage("human", "hello")) == "user"
     assert get_message_role(TypedMessage("ai", "hi")) == "assistant"
     assert get_message_role(TypedMessage("function", "tool payload")) == "tool"
+    assert get_message_role(TypedMessage("moderator", "custom")) == "unknown"
 
 
 def test_get_message_role_normalizes_message_class_names():
@@ -58,6 +59,37 @@ def test_extract_llm_info_from_result_skips_non_assistant_outputs():
     input_messages = json.loads(span.attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES])
     assert [message["role"] for message in input_messages] == ["user", "system"]
     assert SemanticConvention.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+
+
+def test_extract_llm_info_from_result_keeps_only_assistant_outputs():
+    span = SpanStub()
+    state = {
+        "messages": [
+            TypedMessage("human", "hello"),
+            TypedMessage("system", "follow policy"),
+        ]
+    }
+    result = {
+        "messages": [
+            TypedMessage("human", "user says hi"),
+            TypedMessage("system", "stay in scope"),
+            TypedMessage("ai", "assistant response 1"),
+            TypedMessage("assistant", "assistant response 2"),
+        ]
+    }
+
+    extract_llm_info_from_result(span, state, result)
+
+    input_messages = json.loads(span.attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES])
+    assert [message["role"] for message in input_messages] == ["user", "system"]
+
+    output_messages = json.loads(
+        span.attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES]
+    )
+    assert output_messages == [
+        {"role": "assistant", "content": "assistant response 1"},
+        {"role": "assistant", "content": "assistant response 2"},
+    ]
 
 
 def test_process_invoke_response_keeps_only_assistant_outputs():

--- a/sdk/python/tests/test_langgraph_utils.py
+++ b/sdk/python/tests/test_langgraph_utils.py
@@ -1,0 +1,77 @@
+import json
+
+from openlit.instrumentation.langgraph.utils import (
+    _process_invoke_response,
+    extract_llm_info_from_result,
+    get_message_role,
+)
+from openlit.semcov import SemanticConvention
+
+
+class SpanStub:
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class TypedMessage:
+    def __init__(self, message_type, content):
+        self.type = message_type
+        self.content = content
+
+
+class HumanMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class AIMessageChunk:
+    def __init__(self, content):
+        self.content = content
+
+
+def test_get_message_role_normalizes_langchain_roles():
+    assert get_message_role(TypedMessage("human", "hello")) == "user"
+    assert get_message_role(TypedMessage("ai", "hi")) == "assistant"
+    assert get_message_role(TypedMessage("function", "tool payload")) == "tool"
+
+
+def test_get_message_role_normalizes_message_class_names():
+    assert get_message_role(HumanMessage("hello")) == "user"
+    assert get_message_role(AIMessageChunk("hi")) == "assistant"
+
+
+def test_extract_llm_info_from_result_skips_non_assistant_outputs():
+    span = SpanStub()
+    state = {
+        "messages": [
+            TypedMessage("human", "hello"),
+            TypedMessage("system", "follow policy"),
+        ]
+    }
+    result = {"messages": [TypedMessage("human", "not assistant output")]}
+
+    extract_llm_info_from_result(span, state, result)
+
+    input_messages = json.loads(span.attributes[SemanticConvention.GEN_AI_INPUT_MESSAGES])
+    assert [message["role"] for message in input_messages] == ["user", "system"]
+    assert SemanticConvention.GEN_AI_OUTPUT_MESSAGES not in span.attributes
+
+
+def test_process_invoke_response_keeps_only_assistant_outputs():
+    span = SpanStub()
+    response = {
+        "messages": [
+            TypedMessage("human", "question"),
+            TypedMessage("ai", "answer"),
+        ]
+    }
+
+    _process_invoke_response(span, response, capture_message_content=True)
+
+    output_messages = json.loads(
+        span.attributes[SemanticConvention.GEN_AI_OUTPUT_MESSAGES]
+    )
+    assert output_messages == [{"role": "assistant", "content": "answer"}]


### PR DESCRIPTION
## Summary
- normalize LangGraph message roles to OTel GenAI role names so `human` becomes `user` and `ai` becomes `assistant`
- stop emitting non-assistant LangGraph messages in `gen_ai.output.messages`
- add focused unit coverage for role normalization and output filtering

## Why
LangGraph instrumentation could currently write `HumanMessage` entries into `gen_ai.output.messages`, which conflicts with the OTel GenAI message-role expectations and differs from the existing LangChain role mapping.

## Validation
- `python -m pytest sdk/python/tests/test_langgraph_utils.py -q`
- `python -m pytest sdk/python/tests/test_langgraph.py -q` (skipped because optional `langgraph` test dependency is not installed in this environment)

## Summary by Sourcery

Normalize LangGraph message roles to OpenTelemetry GenAI role conventions and restrict recorded output messages to assistant responses only.

Bug Fixes:
- Prevent non-assistant LangGraph messages from being emitted as GenAI output messages in tracing metadata.

Enhancements:
- Add role normalization for LangGraph messages to align with OTel GenAI and LangChain role naming.
- Filter captured output messages so only assistant-role messages are stored in GenAI output attributes.

Tests:
- Add unit tests covering message role normalization and output message filtering behavior for LangGraph instrumentation.