### PR TITLE
feat(typescript): add Mem0 memory layer auto-instrumentation

### DIFF
--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -31,6 +31,7 @@ import ClaudeAgentSDKInstrumentation from './claude-agent-sdk';
 import CursorSDKInstrumentation from './cursor-sdk';
 import AstraInstrumentation from './astra';
 import MCPInstrumentation from './mcp';
+import Mem0Instrumentation from './mem0';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -104,6 +105,7 @@ export default class Instrumentations {
     'cursor-sdk': new CursorSDKInstrumentation(),
     'astra': new AstraInstrumentation(),
     mcp: new MCPInstrumentation(),
+    mem0: new Mem0Instrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/instrumentation/mem0/index.ts
+++ b/sdk/typescript/src/instrumentation/mem0/index.ts
@@ -1,0 +1,88 @@
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import SemanticConvention from '../../semantic-convention';
+import Mem0Wrapper from './wrapper';
+
+export interface Mem0InstrumentationConfig extends InstrumentationConfig {}
+
+export default class OpenlitMem0Instrumentation extends InstrumentationBase {
+  constructor(config: Mem0InstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-mem0`, '1.0.0', config);
+  }
+
+  protected init(): void | InstrumentationModuleDefinition | InstrumentationModuleDefinition[] {
+    const module = new InstrumentationNodeModuleDefinition(
+      'mem0ai',
+      ['>=0.1.32'],
+      (moduleExports) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports) => {
+        if (moduleExports !== undefined) {
+          this._unpatch(moduleExports);
+        }
+      }
+    );
+    return [module];
+  }
+
+  public manualPatch(mem0: any): void {
+    this._patch(mem0);
+  }
+
+  protected _patch(moduleExports: any) {
+    try {
+      // MemoryClient is the primary API-based client for the mem0ai npm package.
+      const MemoryClient = moduleExports.MemoryClient;
+      if (!MemoryClient?.prototype) return;
+
+      const methods: Array<[string, string]> = [
+        ['add', SemanticConvention.DB_OPERATION_ADD],
+        ['search', SemanticConvention.DB_OPERATION_SEARCH],
+        ['get', SemanticConvention.DB_OPERATION_GET],
+        ['getAll', SemanticConvention.DB_OPERATION_FETCH],
+        ['update', SemanticConvention.DB_OPERATION_UPDATE],
+        ['delete', SemanticConvention.DB_OPERATION_DELETE],
+        ['deleteAll', SemanticConvention.DB_OPERATION_DELETE],
+        ['history', SemanticConvention.DB_OPERATION_FETCH],
+        ['reset', SemanticConvention.DB_OPERATION_DELETE],
+      ];
+
+      for (const [method, dbOp] of methods) {
+        if (typeof MemoryClient.prototype[method] === 'function') {
+          if (isWrapped(MemoryClient.prototype[method])) {
+            this._unwrap(MemoryClient.prototype, method);
+          }
+          this._wrap(
+            MemoryClient.prototype,
+            method,
+            Mem0Wrapper._patchMethod(this.tracer, method, dbOp)
+          );
+        }
+      }
+    } catch (e) {
+      console.error('Error in Mem0 _patch method:', e);
+    }
+  }
+
+  protected _unpatch(moduleExports: any) {
+    try {
+      const MemoryClient = moduleExports.MemoryClient;
+      if (!MemoryClient?.prototype) return;
+      for (const method of ['add', 'search', 'get', 'getAll', 'update', 'delete', 'deleteAll', 'history', 'reset']) {
+        if (typeof MemoryClient.prototype[method] === 'function') {
+          this._unwrap(MemoryClient.prototype, method);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/sdk/typescript/src/instrumentation/mem0/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/mem0/wrapper.ts
@@ -1,0 +1,187 @@
+import { SpanKind, Tracer, context, trace } from '@opentelemetry/api';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import { SDK_NAME, SDK_VERSION } from '../../constant';
+import { applyCustomSpanAttributes } from '../../helpers';
+import { SpanStatusCode } from '@opentelemetry/api';
+
+class Mem0Wrapper {
+  static dbSystem = SemanticConvention.DB_SYSTEM_MEM0;
+  static serverAddress = 'api.mem0.ai';
+  static serverPort = 443;
+
+  /**
+   * Set common attributes on a Mem0 span.
+   */
+  static _setCommonAttributes(span: any, dbOperation: string) {
+    const applicationName = OpenlitConfig.applicationName || '';
+    const environment = OpenlitConfig.environment || '';
+
+    span.setAttribute(ATTR_TELEMETRY_SDK_NAME, SDK_NAME);
+    span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, SDK_VERSION);
+    span.setAttribute(SemanticConvention.DB_SYSTEM_NAME, Mem0Wrapper.dbSystem);
+    span.setAttribute(SemanticConvention.DB_OPERATION_NAME, dbOperation);
+    span.setAttribute(SemanticConvention.SERVER_ADDRESS, Mem0Wrapper.serverAddress);
+    span.setAttribute(SemanticConvention.SERVER_PORT, Mem0Wrapper.serverPort);
+    span.setAttribute(SemanticConvention.GEN_AI_ENVIRONMENT, environment);
+    span.setAttribute(SemanticConvention.GEN_AI_APPLICATION_NAME, applicationName);
+    span.setAttribute(ATTR_SERVICE_NAME, applicationName);
+    span.setAttribute(SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT, environment);
+    applyCustomSpanAttributes(span);
+  }
+
+  /**
+   * Patch a MemoryClient method (add, search, get, etc.).
+   *
+   * Span name: `<operation> mem0` (e.g. "ADD mem0", "SEARCH mem0")
+   *
+   * args[0] is typically the payload (messages/query/memory_id/…).
+   */
+  static _patchMethod(tracer: Tracer, methodName: string, dbOperation: string): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const spanName = `${dbOperation} mem0`;
+        const span = tracer.startSpan(spanName, { kind: SpanKind.CLIENT });
+        const startTime = Date.now();
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            const response = await originalMethod.apply(this, args);
+            const duration = (Date.now() - startTime) / 1000;
+
+            Mem0Wrapper._setCommonAttributes(span, dbOperation);
+            span.setAttribute(SemanticConvention.DB_CLIENT_OPERATION_DURATION, duration);
+
+            // Operation-specific attributes
+            const params: any = args[0] || {};
+            switch (methodName) {
+              case 'add': {
+                // add(messages, { user_id?, agent_id?, run_id?, metadata?, ... })
+                const opts: any = args[1] || {};
+                if (opts.user_id) span.setAttribute('mem0.user_id', opts.user_id);
+                if (opts.agent_id) span.setAttribute('mem0.agent_id', opts.agent_id);
+                if (opts.run_id) span.setAttribute('mem0.run_id', opts.run_id);
+                const msgCount = Array.isArray(params) ? params.length : (params ? 1 : 0);
+                span.setAttribute(SemanticConvention.DB_DOCUMENTS_COUNT, msgCount);
+                const returnedCount = Array.isArray(response?.results)
+                  ? response.results.length
+                  : (response ? 1 : 0);
+                span.setAttribute(SemanticConvention.DB_N_RESULTS, returnedCount);
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 messages=${msgCount}`
+                );
+                if (OpenlitConfig.captureMessageContent && params) {
+                  span.setAttribute(
+                    SemanticConvention.DB_QUERY_TEXT,
+                    typeof params === 'string' ? params : JSON.stringify(params)
+                  );
+                }
+                break;
+              }
+              case 'search': {
+                // search(query, { user_id?, agent_id?, run_id?, limit?, filters?, ... })
+                const opts: any = args[1] || {};
+                const query: string = typeof params === 'string' ? params : JSON.stringify(params);
+                span.setAttribute(SemanticConvention.DB_VECTOR_QUERY_TOP_K, opts.limit || 10);
+                if (opts.user_id) span.setAttribute('mem0.user_id', opts.user_id);
+                if (opts.agent_id) span.setAttribute('mem0.agent_id', opts.agent_id);
+                if (opts.run_id) span.setAttribute('mem0.run_id', opts.run_id);
+                if (opts.filters) {
+                  span.setAttribute(SemanticConvention.DB_FILTER, JSON.stringify(opts.filters));
+                }
+                const resultCount = Array.isArray(response?.results)
+                  ? response.results.length
+                  : (Array.isArray(response) ? response.length : 0);
+                span.setAttribute(SemanticConvention.DB_N_RESULTS, resultCount);
+                if (OpenlitConfig.captureMessageContent) {
+                  span.setAttribute(SemanticConvention.DB_QUERY_TEXT, query);
+                }
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 limit=${opts.limit || 10}`
+                );
+                break;
+              }
+              case 'get': {
+                // get(memory_id)
+                const memoryId: string = typeof params === 'string' ? params : JSON.stringify(params);
+                span.setAttribute(SemanticConvention.DB_ID_COUNT, 1);
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 id=${memoryId}`
+                );
+                break;
+              }
+              case 'getAll': {
+                // getAll({ user_id?, agent_id?, run_id?, ... })
+                if (params.user_id) span.setAttribute('mem0.user_id', params.user_id);
+                if (params.agent_id) span.setAttribute('mem0.agent_id', params.agent_id);
+                if (params.run_id) span.setAttribute('mem0.run_id', params.run_id);
+                const returnedRows = Array.isArray(response?.results)
+                  ? response.results.length
+                  : (Array.isArray(response) ? response.length : 0);
+                span.setAttribute(SemanticConvention.DB_RESPONSE_RETURNED_ROWS, returnedRows);
+                span.setAttribute(SemanticConvention.DB_QUERY_SUMMARY, `${dbOperation} mem0`);
+                break;
+              }
+              case 'update': {
+                // update(memory_id, data)
+                const memoryId: string = typeof params === 'string' ? params : JSON.stringify(params);
+                span.setAttribute(SemanticConvention.DB_ID_COUNT, 1);
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 id=${memoryId}`
+                );
+                break;
+              }
+              case 'delete': {
+                // delete(memory_id)
+                const memoryId: string = typeof params === 'string' ? params : JSON.stringify(params);
+                span.setAttribute(SemanticConvention.DB_ID_COUNT, 1);
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 id=${memoryId}`
+                );
+                break;
+              }
+              case 'deleteAll':
+              case 'reset': {
+                // deleteAll({ user_id?, agent_id?, run_id? }) / reset()
+                if (params.user_id) span.setAttribute('mem0.user_id', params.user_id);
+                if (params.agent_id) span.setAttribute('mem0.agent_id', params.agent_id);
+                if (params.run_id) span.setAttribute('mem0.run_id', params.run_id);
+                span.setAttribute(SemanticConvention.DB_QUERY_SUMMARY, `${dbOperation} mem0`);
+                break;
+              }
+              case 'history': {
+                // history(memory_id)
+                const memoryId: string = typeof params === 'string' ? params : JSON.stringify(params);
+                span.setAttribute(SemanticConvention.DB_ID_COUNT, 1);
+                const returnedRows = Array.isArray(response) ? response.length : 0;
+                span.setAttribute(SemanticConvention.DB_RESPONSE_RETURNED_ROWS, returnedRows);
+                span.setAttribute(
+                  SemanticConvention.DB_QUERY_SUMMARY,
+                  `${dbOperation} mem0 id=${memoryId}`
+                );
+                break;
+              }
+            }
+
+            span.setStatus({ code: SpanStatusCode.OK });
+            return response;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+}
+
+export default Mem0Wrapper;

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -245,6 +245,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_STRANDS = 'strands_agents';
   static GEN_AI_SYSTEM_CURSOR = 'cursor';
   static GEN_AI_SYSTEM_MCP = 'mcp';
+  static GEN_AI_SYSTEM_MEM0 = 'mem0';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types
@@ -440,6 +441,7 @@ export default class SemanticConvention {
   static DB_SYSTEM_QDRANT = 'qdrant';
   static DB_SYSTEM_MILVUS = 'milvus';
   static DB_SYSTEM_ASTRA = 'astra';
+  static DB_SYSTEM_MEM0 = 'mem0';
   static DB_COLLECTION_NAME = 'db.collection.name';
   static DB_OPERATION = 'db.operation';
   static DB_OPERATION_NAME = 'db.operation.name';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp' | 'mem0';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
Closes #1246

## Summary

- Adds TypeScript auto-instrumentation for the Mem0 JS SDK (`mem0ai` npm package), achieving parity with the Python SDK instrumentation
- New `sdk/typescript/src/instrumentation/mem0/` directory with `index.ts` (OTel `InstrumentationBase` subclass) and `wrapper.ts` (span/metric logic)
- Wraps all `MemoryClient` operations: `add`, `search`, `get`, `getAll`, `update`, `delete`, `deleteAll`, `history`, `reset`
- Each operation produces a `SpanKind.CLIENT` span with operation-specific attributes:
  - **add**: message count, result count, optional query text (captureMessageContent)
  - **search**: top-k limit, filters, result count, optional query text
  - **get/update/delete**: memory ID and count
  - **getAll/history**: returned row count, user/agent/run scope identifiers
- Adds `GEN_AI_SYSTEM_MEM0 = 'mem0'` and `DB_SYSTEM_MEM0 = 'mem0'` to `semantic-convention.ts`
- Registers `mem0` in `InstrumentationType` union and `Instrumentations.availableInstrumentations`

## Pattern

Follows the exact same DB-span pattern as existing vector store instrumentors (`chroma`, `qdrant`, `milvus`, `astra`):
- Zero provider dependencies (duck-typed, no static imports)
- `SpanKind.CLIENT` with `db.system.name`, `db.operation.name`, server address/port
- `db.client.operation.duration` recorded on every span
- `handleException` + span.end on errors

## Test plan

- [ ] Verify `new MemoryClient(...)` with `.add(messages, opts)` produces a span `ADD mem0` with `db.system.name = mem0`
- [ ] Verify `.search(query, opts)` span includes `db.vector.query.top_k`, `db.n_results`, `db.filter` (when set)
- [ ] Verify `.get(id)` / `.delete(id)` spans include `db.ids_count = 1`
- [ ] Verify `captureMessageContent = true` captures query text on add/search spans
- [ ] Verify errors produce correct span status and `error.type` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add OpenTelemetry-based auto-instrumentation for the Mem0 TypeScript SDK and register Mem0 as a first-class telemetry system.

New Features:
- Introduce Mem0 auto-instrumentation for the `mem0ai` TypeScript SDK, wrapping `MemoryClient` operations to emit client spans with rich DB and gen-ai attributes.

Enhancements:
- Add Mem0 entries to semantic conventions and register `mem0` in the instrumentation type system and global instrumentation registry.