### PR TITLE
feat(typescript): add ElevenLabs auto-instrumentation

### DIFF
--- a/sdk/typescript/src/instrumentation/elevenlabs/index.ts
+++ b/sdk/typescript/src/instrumentation/elevenlabs/index.ts
@@ -1,0 +1,90 @@
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import ElevenLabsWrapper from './wrapper';
+
+export interface ElevenLabsInstrumentationConfig extends InstrumentationConfig {}
+
+export default class OpenlitElevenLabsInstrumentation extends InstrumentationBase {
+  constructor(config: ElevenLabsInstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-elevenlabs`, '1.0.0', config);
+  }
+
+  protected init(): void | InstrumentationModuleDefinition | InstrumentationModuleDefinition[] {
+    const module = new InstrumentationNodeModuleDefinition(
+      'elevenlabs',
+      ['>=1.4.0'],
+      (moduleExports) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports) => {
+        if (moduleExports !== undefined) {
+          this._unpatch(moduleExports);
+        }
+      }
+    );
+    return [module];
+  }
+
+  public manualPatch(elevenlabs: any): void {
+    this._patch(elevenlabs);
+  }
+
+  protected _patch(moduleExports: any) {
+    try {
+      // ElevenLabsClient exposes textToSpeech as an instance property.
+      // Get the prototype via a dummy instance (no API calls at construction time).
+      const ClientClass = moduleExports.ElevenLabsClient;
+      if (!ClientClass) return;
+
+      const dummy = new ClientClass({ apiKey: 'dummy' });
+
+      // textToSpeech.convert — the primary TTS method
+      const ttsProto = dummy.textToSpeech ? Object.getPrototypeOf(dummy.textToSpeech) : null;
+      if (ttsProto && typeof ttsProto.convert === 'function') {
+        if (isWrapped(ttsProto.convert)) {
+          this._unwrap(ttsProto, 'convert');
+        }
+        this._wrap(ttsProto, 'convert', ElevenLabsWrapper._patchTextToSpeechConvert(this.tracer));
+      }
+
+      // generate — alternative top-level method on some SDK versions
+      if (typeof ClientClass.prototype.generate === 'function') {
+        if (isWrapped(ClientClass.prototype.generate)) {
+          this._unwrap(ClientClass.prototype, 'generate');
+        }
+        this._wrap(
+          ClientClass.prototype,
+          'generate',
+          ElevenLabsWrapper._patchGenerate(this.tracer)
+        );
+      }
+    } catch (e) {
+      console.error('Error in ElevenLabs _patch method:', e);
+    }
+  }
+
+  protected _unpatch(moduleExports: any) {
+    try {
+      const ClientClass = moduleExports.ElevenLabsClient;
+      if (!ClientClass) return;
+
+      const dummy = new ClientClass({ apiKey: 'dummy' });
+      const ttsProto = dummy.textToSpeech ? Object.getPrototypeOf(dummy.textToSpeech) : null;
+      if (ttsProto && isWrapped(ttsProto.convert)) {
+        this._unwrap(ttsProto, 'convert');
+      }
+      if (isWrapped(ClientClass.prototype.generate)) {
+        this._unwrap(ClientClass.prototype, 'generate');
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/sdk/typescript/src/instrumentation/elevenlabs/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/elevenlabs/wrapper.ts
@@ -1,0 +1,236 @@
+import { Span, SpanKind, Tracer, context, trace, Attributes } from '@opentelemetry/api';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import BaseWrapper from '../base-wrapper';
+
+function spanCreationAttrs(requestModel: string): Attributes {
+  return {
+    [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO,
+    [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_ELEVENLABS,
+    [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+    [SemanticConvention.SERVER_ADDRESS]: ElevenLabsWrapper.serverAddress,
+    [SemanticConvention.SERVER_PORT]: ElevenLabsWrapper.serverPort,
+  };
+}
+
+class ElevenLabsWrapper extends BaseWrapper {
+  static aiSystem = SemanticConvention.GEN_AI_SYSTEM_ELEVENLABS;
+  static serverAddress = 'api.elevenlabs.io';
+  static serverPort = 443;
+
+  /**
+   * Patch `client.textToSpeech.convert(voiceId, params)`.
+   * Signature: convert(voice_id: string, params: { text, model_id?, output_format?, voice_settings?, ... })
+   */
+  static _patchTextToSpeechConvert(tracer: Tracer): any {
+    const genAIEndpoint = 'elevenlabs.text_to_speech';
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        // args[0] = voiceId (string), args[1] = params object
+        const voiceId: string = typeof args[0] === 'string' ? args[0] : '';
+        const params: any = args[1] || {};
+        const requestModel: string =
+          params.model_id || params.model || 'eleven_multilingual_v2';
+
+        const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO} ${requestModel}`;
+        const effectiveCtx = context.active();
+        const span = tracer.startSpan(
+          spanName,
+          { kind: SpanKind.CLIENT, attributes: spanCreationAttrs(requestModel) },
+          effectiveCtx
+        );
+
+        return context
+          .with(trace.setSpan(effectiveCtx, span), () => originalMethod.apply(this, args))
+          .then((response: any) =>
+            ElevenLabsWrapper._handleAudioResponse({
+              span,
+              genAIEndpoint,
+              voiceId,
+              params,
+              requestModel,
+              response,
+            })
+          )
+          .catch((e: any) => {
+            OpenLitHelper.handleException(span, e);
+            BaseWrapper.recordMetrics(span, {
+              genAIEndpoint,
+              model: requestModel,
+              aiSystem: ElevenLabsWrapper.aiSystem,
+              serverAddress: ElevenLabsWrapper.serverAddress,
+              serverPort: ElevenLabsWrapper.serverPort,
+              errorType: e?.constructor?.name || '_OTHER',
+            });
+            span.end();
+            throw e;
+          });
+      };
+    };
+  }
+
+  /**
+   * Patch `client.generate({ text, voice, model, ... })`.
+   * Older / convenience API on the client itself.
+   */
+  static _patchGenerate(tracer: Tracer): any {
+    const genAIEndpoint = 'elevenlabs.generate';
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const params: any = args[0] || {};
+        const voiceId: string =
+          typeof params.voice === 'string'
+            ? params.voice
+            : typeof params.voice_id === 'string'
+            ? params.voice_id
+            : '';
+        const requestModel: string =
+          params.model || params.model_id || 'eleven_multilingual_v2';
+
+        const spanName = `${SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO} ${requestModel}`;
+        const effectiveCtx = context.active();
+        const span = tracer.startSpan(
+          spanName,
+          { kind: SpanKind.CLIENT, attributes: spanCreationAttrs(requestModel) },
+          effectiveCtx
+        );
+
+        return context
+          .with(trace.setSpan(effectiveCtx, span), () => originalMethod.apply(this, args))
+          .then((response: any) =>
+            ElevenLabsWrapper._handleAudioResponse({
+              span,
+              genAIEndpoint,
+              voiceId,
+              params,
+              requestModel,
+              response,
+            })
+          )
+          .catch((e: any) => {
+            OpenLitHelper.handleException(span, e);
+            BaseWrapper.recordMetrics(span, {
+              genAIEndpoint,
+              model: requestModel,
+              aiSystem: ElevenLabsWrapper.aiSystem,
+              serverAddress: ElevenLabsWrapper.serverAddress,
+              serverPort: ElevenLabsWrapper.serverPort,
+              errorType: e?.constructor?.name || '_OTHER',
+            });
+            span.end();
+            throw e;
+          });
+      };
+    };
+  }
+
+  static async _handleAudioResponse({
+    span,
+    genAIEndpoint,
+    voiceId,
+    params,
+    requestModel,
+    response,
+  }: {
+    span: Span;
+    genAIEndpoint: string;
+    voiceId: string;
+    params: any;
+    requestModel: string;
+    response: any;
+  }): Promise<any> {
+    let metricParams;
+    try {
+      const captureContent = OpenlitConfig.captureMessageContent;
+      const text: string = params.text || params.input || '';
+      const outputFormat: string = params.output_format || params.outputFormat || 'mp3_44100_128';
+      const voiceSettings = params.voice_settings || params.voiceSettings;
+
+      // Audio cost is based on character count (same as Python: get_audio_model_cost)
+      const pricingInfo = OpenlitConfig.pricingInfo || {};
+      const cost = OpenLitHelper.getAudioModelCost(requestModel, pricingInfo, text);
+
+      ElevenLabsWrapper.setBaseSpanAttributes(span, {
+        genAIEndpoint,
+        model: requestModel,
+        cost,
+        aiSystem: ElevenLabsWrapper.aiSystem,
+        serverAddress: ElevenLabsWrapper.serverAddress,
+        serverPort: ElevenLabsWrapper.serverPort,
+      });
+
+      // Request attributes
+      if (voiceId) {
+        span.setAttribute(SemanticConvention.GEN_AI_REQUEST_AUDIO_VOICE, voiceId);
+      }
+      if (voiceSettings) {
+        span.setAttribute(
+          SemanticConvention.GEN_AI_REQUEST_AUDIO_SETTINGS,
+          JSON.stringify(voiceSettings)
+        );
+      }
+      span.setAttribute(SemanticConvention.GEN_AI_REQUEST_IS_STREAM, false);
+
+      // Response attributes
+      span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, outputFormat);
+      span.setAttribute(SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, 0);
+      span.setAttribute(SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, 0);
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON, ['stop']);
+      span.setAttribute(SemanticConvention.GEN_AI_RESPONSE_MODEL, requestModel);
+
+      // Content capture
+      let inputMessagesJson: string | undefined;
+      let outputMessagesJson: string | undefined;
+      if (captureContent) {
+        inputMessagesJson = OpenLitHelper.buildInputMessages([
+          { role: 'user', content: text },
+        ]);
+        outputMessagesJson = OpenLitHelper.buildOutputMessages('[audio generated]', 'stop');
+        span.setAttribute(SemanticConvention.GEN_AI_INPUT_MESSAGES, inputMessagesJson);
+        span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES, outputMessagesJson);
+      }
+
+      // Emit inference event
+      if (!OpenlitConfig.disableEvents) {
+        const eventAttrs: Attributes = {
+          [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AUDIO,
+          [SemanticConvention.GEN_AI_REQUEST_MODEL]: requestModel,
+          [SemanticConvention.GEN_AI_RESPONSE_MODEL]: requestModel,
+          [SemanticConvention.SERVER_ADDRESS]: ElevenLabsWrapper.serverAddress,
+          [SemanticConvention.SERVER_PORT]: ElevenLabsWrapper.serverPort,
+          [SemanticConvention.GEN_AI_OUTPUT_TYPE]: outputFormat,
+          [SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS]: 0,
+          [SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS]: 0,
+          [SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON]: ['stop'],
+        };
+        if (captureContent) {
+          if (inputMessagesJson) eventAttrs[SemanticConvention.GEN_AI_INPUT_MESSAGES] = inputMessagesJson;
+          if (outputMessagesJson) eventAttrs[SemanticConvention.GEN_AI_OUTPUT_MESSAGES] = outputMessagesJson;
+        }
+        OpenLitHelper.emitInferenceEvent(span, eventAttrs);
+      }
+
+      metricParams = {
+        genAIEndpoint,
+        model: requestModel,
+        cost,
+        aiSystem: ElevenLabsWrapper.aiSystem,
+        serverAddress: ElevenLabsWrapper.serverAddress,
+        serverPort: ElevenLabsWrapper.serverPort,
+      };
+
+      return response;
+    } catch (e: any) {
+      OpenLitHelper.handleException(span, e);
+      throw e;
+    } finally {
+      span.end();
+      if (metricParams) {
+        BaseWrapper.recordMetrics(span, metricParams);
+      }
+    }
+  }
+}
+
+export default ElevenLabsWrapper;

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -31,6 +31,7 @@ import ClaudeAgentSDKInstrumentation from './claude-agent-sdk';
 import CursorSDKInstrumentation from './cursor-sdk';
 import AstraInstrumentation from './astra';
 import MCPInstrumentation from './mcp';
+import ElevenLabsInstrumentation from './elevenlabs';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -104,6 +105,7 @@ export default class Instrumentations {
     'cursor-sdk': new CursorSDKInstrumentation(),
     'astra': new AstraInstrumentation(),
     mcp: new MCPInstrumentation(),
+    elevenlabs: new ElevenLabsInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -87,6 +87,7 @@ export default class SemanticConvention {
   static GEN_AI_REQUEST_AUDIO_VOICE = 'gen_ai.request.audio_voice';
   static GEN_AI_REQUEST_AUDIO_RESPONSE_FORMAT = 'gen_ai.request.audio_response_format';
   static GEN_AI_REQUEST_AUDIO_SPEED = 'gen_ai.request.audio_speed';
+  static GEN_AI_REQUEST_AUDIO_SETTINGS = 'gen_ai.request.audio_settings';
   static GEN_AI_REQUEST_FINETUNE_STATUS = 'gen_ai.request.fine_tune_status';
   static GEN_AI_REQUEST_FINETUNE_MODEL_SUFFIX = 'gen_ai.request.fine_tune_model_suffix';
   static GEN_AI_REQUEST_FINETUNE_MODEL_EPOCHS = 'gen_ai.request.fine_tune_n_epochs';
@@ -245,6 +246,9 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_STRANDS = 'strands_agents';
   static GEN_AI_SYSTEM_CURSOR = 'cursor';
   static GEN_AI_SYSTEM_MCP = 'mcp';
+  static GEN_AI_SYSTEM_ELEVENLABS = 'elevenlabs';
+  static GEN_AI_SYSTEM_MEM0 = 'mem0';
+  static GEN_AI_SYSTEM_TRANSFORMERS = 'huggingface';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types
@@ -440,6 +444,8 @@ export default class SemanticConvention {
   static DB_SYSTEM_QDRANT = 'qdrant';
   static DB_SYSTEM_MILVUS = 'milvus';
   static DB_SYSTEM_ASTRA = 'astra';
+  static DB_SYSTEM_POSTGRESQL = 'postgresql';
+  static DB_SYSTEM_MEM0 = 'mem0';
   static DB_COLLECTION_NAME = 'db.collection.name';
   static DB_OPERATION = 'db.operation';
   static DB_OPERATION_NAME = 'db.operation.name';
@@ -459,6 +465,14 @@ export default class SemanticConvention {
   static DB_OPERATION_SELECT = 'SELECT';
   static DB_OPERATION_REPLACE = 'findAndModify';
   static DB_OPERATION_FIND_AND_DELETE = 'findAndDelete';
+  static DB_OPERATION_CREATE = 'CREATE';
+  static DB_OPERATION_ALTER = 'ALTER';
+  static DB_OPERATION_DROP = 'DROP';
+  static DB_OPERATION_TRUNCATE = 'TRUNCATE';
+  static DB_OPERATION_COMMIT = 'COMMIT';
+  static DB_OPERATION_ROLLBACK = 'ROLLBACK';
+  static DB_OPERATION_COPY = 'COPY';
+  static DB_TABLE_NAME = 'db.sql.table';
   static DB_ID_COUNT = 'db.ids_count';
   static DB_VECTOR_COUNT = 'db.vector.count';
   static DB_METADATA_COUNT = 'db.metadatas_count';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp' | 'elevenlabs';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
Closes #1250

## Summary

- Adds TypeScript auto-instrumentation for the ElevenLabs JS SDK (`elevenlabs` npm package), achieving parity with the Python SDK instrumentation
- New `sdk/typescript/src/instrumentation/elevenlabs/` directory with `index.ts` (OTel `InstrumentationBase` subclass) and `wrapper.ts` (span/metric logic)
- Wraps `ElevenLabsClient.textToSpeech.convert` (primary TTS path in SDK ≥ 1.4.0) and `ElevenLabsClient.generate` (convenience API on older versions)
- Captures: model, `gen_ai.request.audio_voice`, `gen_ai.request.audio_settings`, output format, cost (via `getAudioModelCost`), and input/output messages when `captureMessageContent` is enabled
- Emits OTel inference event with audio operation attributes
- Adds new semantic convention constants: `GEN_AI_SYSTEM_ELEVENLABS`, `GEN_AI_REQUEST_AUDIO_SETTINGS`, `GEN_AI_SYSTEM_MEM0`, `GEN_AI_SYSTEM_TRANSFORMERS`, `DB_SYSTEM_POSTGRESQL`, `DB_SYSTEM_MEM0` and SQL operation constants
- Registers `elevenlabs` in `InstrumentationType` union and `Instrumentations.availableInstrumentations`

## Pattern

Follows the exact same structure as existing instrumentors (`huggingface`, `mistral`):
- Zero provider dependencies (duck-typed, no static imports)
- `SpanKind.CLIENT` with the 5 required creation-time attributes
- `setBaseSpanAttributes` + `recordMetrics` via `BaseWrapper`
- `handleException` on errors

## Test plan

- [ ] Verify `new ElevenLabsClient({ apiKey })` call with `textToSpeech.convert` produces a span with `gen_ai.system = elevenlabs` and `gen_ai.operation.name = audio`
- [ ] Verify span includes `gen_ai.request.audio_voice`, `gen_ai.output.type` (output format), `gen_ai.usage.cost`
- [ ] Verify `captureMessageContent = true` captures input text and `[audio generated]` output message
- [ ] Verify errors are recorded correctly and span is ended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add OpenTelemetry-based auto-instrumentation for the ElevenLabs TypeScript SDK and extend telemetry semantic conventions for audio and database operations.

New Features:
- Introduce ElevenLabs TypeScript instrumentation that wraps ElevenLabsClient text-to-speech and generate APIs to produce spans, metrics, and inference events.
- Capture ElevenLabs audio request metadata including model, voice, audio settings, output format, cost, and optional input/output message content.

Enhancements:
- Expand semantic convention constants with ElevenLabs, Mem0, and Transformers gen AI system identifiers and richer audio request attributes.
- Augment database semantic conventions with PostgreSQL and Mem0 systems plus additional SQL operation and table name constants.
- Register the ElevenLabs instrumentation in the global instrumentation registry and type union for availability in configuration.