### PR TITLE
feat(typescript): add Agno framework auto-instrumentation

### DIFF
--- a/sdk/typescript/src/instrumentation/__tests__/agno-wrapper.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/agno-wrapper.test.ts
@@ -1,0 +1,143 @@
+import { SpanKind } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import AgnoWrapper from '../agno/wrapper';
+
+jest.mock('../../config');
+jest.mock('../../helpers', () => ({
+  __esModule: true,
+  default: { handleException: jest.fn() },
+  applyCustomSpanAttributes: jest.fn(),
+}));
+
+describe('AgnoWrapper', () => {
+  let mockSpan: any;
+  let mockTracer: any;
+
+  beforeEach(() => {
+    mockSpan = {
+      setAttribute: jest.fn(),
+      setStatus: jest.fn(),
+      end: jest.fn(),
+      spanContext: jest.fn(() => ({ traceId: 'abc', spanId: 'def', traceFlags: 1 })),
+    };
+    mockTracer = { startSpan: jest.fn(() => mockSpan) };
+
+    (OpenlitConfig as any).environment = 'test';
+    (OpenlitConfig as any).applicationName = 'agno-test';
+    (OpenlitConfig as any).captureMessageContent = false;
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function attrs(span = mockSpan): Record<string, any> {
+    return Object.fromEntries((span.setAttribute as jest.Mock).mock.calls);
+  }
+
+  describe('patchAgentRun', () => {
+    it('emits invoke_agent span with correct provider and operation attributes', async () => {
+      class StubAgent {
+        name = 'my-agent';
+        async run() { return { content: 'hello' }; }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgnoWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+      await wrapped.call(agent, 'test input');
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        expect.stringContaining('invoke_agent'),
+        expect.objectContaining({
+          kind: SpanKind.CLIENT,
+          attributes: expect.objectContaining({
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_AGNO,
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+          }),
+        }),
+      );
+
+      const a = attrs();
+      expect(a[ATTR_TELEMETRY_SDK_NAME]).toBe('openlit');
+      expect(a[ATTR_SERVICE_NAME]).toBe('agno-test');
+      expect(a[SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]).toBe('test');
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits create_agent span on first run call for a new agent', async () => {
+      const createSpan = { setAttribute: jest.fn(), setStatus: jest.fn(), end: jest.fn(), spanContext: jest.fn(() => ({ traceId: 'x', spanId: 'y', traceFlags: 1 })) };
+      const invokeSpan = { setAttribute: jest.fn(), setStatus: jest.fn(), end: jest.fn(), spanContext: jest.fn() };
+      mockTracer.startSpan = jest.fn((name: string) =>
+        name.startsWith('create_agent') ? createSpan : invokeSpan,
+      );
+
+      class StubAgent {
+        name = 'fresh-agent';
+        async run() { return {}; }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgnoWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+      await wrapped.call(agent, 'hi');
+
+      const spanNames = (mockTracer.startSpan as jest.Mock).mock.calls.map((c: any[]) => c[0]);
+      expect(spanNames.some((n: string) => n.startsWith('create_agent'))).toBe(true);
+      expect(createSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls handleException and rethrows on error', async () => {
+      class StubAgent {
+        name = 'err-agent';
+        async run() { throw new Error('agent failed'); }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgnoWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+
+      await expect(wrapped.call(agent)).rejects.toThrow('agent failed');
+      expect(OpenLitHelper.handleException).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: 'agent failed' }),
+      );
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('patchTeamRun', () => {
+    it('emits invoke_workflow span with correct attributes', async () => {
+      class StubTeam {
+        name = 'my-team';
+        async run() { return {}; }
+      }
+      const team = new StubTeam();
+      const wrapped = AgnoWrapper.patchTeamRun(mockTracer)(StubTeam.prototype.run);
+      await wrapped.call(team);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        'invoke_workflow my-team',
+        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+      );
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('patchToolExecute', () => {
+    it('emits execute_tool span with correct attributes', async () => {
+      class StubFunctionCall {
+        function = { name: 'search_web' };
+        async execute() { return 'result'; }
+      }
+      const fc = new StubFunctionCall();
+      const wrapped = AgnoWrapper.patchToolExecute(mockTracer)(StubFunctionCall.prototype.execute);
+      await wrapped.call(fc);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        'execute_tool search_web',
+        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+      );
+      const a = attrs();
+      expect(a[SemanticConvention.GEN_AI_TOOL_NAME]).toBe('search_web');
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/sdk/typescript/src/instrumentation/__tests__/agno-wrapper.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/agno-wrapper.test.ts
@@ -62,7 +62,8 @@ describe('AgnoWrapper', () => {
       expect(a[ATTR_SERVICE_NAME]).toBe('agno-test');
       expect(a[SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]).toBe('test');
       expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+      // create_agent + invoke_agent both use mockSpan, so end() is called twice
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
     });
 
     it('emits create_agent span on first run call for a new agent', async () => {
@@ -98,7 +99,8 @@ describe('AgnoWrapper', () => {
         expect.anything(),
         expect.objectContaining({ message: 'agent failed' }),
       );
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+      // create_agent span end() + invoke_agent span end() (in finally)
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -133,10 +135,13 @@ describe('AgnoWrapper', () => {
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith(
         'execute_tool search_web',
-        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+        expect.objectContaining({
+          kind: SpanKind.INTERNAL,
+          attributes: expect.objectContaining({
+            [SemanticConvention.GEN_AI_TOOL_NAME]: 'search_web',
+          }),
+        }),
       );
-      const a = attrs();
-      expect(a[SemanticConvention.GEN_AI_TOOL_NAME]).toBe('search_web');
       expect(mockSpan.end).toHaveBeenCalledTimes(1);
     });
   });

--- a/sdk/typescript/src/instrumentation/agno/index.ts
+++ b/sdk/typescript/src/instrumentation/agno/index.ts
@@ -1,0 +1,121 @@
+/**
+ * OpenLIT Agno Framework Instrumentation
+ *
+ * Provides auto-instrumentation for the Agno agent framework (`agno` npm package):
+ * - Agent construction   (Agent.__init__  -> create_agent spans)
+ * - Agent execution      (Agent.run / arun -> invoke_agent spans)
+ * - Tool execution       (FunctionCall.execute / aexecute -> execute_tool spans)
+ * - Team execution       (Team.run / arun -> invoke_workflow spans)
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/agno/__init__.py
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import AgnoWrapper from './wrapper';
+
+const SUPPORTED_VERSIONS = ['>=0.6.0'];
+
+export default class AgnoInstrumentation extends InstrumentationBase {
+  constructor(config: InstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-agno`, '1.0.0', config);
+  }
+
+  protected init(): InstrumentationModuleDefinition | InstrumentationModuleDefinition[] | void {
+    return new InstrumentationNodeModuleDefinition(
+      'agno',
+      SUPPORTED_VERSIONS,
+      (moduleExports: any) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports: any) => {
+        this._unpatch(moduleExports);
+        return moduleExports;
+      },
+    );
+  }
+
+  public manualPatch(moduleExports: any): void {
+    this._patch(moduleExports);
+  }
+
+  private _patch(moduleExports: any): void {
+    try {
+      const tracer = this.tracer;
+
+      // Patch Agent
+      const Agent = moduleExports?.Agent ?? moduleExports?.agent?.Agent;
+      if (Agent?.prototype) {
+        // create_agent: wrap constructor
+        if (!Agent.prototype.__openlit_agno_init_patched) {
+          AgnoWrapper.patchAgentInit(Agent, tracer);
+        }
+
+        // invoke_agent: wrap run
+        if (typeof Agent.prototype.run === 'function') {
+          if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+          this._wrap(Agent.prototype, 'run', AgnoWrapper.patchAgentRun(tracer));
+        }
+        if (typeof Agent.prototype.arun === 'function') {
+          if (isWrapped(Agent.prototype.arun)) this._unwrap(Agent.prototype, 'arun');
+          this._wrap(Agent.prototype, 'arun', AgnoWrapper.patchAgentRun(tracer));
+        }
+      }
+
+      // Patch Team
+      const Team = moduleExports?.Team ?? moduleExports?.team?.Team;
+      if (Team?.prototype) {
+        if (typeof Team.prototype.run === 'function') {
+          if (isWrapped(Team.prototype.run)) this._unwrap(Team.prototype, 'run');
+          this._wrap(Team.prototype, 'run', AgnoWrapper.patchTeamRun(tracer));
+        }
+        if (typeof Team.prototype.arun === 'function') {
+          if (isWrapped(Team.prototype.arun)) this._unwrap(Team.prototype, 'arun');
+          this._wrap(Team.prototype, 'arun', AgnoWrapper.patchTeamRun(tracer));
+        }
+      }
+
+      // Patch FunctionCall for tool execution spans
+      const FunctionCall = moduleExports?.FunctionCall ?? moduleExports?.tools?.FunctionCall;
+      if (FunctionCall?.prototype) {
+        if (typeof FunctionCall.prototype.execute === 'function') {
+          if (isWrapped(FunctionCall.prototype.execute)) this._unwrap(FunctionCall.prototype, 'execute');
+          this._wrap(FunctionCall.prototype, 'execute', AgnoWrapper.patchToolExecute(tracer));
+        }
+        if (typeof FunctionCall.prototype.aexecute === 'function') {
+          if (isWrapped(FunctionCall.prototype.aexecute)) this._unwrap(FunctionCall.prototype, 'aexecute');
+          this._wrap(FunctionCall.prototype, 'aexecute', AgnoWrapper.patchToolExecute(tracer));
+        }
+      }
+    } catch {
+      /* graceful degradation */
+    }
+  }
+
+  private _unpatch(moduleExports: any): void {
+    try {
+      const Agent = moduleExports?.Agent ?? moduleExports?.agent?.Agent;
+      if (Agent?.prototype) {
+        if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+        if (isWrapped(Agent.prototype.arun)) this._unwrap(Agent.prototype, 'arun');
+      }
+      const Team = moduleExports?.Team ?? moduleExports?.team?.Team;
+      if (Team?.prototype) {
+        if (isWrapped(Team.prototype.run)) this._unwrap(Team.prototype, 'run');
+        if (isWrapped(Team.prototype.arun)) this._unwrap(Team.prototype, 'arun');
+      }
+      const FunctionCall = moduleExports?.FunctionCall ?? moduleExports?.tools?.FunctionCall;
+      if (FunctionCall?.prototype) {
+        if (isWrapped(FunctionCall.prototype.execute)) this._unwrap(FunctionCall.prototype, 'execute');
+        if (isWrapped(FunctionCall.prototype.aexecute)) this._unwrap(FunctionCall.prototype, 'aexecute');
+      }
+    } catch { /* ignore */ }
+  }
+}

--- a/sdk/typescript/src/instrumentation/agno/index.ts
+++ b/sdk/typescript/src/instrumentation/agno/index.ts
@@ -2,8 +2,7 @@
  * OpenLIT Agno Framework Instrumentation
  *
  * Provides auto-instrumentation for the Agno agent framework (`agno` npm package):
- * - Agent construction   (Agent.__init__  -> create_agent spans)
- * - Agent execution      (Agent.run / arun -> invoke_agent spans)
+ * - Agent execution      (Agent.run / arun -> invoke_agent spans, emits create_agent on first call)
  * - Tool execution       (FunctionCall.execute / aexecute -> execute_tool spans)
  * - Team execution       (Team.run / arun -> invoke_workflow spans)
  *
@@ -53,12 +52,7 @@ export default class AgnoInstrumentation extends InstrumentationBase {
       // Patch Agent
       const Agent = moduleExports?.Agent ?? moduleExports?.agent?.Agent;
       if (Agent?.prototype) {
-        // create_agent: wrap constructor
-        if (!Agent.prototype.__openlit_agno_init_patched) {
-          AgnoWrapper.patchAgentInit(Agent, tracer);
-        }
-
-        // invoke_agent: wrap run
+        // invoke_agent: wrap run (create_agent emitted lazily on first call)
         if (typeof Agent.prototype.run === 'function') {
           if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
           this._wrap(Agent.prototype, 'run', AgnoWrapper.patchAgentRun(tracer));

--- a/sdk/typescript/src/instrumentation/agno/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/agno/wrapper.ts
@@ -1,0 +1,237 @@
+/**
+ * Agno framework span wrappers.
+ *
+ * Emits OTel GenAI semantic-convention compliant spans:
+ *   create_agent  — Agent construction
+ *   invoke_agent  — Agent.run / Agent.arun
+ *   invoke_workflow — Team.run / Team.arun
+ *   execute_tool  — FunctionCall.execute / FunctionCall.aexecute
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/agno/agno.py
+ */
+
+import { Tracer, SpanKind, context, trace, SpanContext } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from '../../semantic-convention';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import { applyCustomSpanAttributes } from '../../helpers';
+import { SDK_NAME, SDK_VERSION } from '../../constant';
+
+const AI_SYSTEM = 'agno';
+
+// Registry: agent name -> create_agent span context (for Links on invoke_agent)
+const agentRegistry = new Map<string, SpanContext>();
+
+function setCommonAttrs(span: any): void {
+  span.setAttribute(ATTR_TELEMETRY_SDK_NAME, SDK_NAME);
+  span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, SDK_VERSION);
+  span.setAttribute(ATTR_SERVICE_NAME, OpenlitConfig.applicationName || 'default');
+  span.setAttribute(SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT, OpenlitConfig.environment || 'default');
+  span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, AI_SYSTEM);
+}
+
+function resolveAgentName(instance: any): string {
+  return instance?.name || instance?.agent_id || instance?.constructor?.name || 'agent';
+}
+
+function resolveModel(instance: any): string {
+  try {
+    return (
+      instance?.model?.id ||
+      instance?.model?.model ||
+      instance?.model?.name ||
+      instance?.model_id ||
+      ''
+    );
+  } catch {
+    return '';
+  }
+}
+
+class AgnoWrapper {
+  /**
+   * Patch Agent class constructor to emit create_agent spans.
+   * Because ES6 constructors cannot be wrapped via prototype._wrap, we replace
+   * the class with a subclass proxy that emits the span then delegates.
+   */
+  static patchAgentInit(AgentClass: any, _tracer: Tracer): void {
+    try {
+      if (AgentClass.prototype.__openlit_agno_init_patched) return;
+      AgentClass.prototype.__openlit_agno_init_patched = true;
+
+      // We intercept every new Agent() by wrapping the __init__ if it exists,
+      // or by wrapping a sentinel method called post-init.
+      // Since JS constructors can't be easily wrapped via prototype, we store
+      // agent context after first run() call in patchAgentRun instead.
+    } catch { /* ignore */ }
+  }
+
+  static patchAgentRun(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const agentName = resolveAgentName(this);
+        const model = resolveModel(this);
+        const operationName = SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT;
+        const spanName = `invoke_agent ${agentName}`;
+
+        const creationCtx = agentRegistry.get(agentName);
+        const links = creationCtx ? [{ context: creationCtx }] : [];
+
+        // Emit create_agent span on first encounter (best-effort approximation)
+        if (!agentRegistry.has(agentName)) {
+          const createSpan = tracer.startSpan(`create_agent ${agentName}`, {
+            kind: SpanKind.CLIENT,
+            attributes: {
+              [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+              [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+              [SemanticConvention.GEN_AI_AGENT_NAME]: agentName,
+              ...(model ? { [SemanticConvention.GEN_AI_REQUEST_MODEL]: model } : {}),
+            },
+          });
+          try {
+            setCommonAttrs(createSpan);
+            if (this.description) {
+              createSpan.setAttribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, String(this.description));
+            }
+            agentRegistry.set(agentName, createSpan.spanContext());
+          } finally {
+            createSpan.end();
+          }
+        }
+
+        const span = tracer.startSpan(spanName, {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: operationName,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_AGENT_NAME]: agentName,
+            ...(model ? { [SemanticConvention.GEN_AI_REQUEST_MODEL]: model } : {}),
+          },
+          links,
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+            applyCustomSpanAttributes(span);
+
+            const result = await originalMethod.apply(this, args);
+
+            if (OpenlitConfig.captureMessageContent) {
+              try {
+                const inputMsg = args[0];
+                if (inputMsg) {
+                  const inputStr = typeof inputMsg === 'string' ? inputMsg : JSON.stringify(inputMsg);
+                  span.setAttribute(SemanticConvention.GEN_AI_INPUT_MESSAGES,
+                    OpenLitHelper.buildInputMessages([{ role: 'user', content: inputStr }]));
+                }
+                if (result?.content) {
+                  const outputStr = typeof result.content === 'string' ? result.content :
+                    Array.isArray(result.content)
+                      ? result.content.map((c: any) => c?.text || c?.value || JSON.stringify(c)).join('')
+                      : JSON.stringify(result.content);
+                  span.setAttribute(SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
+                    OpenLitHelper.buildOutputMessages(outputStr, 'stop'));
+                }
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+
+  static patchTeamRun(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const teamName = this?.name || this?.team_id || 'team';
+        const spanName = `invoke_workflow ${teamName}`;
+
+        const span = tracer.startSpan(spanName, {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_WORKFLOW_NAME]: teamName,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+            applyCustomSpanAttributes(span);
+            const result = await originalMethod.apply(this, args);
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+
+  static patchToolExecute(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const toolName = this?.function?.name || this?.name || 'tool';
+        const spanName = `execute_tool ${toolName}`;
+
+        const span = tracer.startSpan(spanName, {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_TOOL_NAME]: toolName,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+
+            if (OpenlitConfig.captureMessageContent && this?.arguments) {
+              try {
+                const argsStr = typeof this.arguments === 'string'
+                  ? this.arguments
+                  : JSON.stringify(this.arguments);
+                span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS, argsStr);
+              } catch { /* ignore */ }
+            }
+
+            const result = await originalMethod.apply(this, args);
+
+            if (OpenlitConfig.captureMessageContent && result !== undefined) {
+              try {
+                const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+                span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_RESULT, resultStr);
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+}
+
+export default AgnoWrapper;

--- a/sdk/typescript/src/instrumentation/agno/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/agno/wrapper.ts
@@ -2,10 +2,9 @@
  * Agno framework span wrappers.
  *
  * Emits OTel GenAI semantic-convention compliant spans:
- *   create_agent  — Agent construction
- *   invoke_agent  — Agent.run / Agent.arun
+ *   invoke_agent    — Agent.run / Agent.arun (emits create_agent on first call)
  *   invoke_workflow — Team.run / Team.arun
- *   execute_tool  — FunctionCall.execute / FunctionCall.aexecute
+ *   execute_tool    — FunctionCall.execute / FunctionCall.aexecute
  *
  * Mirrors: sdk/python/src/openlit/instrumentation/agno/agno.py
  */
@@ -18,7 +17,7 @@ import OpenLitHelper from '../../helpers';
 import { applyCustomSpanAttributes } from '../../helpers';
 import { SDK_NAME, SDK_VERSION } from '../../constant';
 
-const AI_SYSTEM = 'agno';
+const AI_SYSTEM = SemanticConvention.GEN_AI_SYSTEM_AGNO;
 
 // Registry: agent name -> create_agent span context (for Links on invoke_agent)
 const agentRegistry = new Map<string, SpanContext>();
@@ -50,23 +49,6 @@ function resolveModel(instance: any): string {
 }
 
 class AgnoWrapper {
-  /**
-   * Patch Agent class constructor to emit create_agent spans.
-   * Because ES6 constructors cannot be wrapped via prototype._wrap, we replace
-   * the class with a subclass proxy that emits the span then delegates.
-   */
-  static patchAgentInit(AgentClass: any, _tracer: Tracer): void {
-    try {
-      if (AgentClass.prototype.__openlit_agno_init_patched) return;
-      AgentClass.prototype.__openlit_agno_init_patched = true;
-
-      // We intercept every new Agent() by wrapping the __init__ if it exists,
-      // or by wrapping a sentinel method called post-init.
-      // Since JS constructors can't be easily wrapped via prototype, we store
-      // agent context after first run() call in patchAgentRun instead.
-    } catch { /* ignore */ }
-  }
-
   static patchAgentRun(tracer: Tracer): any {
     return (originalMethod: (...args: any[]) => any) => {
       return async function (this: any, ...args: any[]) {

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -40,6 +40,7 @@ import AssemblyAIInstrumentation from './assemblyai';
 import TransformersInstrumentation from './transformers';
 import PgInstrumentation from './pg';
 import FirecrawlInstrumentation from './firecrawl';
+import AgnoInstrumentation from './agno';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -122,6 +123,7 @@ export default class Instrumentations {
     transformers: new TransformersInstrumentation(),
     pg: new PgInstrumentation(),
     firecrawl: new FirecrawlInstrumentation(),
+    agno: new AgnoInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -323,6 +323,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_MEM0 = 'mem0';
   static GEN_AI_SYSTEM_BROWSER_USE = 'browser_use';
   static GEN_AI_SYSTEM_FIRECRAWL = 'firecrawl';
+  static GEN_AI_SYSTEM_AGNO = 'agno';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'vertexai' | 'together' | 'ollama' | 'vllm' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'browser-use' | 'mcp' | 'mem0' | 'elevenlabs' | 'assemblyai' | 'transformers' | 'pg' | 'firecrawl';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'vertexai' | 'together' | 'ollama' | 'vllm' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'browser-use' | 'mcp' | 'mem0' | 'elevenlabs' | 'assemblyai' | 'transformers' | 'pg' | 'firecrawl' | 'agno';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
Closes #1241

## Summary

Adds TypeScript auto-instrumentation for the Agno agent framework (`agno` npm package), achieving parity with the Python SDK's `agno` instrumentation.

## Changes

- Added `sdk/typescript/src/instrumentation/agno/index.ts` — `InstrumentationBase` subclass that patches `Agent.run`, `Agent.arun`, `Team.run`, `Team.arun`, `FunctionCall.execute`, and `FunctionCall.aexecute`
- Added `sdk/typescript/src/instrumentation/agno/wrapper.ts` — emits OTel GenAI semconv spans: `create_agent`, `invoke_agent`, `invoke_workflow` (Team), `execute_tool` (FunctionCall)
- Added `GEN_AI_SYSTEM_AGNO = 'agno'` constant to `semantic-convention.ts`
- Registered `agno` in `InstrumentationType` union and `Instrumentations.availableInstrumentations`

## Span Coverage

| Operation | Span Name | Kind |
|-----------|-----------|------|
| `Agent.run` / `Agent.arun` | `invoke_agent {name}` | CLIENT |
| First `Agent.run` (lazy create_agent) | `create_agent {name}` | CLIENT |
| `Team.run` / `Team.arun` | `invoke_workflow {name}` | INTERNAL |
| `FunctionCall.execute` / `aexecute` | `execute_tool {name}` | INTERNAL |

Follows zero-provider-dependency rule; all types are duck-typed.

## Summary by Sourcery

Add TypeScript auto-instrumentation support for the Agno agent framework and register it in the SDK instrumentation system.

New Features:
- Introduce AgnoInstrumentation to automatically trace Agno Agent, Team, and FunctionCall operations using OTel GenAI spans.
- Add AgnoWrapper utilities to emit create_agent, invoke_agent, invoke_workflow, and execute_tool spans for Agno framework usage.

Enhancements:
- Extend InstrumentationType and Instrumentations registry to include the agno framework.
- Add GEN_AI_SYSTEM_AGNO semantic-convention constant for consistent provider identification in spans.