### PR TITLE
feat(ts-sdk): add manual tracing (startTrace, trace) for Python parity

### DIFF
--- a/docs/latest/sdk/features/tracing.mdx
+++ b/docs/latest/sdk/features/tracing.mdx
@@ -157,6 +157,38 @@ def guess_one_liner(one_liner: str):
         trace.set_result(completion.choices[0].message.content)
 ```
 
+### TypeScript
+
+The TypeScript SDK exposes the same capability. Use `Openlit.startTrace(name, fn)` as the equivalent of Python's `start_trace` context manager (JavaScript has no `with` statement, so it takes a callback) and `@Openlit.trace()` as the equivalent of the `@openlit.trace` decorator. Any auto-instrumented call inside the trace is grouped under one trace ID.
+
+```typescript typescript
+import Openlit from 'openlit';
+
+// Context-manager style: the span is the active context, ends automatically.
+const oneLiner = await Openlit.startTrace('Guess One-liner', async (trace) => {
+  const completion = await client.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: 'Give me a movie one-liner' }],
+  });
+  const result = completion.choices[0].message.content;
+  trace.setResult(result);                  // -> gen_ai.output.messages
+  trace.setMetadata({ 'user.id': 'u123' });  // custom attributes
+  return result;
+});
+
+// Decorator style (requires experimentalDecorators in tsconfig.json):
+class Movies {
+  @Openlit.trace()
+  async generateOneLiner() {
+    const completion = await client.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Give me a movie one-liner' }],
+    });
+    return completion.choices[0].message.content;
+  }
+}
+```
+
 ---
 
 <CardGroup cols={3}>

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -268,6 +268,60 @@ if (!('err' in result)) {
 }
 ```
 
+### Manual Tracing
+
+In addition to auto-instrumentation, you can manually create traces to group custom business logic, multi-step chains, and non-instrumented code into a single trace. This is the TypeScript parity for Python's `openlit.trace` / `openlit.start_trace`.
+
+Any auto-instrumented LLM/vector-DB span created inside a manual trace is automatically nested under it (they share one trace ID).
+
+**`Openlit.startTrace(name, fn)`** — runs `fn` inside a manual span that is set as the active context. The span ends automatically, including on error.
+
+```typescript
+import Openlit from 'openlit';
+
+Openlit.init();
+
+const oneLiner = await Openlit.startTrace('Guess One-liner', async (trace) => {
+  const completion = await client.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: 'Give me a movie one-liner' }],
+  });
+  const result = completion.choices[0].message.content;
+  trace.setResult(result);                 // -> gen_ai.output.messages
+  trace.setMetadata({ 'user.id': 'u123' }); // custom span attributes
+  return result;
+});
+```
+
+**`@Openlit.trace()`** — a method decorator that wraps a method in a manual span named after the method (or a custom name) and records its return value. Requires `experimentalDecorators` in your `tsconfig.json`.
+
+```typescript
+import Openlit from 'openlit';
+
+class Movies {
+  @Openlit.trace()
+  async generateOneLiner() {
+    const completion = await client.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Give me a movie one-liner' }],
+    });
+    return completion.choices[0].message.content;
+  }
+}
+```
+
+**`Openlit.startActiveSpan(name)`** — start a span you end yourself, for cases where wrapping your code in a callback is not possible. Prefer `startTrace` so child spans nest automatically.
+
+```typescript
+const trace = Openlit.startActiveSpan('my-step');
+try {
+  // ... your code ...
+  trace.setResult('done');
+} finally {
+  trace.end();
+}
+```
+
 ## 🌱 Contributing
 
 Whether it's big or small, we love contributions 💚. Check out our [Contribution guide](../../CONTRIBUTING.md) to get started

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -17,6 +17,7 @@ import {
   getCurrentAgentVersion,
 } from './helpers';
 import { runEval, runEvalBatch, fetchEvalTypes } from './evals';
+import { trace as traceDecorator, startTrace, startActiveSpan } from './tracing';
 import Metrics from './otel/metrics';
 import SemanticConvention from './semantic-convention';
 import { parseBoolEnv } from './otel/utils';
@@ -165,6 +166,21 @@ class Openlit extends BaseOpenlit {
   static withAgentVersion = runWithAgentVersion;
   static getAgentVersion = getCurrentAgentVersion;
 
+  /**
+   * Manual tracing helpers (parity with Python's `openlit.trace` /
+   * `openlit.start_trace`). Use these to group custom business logic,
+   * multi-step chains, and non-instrumented code into a single trace.
+   *
+   * - `Openlit.startTrace(name, fn)` — run `fn` inside a manual span that is
+   *   the active context, so auto-instrumented child spans nest under it.
+   * - `@Openlit.trace()` — method decorator that wraps a method in a manual
+   *   span and records its return value.
+   * - `Openlit.startActiveSpan(name)` — start a span you `end()` yourself.
+   */
+  static trace = traceDecorator;
+  static startTrace = startTrace;
+  static startActiveSpan = startActiveSpan;
+
   static init(options?: OpenlitOptions) {
     try {
       diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
@@ -227,6 +243,10 @@ const openlit = Openlit as typeof Openlit & {
 export default openlit;
 export { Openlit, usingAttributes, injectAdditionalAttributes };
 export type { OpenlitOptions } from './types';
+
+// Manual tracing helpers (parity with Python's openlit.trace / start_trace)
+export { startTrace, startActiveSpan, TracedSpan } from './tracing';
+export { trace as traceDecorator } from './tracing';
 
 // Guard re-exports for named imports: import { PII, Pipeline } from 'openlit'
 export {

--- a/sdk/typescript/src/tracing.ts
+++ b/sdk/typescript/src/tracing.ts
@@ -1,0 +1,213 @@
+import {
+  Span,
+  SpanKind,
+  SpanStatusCode,
+  trace as otelTrace,
+} from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from './semantic-convention';
+import OpenlitConfig from './config';
+
+/**
+ * Manual tracing helpers for the OpenLIT TypeScript SDK.
+ *
+ * These mirror the Python SDK's `openlit.trace` decorator and
+ * `openlit.start_trace()` context manager, giving TypeScript users a way to
+ * manually create spans around custom business logic, multi-step chains, and
+ * non-instrumented code. Any auto-instrumented LLM/vector-DB span created
+ * inside the wrapped function is automatically nested under the manual span
+ * (they share one trace ID) because the manual span is set as the active
+ * OpenTelemetry context.
+ */
+
+const TRACER_NAME = 'openlit';
+
+function getTracer() {
+  return otelTrace.getTracer(TRACER_NAME);
+}
+
+/**
+ * A thin wrapper around an OpenTelemetry {@link Span} that provides ergonomic
+ * helpers for recording a manual trace's result and metadata.
+ *
+ * Mirrors Python's `TracedSpan`.
+ */
+export class TracedSpan {
+  private readonly _span: Span;
+
+  constructor(span: Span) {
+    this._span = span;
+  }
+
+  /**
+   * The underlying OpenTelemetry span, exposed for advanced use cases
+   * (e.g. adding events or links directly).
+   */
+  get span(): Span {
+    return this._span;
+  }
+
+  /**
+   * Record the final result of the trace on `gen_ai.output.messages`.
+   * Mirrors Python's `TracedSpan.set_result()`.
+   */
+  setResult(result: unknown): this {
+    const value =
+      typeof result === 'string' ? result : JSON.stringify(result ?? '');
+    this._span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, value);
+    return this;
+  }
+
+  /**
+   * Attach arbitrary custom attributes to the span.
+   * Mirrors Python's `TracedSpan.set_metadata()`.
+   */
+  setMetadata(metadata: Record<string, any>): this {
+    if (metadata) {
+      this._span.setAttributes(metadata);
+    }
+    return this;
+  }
+
+  /**
+   * End the underlying span. Only required when the span was created with
+   * {@link startActiveSpan}; {@link startTrace} ends the span automatically.
+   */
+  end(): void {
+    this._span.end();
+  }
+}
+
+function stampCommonAttributes(span: Span): void {
+  try {
+    if (OpenlitConfig.applicationName) {
+      span.setAttribute(ATTR_SERVICE_NAME, OpenlitConfig.applicationName);
+    }
+    if (OpenlitConfig.environment) {
+      span.setAttribute(
+        SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT,
+        OpenlitConfig.environment
+      );
+    }
+  } catch {
+    // Stamping common attributes must never break the wrapped call.
+  }
+}
+
+/**
+ * Run `fn` inside a new manual span named `name`, returning whatever `fn`
+ * returns. The span is made the active context for the duration of `fn`, so
+ * any auto-instrumented spans created within nest correctly under it and share
+ * one trace ID. The span is ended automatically — including on error, in which
+ * case the exception is recorded and re-thrown.
+ *
+ * This is the TypeScript analogue of Python's `openlit.start_trace()` context
+ * manager, adapted to a callback because JavaScript has no `with` statement.
+ *
+ * @example
+ *   const text = await Openlit.startTrace('Guess One-liner', async (trace) => {
+ *     const completion = await client.chat.completions.create({ ... });
+ *     const out = completion.choices[0].message.content;
+ *     trace.setResult(out);
+ *     return out;
+ *   });
+ */
+export function startTrace<T>(
+  name: string,
+  fn: (trace: TracedSpan) => T | Promise<T>
+): Promise<T> {
+  const tracer = getTracer();
+  return tracer.startActiveSpan(
+    name,
+    { kind: SpanKind.CLIENT },
+    async (span: Span) => {
+      const traced = new TracedSpan(span);
+      stampCommonAttributes(span);
+      try {
+        const result = await fn(traced);
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      } catch (e: any) {
+        span.recordException(e);
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: e?.message ?? String(e),
+        });
+        throw e;
+      } finally {
+        span.end();
+      }
+    }
+  );
+}
+
+/**
+ * Start a manual span and return a {@link TracedSpan} that you must `end()`
+ * yourself. Unlike {@link startTrace}, this does **not** make the span the
+ * active context, so it is best for cases where you cannot wrap your code in a
+ * callback. Prefer {@link startTrace} when possible so that child spans nest
+ * automatically.
+ *
+ * @example
+ *   const trace = Openlit.startActiveSpan('my-step');
+ *   try {
+ *     // ... your code ...
+ *     trace.setResult('done');
+ *   } finally {
+ *     trace.end();
+ *   }
+ */
+export function startActiveSpan(name: string): TracedSpan {
+  const span = getTracer().startSpan(name, { kind: SpanKind.CLIENT });
+  stampCommonAttributes(span);
+  return new TracedSpan(span);
+}
+
+/**
+ * Method decorator that wraps the decorated method in a manual span named
+ * after the method (or `name`, when provided). Mirrors Python's
+ * `@openlit.trace` decorator: any auto-instrumented call inside the method is
+ * grouped under a single trace. The return value is recorded on
+ * `gen_ai.output.messages`.
+ *
+ * Works with both synchronous and async methods.
+ *
+ * @example
+ *   class Movies {
+ *     @trace()
+ *     async generateOneLiner() {
+ *       return (await client.chat.completions.create({ ... }))
+ *         .choices[0].message.content;
+ *     }
+ *   }
+ */
+export function trace(name?: string) {
+  return function (
+    _target: any,
+    propertyKey: string | symbol,
+    descriptor: PropertyDescriptor
+  ): PropertyDescriptor {
+    const original = descriptor.value;
+    if (typeof original !== 'function') {
+      throw new TypeError(
+        '@trace can only be applied to methods, got ' + typeof original
+      );
+    }
+    const spanName = name ?? String(propertyKey);
+
+    descriptor.value = function (this: any, ...args: any[]) {
+      return startTrace(spanName, async (traced) => {
+        const response = await original.apply(this, args);
+        try {
+          traced.setResult(response ?? '');
+          traced.span.setAttribute('function.args', JSON.stringify(args));
+        } catch {
+          // Recording the result/args must never break the wrapped call.
+        }
+        return response;
+      });
+    };
+
+    return descriptor;
+  };
+}


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add manual tracing capabilities to the TypeScript SDK to match Python’s tracing features and update documentation accordingly.

New Features:
- Expose manual tracing APIs in the TypeScript SDK, including startTrace, startActiveSpan, and a trace method decorator for wrapping custom logic in spans.
- Provide a TracedSpan helper for setting trace results and metadata on OpenTelemetry spans and re-export these helpers from the main TypeScript SDK entrypoint.

Documentation:
- Document manual tracing usage for the TypeScript SDK in the SDK README and tracing feature docs, including examples for startTrace and the trace decorator.