### PR TITLE
feat(typescript): add browser-use auto-instrumentation

### DIFF
--- a/sdk/typescript/src/instrumentation/browser-use/index.ts
+++ b/sdk/typescript/src/instrumentation/browser-use/index.ts
@@ -1,0 +1,88 @@
+/**
+ * OpenLIT browser-use Framework Instrumentation
+ *
+ * Provides auto-instrumentation for the browser-use browser automation SDK:
+ * - Agent.run   -> invoke_agent spans (full browser session)
+ * - Agent.step  -> execute_tool spans  (individual browser action steps)
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/browser_use/__init__.py
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import BrowserUseWrapper from './wrapper';
+
+const SUPPORTED_VERSIONS = ['>=0.1.0'];
+
+export default class BrowserUseInstrumentation extends InstrumentationBase {
+  constructor(config: InstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-browser-use`, '1.0.0', config);
+  }
+
+  protected init(): InstrumentationModuleDefinition | InstrumentationModuleDefinition[] | void {
+    return new InstrumentationNodeModuleDefinition(
+      'browser-use',
+      SUPPORTED_VERSIONS,
+      (moduleExports: any) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports: any) => {
+        this._unpatch(moduleExports);
+        return moduleExports;
+      },
+    );
+  }
+
+  public manualPatch(moduleExports: any): void {
+    this._patch(moduleExports);
+  }
+
+  private _patch(moduleExports: any): void {
+    try {
+      const tracer = this.tracer;
+
+      // Agent class may be at moduleExports.Agent or moduleExports.agent.Agent
+      const Agent =
+        moduleExports?.Agent ??
+        moduleExports?.agent?.Agent ??
+        moduleExports?.BrowserAgent;
+
+      if (Agent?.prototype) {
+        // invoke_agent: full browser task run
+        if (typeof Agent.prototype.run === 'function') {
+          if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+          this._wrap(Agent.prototype, 'run', BrowserUseWrapper.patchAgentRun(tracer));
+        }
+
+        // execute_tool: individual action step
+        if (typeof Agent.prototype.step === 'function') {
+          if (isWrapped(Agent.prototype.step)) this._unwrap(Agent.prototype, 'step');
+          this._wrap(Agent.prototype, 'step', BrowserUseWrapper.patchAgentStep(tracer));
+        }
+      }
+    } catch {
+      /* graceful degradation — if the package shape changes we fail silently */
+    }
+  }
+
+  private _unpatch(moduleExports: any): void {
+    try {
+      const Agent =
+        moduleExports?.Agent ??
+        moduleExports?.agent?.Agent ??
+        moduleExports?.BrowserAgent;
+
+      if (Agent?.prototype) {
+        if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+        if (isWrapped(Agent.prototype.step)) this._unwrap(Agent.prototype, 'step');
+      }
+    } catch { /* ignore */ }
+  }
+}

--- a/sdk/typescript/src/instrumentation/browser-use/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/browser-use/wrapper.ts
@@ -1,0 +1,151 @@
+/**
+ * browser-use span wrappers.
+ *
+ * Emits OTel GenAI semantic-convention compliant spans:
+ *   invoke_agent  — Agent.run  (full browser task session)
+ *   execute_tool  — Agent.step (individual browser action)
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/browser_use/async_browser_use.py
+ */
+
+import { Tracer, SpanKind, context, trace } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from '../../semantic-convention';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import { applyCustomSpanAttributes } from '../../helpers';
+import { SDK_NAME, SDK_VERSION } from '../../constant';
+
+const AI_SYSTEM = 'browser_use';
+
+function setCommonAttrs(span: any): void {
+  span.setAttribute(ATTR_TELEMETRY_SDK_NAME, SDK_NAME);
+  span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, SDK_VERSION);
+  span.setAttribute(ATTR_SERVICE_NAME, OpenlitConfig.applicationName || 'default');
+  span.setAttribute(SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT, OpenlitConfig.environment || 'default');
+  span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, AI_SYSTEM);
+}
+
+function resolveAgentName(instance: any): string {
+  return instance?.agent_id || instance?.task?.substring?.(0, 40) || 'browser_agent';
+}
+
+function resolveTask(instance: any): string | undefined {
+  try {
+    return typeof instance?.task === 'string' ? instance.task : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+class BrowserUseWrapper {
+  /**
+   * Wrap Agent.run — emits an invoke_agent span covering the full browser automation task.
+   */
+  static patchAgentRun(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const agentName = resolveAgentName(this);
+        const task = resolveTask(this);
+        const spanName = `invoke_agent ${agentName}`;
+
+        const span = tracer.startSpan(spanName, {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_AGENT_NAME]: agentName,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+            applyCustomSpanAttributes(span);
+
+            if (task && OpenlitConfig.captureMessageContent) {
+              span.setAttribute(
+                SemanticConvention.GEN_AI_INPUT_MESSAGES,
+                OpenLitHelper.buildInputMessages([{ role: 'user', content: task }])
+              );
+            }
+
+            const result = await originalMethod.apply(this, args);
+
+            if (result && OpenlitConfig.captureMessageContent) {
+              try {
+                const resultStr = typeof result === 'string' ? result :
+                  result?.result || result?.final_result || JSON.stringify(result);
+                if (resultStr) {
+                  span.setAttribute(
+                    SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
+                    OpenLitHelper.buildOutputMessages(String(resultStr), 'stop')
+                  );
+                }
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+
+  /**
+   * Wrap Agent.step — emits an execute_tool span for each individual browser action.
+   */
+  static patchAgentStep(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const stepNum = (this?.n_steps ?? this?.step_count ?? 0) + 1;
+        const spanName = `execute_tool browser_step_${stepNum}`;
+
+        const span = tracer.startSpan(spanName, {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_TOOL_NAME]: `browser_step_${stepNum}`,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+
+            const result = await originalMethod.apply(this, args);
+
+            if (result && OpenlitConfig.captureMessageContent) {
+              try {
+                const actionStr =
+                  result?.model_output?.action
+                    ? JSON.stringify(result.model_output.action)
+                    : typeof result === 'string' ? result : undefined;
+                if (actionStr) {
+                  span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_RESULT, actionStr);
+                }
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+}
+
+export default BrowserUseWrapper;

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -31,6 +31,7 @@ import ClaudeAgentSDKInstrumentation from './claude-agent-sdk';
 import CursorSDKInstrumentation from './cursor-sdk';
 import AstraInstrumentation from './astra';
 import MCPInstrumentation from './mcp';
+import BrowserUseInstrumentation from './browser-use';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -104,6 +105,7 @@ export default class Instrumentations {
     'cursor-sdk': new CursorSDKInstrumentation(),
     'astra': new AstraInstrumentation(),
     mcp: new MCPInstrumentation(),
+    'browser-use': new BrowserUseInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -245,6 +245,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_STRANDS = 'strands_agents';
   static GEN_AI_SYSTEM_CURSOR = 'cursor';
   static GEN_AI_SYSTEM_MCP = 'mcp';
+  static GEN_AI_SYSTEM_BROWSER_USE = 'browser_use';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'together' | 'ollama' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'mcp' | 'browser-use';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
Closes #1242

## Summary

Adds TypeScript auto-instrumentation for the browser-use browser automation SDK, achieving parity with the Python SDK's `browser_use` instrumentation.

## Changes

- Added `sdk/typescript/src/instrumentation/browser-use/index.ts` — `InstrumentationBase` subclass that patches `Agent.run` and `Agent.step`
- Added `sdk/typescript/src/instrumentation/browser-use/wrapper.ts` — emits OTel GenAI semconv spans: `invoke_agent` (full task run) and `execute_tool` (individual browser action step)
- Added `GEN_AI_SYSTEM_BROWSER_USE = 'browser_use'` constant to `semantic-convention.ts` (mirrors Python SDK value)
- Registered `browser-use` in `InstrumentationType` union and `Instrumentations.availableInstrumentations`

## Span Coverage

| Method | Span Name | Kind | Notes |
|--------|-----------|------|-------|
| `Agent.run` | `invoke_agent {agent_id}` | CLIENT | Full browser task; captures task as input message |
| `Agent.step` | `execute_tool browser_step_{n}` | INTERNAL | Per-step browser action; captures action result |

Follows zero-provider-dependency rule; all types are duck-typed. If `browser-use` is not installed, the instrumentation is a silent no-op.

## Summary by Sourcery

Add OpenTelemetry-based auto-instrumentation for the browser-use browser automation SDK in the TypeScript SDK, aligning it with existing GenAI instrumentation.

New Features:
- Introduce browser-use instrumentation that wraps Agent.run and Agent.step to emit GenAI semantic-convention spans for full tasks and individual steps.
- Expose browser-use as a selectable instrumentation type within the TypeScript SDK’s instrumentation registry.
- Add a semantic-convention constant identifying browser-use as a GenAI provider/system.