### PR TITLE
feat(typescript): add Microsoft Agent Framework auto-instrumentation

### DIFF
--- a/sdk/typescript/src/instrumentation/__tests__/agent-framework-wrapper.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/agent-framework-wrapper.test.ts
@@ -62,7 +62,8 @@ describe('AgentFrameworkWrapper', () => {
       expect(a[ATTR_SERVICE_NAME]).toBe('af-test');
       expect(a[SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]).toBe('test');
       expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+      // create_agent + invoke_agent both use mockSpan, so end() is called twice
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
     });
 
     it('emits create_agent span on first run call', async () => {
@@ -98,7 +99,8 @@ describe('AgentFrameworkWrapper', () => {
         expect.anything(),
         expect.objectContaining({ message: 'af agent failed' }),
       );
-      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+      // create_agent span end() + invoke_agent span end() (in finally)
+      expect(mockSpan.end).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -114,10 +116,13 @@ describe('AgentFrameworkWrapper', () => {
 
       expect(mockTracer.startSpan).toHaveBeenCalledWith(
         'execute_tool get_weather',
-        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+        expect.objectContaining({
+          kind: SpanKind.INTERNAL,
+          attributes: expect.objectContaining({
+            [SemanticConvention.GEN_AI_TOOL_NAME]: 'get_weather',
+          }),
+        }),
       );
-      const a = attrs();
-      expect(a[SemanticConvention.GEN_AI_TOOL_NAME]).toBe('get_weather');
       expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
       expect(mockSpan.end).toHaveBeenCalledTimes(1);
     });

--- a/sdk/typescript/src/instrumentation/__tests__/agent-framework-wrapper.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/agent-framework-wrapper.test.ts
@@ -1,0 +1,144 @@
+import { SpanKind } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import SemanticConvention from '../../semantic-convention';
+import AgentFrameworkWrapper from '../agent-framework/wrapper';
+
+jest.mock('../../config');
+jest.mock('../../helpers', () => ({
+  __esModule: true,
+  default: { handleException: jest.fn() },
+  applyCustomSpanAttributes: jest.fn(),
+}));
+
+describe('AgentFrameworkWrapper', () => {
+  let mockSpan: any;
+  let mockTracer: any;
+
+  beforeEach(() => {
+    mockSpan = {
+      setAttribute: jest.fn(),
+      setStatus: jest.fn(),
+      end: jest.fn(),
+      spanContext: jest.fn(() => ({ traceId: 'abc', spanId: 'def', traceFlags: 1 })),
+    };
+    mockTracer = { startSpan: jest.fn(() => mockSpan) };
+
+    (OpenlitConfig as any).environment = 'test';
+    (OpenlitConfig as any).applicationName = 'af-test';
+    (OpenlitConfig as any).captureMessageContent = false;
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  function attrs(span = mockSpan): Record<string, any> {
+    return Object.fromEntries((span.setAttribute as jest.Mock).mock.calls);
+  }
+
+  describe('patchAgentRun', () => {
+    it('emits invoke_agent span with correct provider attribute', async () => {
+      class StubAgent {
+        name = 'my-af-agent';
+        async run() { return { result: 'done' }; }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgentFrameworkWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+      await wrapped.call(agent, 'hello');
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        expect.stringContaining('invoke_agent'),
+        expect.objectContaining({
+          kind: SpanKind.CLIENT,
+          attributes: expect.objectContaining({
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: SemanticConvention.GEN_AI_SYSTEM_AGENT_FRAMEWORK,
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+          }),
+        }),
+      );
+
+      const a = attrs();
+      expect(a[ATTR_TELEMETRY_SDK_NAME]).toBe('openlit');
+      expect(a[ATTR_SERVICE_NAME]).toBe('af-test');
+      expect(a[SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]).toBe('test');
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits create_agent span on first run call', async () => {
+      const createSpan = { setAttribute: jest.fn(), setStatus: jest.fn(), end: jest.fn(), spanContext: jest.fn(() => ({ traceId: 'x', spanId: 'y', traceFlags: 1 })) };
+      const invokeSpan = { setAttribute: jest.fn(), setStatus: jest.fn(), end: jest.fn(), spanContext: jest.fn() };
+      mockTracer.startSpan = jest.fn((name: string) =>
+        name.startsWith('create_agent') ? createSpan : invokeSpan,
+      );
+
+      class StubAgent {
+        name = 'fresh-af-agent';
+        async run() { return {}; }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgentFrameworkWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+      await wrapped.call(agent, 'hi');
+
+      const spanNames = (mockTracer.startSpan as jest.Mock).mock.calls.map((c: any[]) => c[0]);
+      expect(spanNames.some((n: string) => n.startsWith('create_agent'))).toBe(true);
+      expect(createSpan.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls handleException and rethrows on error', async () => {
+      class StubAgent {
+        name = 'err-af-agent';
+        async run() { throw new Error('af agent failed'); }
+      }
+      const agent = new StubAgent();
+      const wrapped = AgentFrameworkWrapper.patchAgentRun(mockTracer)(StubAgent.prototype.run);
+
+      await expect(wrapped.call(agent)).rejects.toThrow('af agent failed');
+      expect(OpenLitHelper.handleException).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ message: 'af agent failed' }),
+      );
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('patchToolInvoke', () => {
+    it('emits execute_tool span with correct attributes', async () => {
+      class StubFunctionTool {
+        name = 'get_weather';
+        async invoke() { return 'sunny'; }
+      }
+      const tool = new StubFunctionTool();
+      const wrapped = AgentFrameworkWrapper.patchToolInvoke(mockTracer)(StubFunctionTool.prototype.invoke);
+      await wrapped.call(tool);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        'execute_tool get_weather',
+        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+      );
+      const a = attrs();
+      expect(a[SemanticConvention.GEN_AI_TOOL_NAME]).toBe('get_weather');
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('patchWorkflowRun', () => {
+    it('emits invoke_workflow span with correct attributes', async () => {
+      class StubWorkflow {
+        name = 'my-workflow';
+        async run() { return {}; }
+      }
+      const wf = new StubWorkflow();
+      const wrapped = AgentFrameworkWrapper.patchWorkflowRun(mockTracer)(StubWorkflow.prototype.run);
+      await wrapped.call(wf);
+
+      expect(mockTracer.startSpan).toHaveBeenCalledWith(
+        'invoke_workflow my-workflow',
+        expect.objectContaining({ kind: SpanKind.INTERNAL }),
+      );
+      expect(mockSpan.setStatus).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/sdk/typescript/src/instrumentation/agent-framework/index.ts
+++ b/sdk/typescript/src/instrumentation/agent-framework/index.ts
@@ -1,0 +1,121 @@
+/**
+ * OpenLIT Microsoft Agent Framework Instrumentation
+ *
+ * Provides auto-instrumentation for the Microsoft Agent Framework
+ * (`agent-framework` npm package):
+ * - Agent.__init__     -> create_agent spans
+ * - Agent.run          -> invoke_agent spans
+ * - FunctionTool.invoke -> execute_tool spans
+ * - Workflow.run       -> invoke_workflow spans
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/agent_framework/__init__.py
+ */
+
+import {
+  InstrumentationBase,
+  InstrumentationModuleDefinition,
+  InstrumentationNodeModuleDefinition,
+  isWrapped,
+} from '@opentelemetry/instrumentation';
+import type { InstrumentationConfig } from '@opentelemetry/instrumentation';
+import { INSTRUMENTATION_PREFIX } from '../../constant';
+import AgentFrameworkWrapper from './wrapper';
+
+const SUPPORTED_VERSIONS = ['>=1.0.0-rc.1'];
+
+export default class AgentFrameworkInstrumentation extends InstrumentationBase {
+  constructor(config: InstrumentationConfig = {}) {
+    super(`${INSTRUMENTATION_PREFIX}/instrumentation-agent-framework`, '1.0.0', config);
+  }
+
+  protected init(): InstrumentationModuleDefinition | InstrumentationModuleDefinition[] | void {
+    return new InstrumentationNodeModuleDefinition(
+      'agent-framework',
+      SUPPORTED_VERSIONS,
+      (moduleExports: any) => {
+        this._patch(moduleExports);
+        return moduleExports;
+      },
+      (moduleExports: any) => {
+        this._unpatch(moduleExports);
+        return moduleExports;
+      },
+    );
+  }
+
+  public manualPatch(moduleExports: any): void {
+    this._patch(moduleExports);
+  }
+
+  private _patch(moduleExports: any): void {
+    try {
+      const tracer = this.tracer;
+
+      // Patch Agent
+      const Agent = moduleExports?.Agent ?? moduleExports?.agents?.Agent;
+      if (Agent?.prototype) {
+        // invoke_agent: Agent.run
+        if (typeof Agent.prototype.run === 'function') {
+          if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+          this._wrap(Agent.prototype, 'run', AgentFrameworkWrapper.patchAgentRun(tracer));
+        }
+
+        // create_agent: Agent.__init__ — attempted via constructor wrapping
+        if (!Agent.prototype.__openlit_af_init_patched) {
+          AgentFrameworkWrapper.patchAgentInit(Agent, tracer);
+        }
+      }
+
+      // Patch FunctionTool (execute_tool spans)
+      const FunctionTool =
+        moduleExports?.FunctionTool ??
+        moduleExports?.tools?.FunctionTool ??
+        moduleExports?._tools?.FunctionTool;
+
+      if (FunctionTool?.prototype) {
+        if (typeof FunctionTool.prototype.invoke === 'function') {
+          if (isWrapped(FunctionTool.prototype.invoke)) this._unwrap(FunctionTool.prototype, 'invoke');
+          this._wrap(FunctionTool.prototype, 'invoke', AgentFrameworkWrapper.patchToolInvoke(tracer));
+        }
+      }
+
+      // Patch Workflow (invoke_workflow spans)
+      const Workflow =
+        moduleExports?.Workflow ??
+        moduleExports?._workflows?.Workflow ??
+        moduleExports?.workflows?.Workflow;
+
+      if (Workflow?.prototype) {
+        if (typeof Workflow.prototype.run === 'function') {
+          if (isWrapped(Workflow.prototype.run)) this._unwrap(Workflow.prototype, 'run');
+          this._wrap(Workflow.prototype, 'run', AgentFrameworkWrapper.patchWorkflowRun(tracer));
+        }
+      }
+    } catch {
+      /* graceful degradation */
+    }
+  }
+
+  private _unpatch(moduleExports: any): void {
+    try {
+      const Agent = moduleExports?.Agent ?? moduleExports?.agents?.Agent;
+      if (Agent?.prototype) {
+        if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
+      }
+      const FunctionTool =
+        moduleExports?.FunctionTool ??
+        moduleExports?.tools?.FunctionTool ??
+        moduleExports?._tools?.FunctionTool;
+      if (FunctionTool?.prototype) {
+        if (isWrapped(FunctionTool.prototype.invoke)) this._unwrap(FunctionTool.prototype, 'invoke');
+      }
+      const Workflow =
+        moduleExports?.Workflow ??
+        moduleExports?._workflows?.Workflow ??
+        moduleExports?.workflows?.Workflow;
+      if (Workflow?.prototype) {
+        if (isWrapped(Workflow.prototype.run)) this._unwrap(Workflow.prototype, 'run');
+      }
+    } catch { /* ignore */ }
+  }
+}

--- a/sdk/typescript/src/instrumentation/agent-framework/index.ts
+++ b/sdk/typescript/src/instrumentation/agent-framework/index.ts
@@ -2,9 +2,8 @@
  * OpenLIT Microsoft Agent Framework Instrumentation
  *
  * Provides auto-instrumentation for the Microsoft Agent Framework
- * (`agent-framework` npm package):
- * - Agent.__init__     -> create_agent spans
- * - Agent.run          -> invoke_agent spans
+ * (`@microsoft/agent-framework` npm package):
+ * - Agent.run          -> invoke_agent spans (emits create_agent on first call)
  * - FunctionTool.invoke -> execute_tool spans
  * - Workflow.run       -> invoke_workflow spans
  *
@@ -30,7 +29,7 @@ export default class AgentFrameworkInstrumentation extends InstrumentationBase {
 
   protected init(): InstrumentationModuleDefinition | InstrumentationModuleDefinition[] | void {
     return new InstrumentationNodeModuleDefinition(
-      'agent-framework',
+      '@microsoft/agent-framework',
       SUPPORTED_VERSIONS,
       (moduleExports: any) => {
         this._patch(moduleExports);
@@ -54,15 +53,10 @@ export default class AgentFrameworkInstrumentation extends InstrumentationBase {
       // Patch Agent
       const Agent = moduleExports?.Agent ?? moduleExports?.agents?.Agent;
       if (Agent?.prototype) {
-        // invoke_agent: Agent.run
+        // invoke_agent: wrap run (create_agent emitted lazily on first call)
         if (typeof Agent.prototype.run === 'function') {
           if (isWrapped(Agent.prototype.run)) this._unwrap(Agent.prototype, 'run');
           this._wrap(Agent.prototype, 'run', AgentFrameworkWrapper.patchAgentRun(tracer));
-        }
-
-        // create_agent: Agent.__init__ — attempted via constructor wrapping
-        if (!Agent.prototype.__openlit_af_init_patched) {
-          AgentFrameworkWrapper.patchAgentInit(Agent, tracer);
         }
       }
 

--- a/sdk/typescript/src/instrumentation/agent-framework/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/agent-framework/wrapper.ts
@@ -1,0 +1,233 @@
+/**
+ * Microsoft Agent Framework span wrappers.
+ *
+ * Emits OTel GenAI semantic-convention compliant spans:
+ *   create_agent     — Agent construction
+ *   invoke_agent     — Agent.run
+ *   execute_tool     — FunctionTool.invoke
+ *   invoke_workflow  — Workflow.run
+ *
+ * Mirrors: sdk/python/src/openlit/instrumentation/agent_framework/__init__.py
+ */
+
+import { Tracer, SpanKind, context, trace, SpanContext } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from '../../semantic-convention';
+import OpenlitConfig from '../../config';
+import OpenLitHelper from '../../helpers';
+import { applyCustomSpanAttributes } from '../../helpers';
+import { SDK_NAME, SDK_VERSION } from '../../constant';
+
+const AI_SYSTEM = 'agent_framework';
+
+// Thread-safe agent creation registry (maps agent name -> SpanContext)
+const agentRegistry = new Map<string, SpanContext>();
+
+function setCommonAttrs(span: any): void {
+  span.setAttribute(ATTR_TELEMETRY_SDK_NAME, SDK_NAME);
+  span.setAttribute(SemanticConvention.GEN_AI_SDK_VERSION, SDK_VERSION);
+  span.setAttribute(ATTR_SERVICE_NAME, OpenlitConfig.applicationName || 'default');
+  span.setAttribute(SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT, OpenlitConfig.environment || 'default');
+  span.setAttribute(SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL, AI_SYSTEM);
+}
+
+function resolveAgentName(instance: any): string {
+  return instance?.name || instance?.agent_id || instance?.id || instance?.constructor?.name || 'agent';
+}
+
+function resolveModel(instance: any): string | undefined {
+  try {
+    return instance?.model?.id || instance?.model_id || instance?.llm?.model_id || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+class AgentFrameworkWrapper {
+  /**
+   * Patch Agent class to emit create_agent spans on construction.
+   * We mark the prototype with a sentinel so we only patch once.
+   */
+  static patchAgentInit(AgentClass: any, _tracer: Tracer): void {
+    try {
+      AgentClass.prototype.__openlit_af_init_patched = true;
+      // Emit the create_agent span lazily on first invoke_agent instead of
+      // intercepting the constructor (which is complex in JS). The registry-based
+      // approach is used: the first time Agent.run is called, a create_agent span
+      // is emitted if not already registered.
+    } catch { /* ignore */ }
+  }
+
+  static patchAgentRun(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const agentName = resolveAgentName(this);
+        const model = resolveModel(this);
+
+        // Emit create_agent span on first encounter
+        if (!agentRegistry.has(agentName)) {
+          const createSpan = tracer.startSpan(`create_agent ${agentName}`, {
+            kind: SpanKind.CLIENT,
+            attributes: {
+              [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_CREATE_AGENT,
+              [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+              [SemanticConvention.GEN_AI_AGENT_NAME]: agentName,
+              ...(model ? { [SemanticConvention.GEN_AI_REQUEST_MODEL]: model } : {}),
+            },
+          });
+          try {
+            setCommonAttrs(createSpan);
+            if (this.description) {
+              createSpan.setAttribute(SemanticConvention.GEN_AI_AGENT_DESCRIPTION, String(this.description));
+            }
+            if (this.tools) {
+              try {
+                const toolNames = Array.isArray(this.tools)
+                  ? this.tools.map((t: any) => t?.name || t?.function?.name || String(t)).filter(Boolean)
+                  : [];
+                if (toolNames.length > 0) {
+                  createSpan.setAttribute(SemanticConvention.GEN_AI_TOOL_DEFINITIONS, JSON.stringify(toolNames));
+                }
+              } catch { /* ignore */ }
+            }
+            agentRegistry.set(agentName, createSpan.spanContext());
+          } finally {
+            createSpan.end();
+          }
+        }
+
+        const creationCtx = agentRegistry.get(agentName);
+        const links = creationCtx ? [{ context: creationCtx }] : [];
+        const span = tracer.startSpan(`invoke_agent ${agentName}`, {
+          kind: SpanKind.CLIENT,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_AGENT,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_AGENT_NAME]: agentName,
+            ...(model ? { [SemanticConvention.GEN_AI_REQUEST_MODEL]: model } : {}),
+          },
+          links,
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+            applyCustomSpanAttributes(span);
+
+            if (OpenlitConfig.captureMessageContent && args[0]) {
+              try {
+                const inputStr = typeof args[0] === 'string' ? args[0] : JSON.stringify(args[0]);
+                span.setAttribute(
+                  SemanticConvention.GEN_AI_INPUT_MESSAGES,
+                  OpenLitHelper.buildInputMessages([{ role: 'user', content: inputStr }])
+                );
+              } catch { /* ignore */ }
+            }
+
+            const result = await originalMethod.apply(this, args);
+
+            if (OpenlitConfig.captureMessageContent && result) {
+              try {
+                const outputStr = typeof result === 'string' ? result :
+                  result?.content || result?.result || result?.output || JSON.stringify(result);
+                if (outputStr) {
+                  span.setAttribute(
+                    SemanticConvention.GEN_AI_OUTPUT_MESSAGES,
+                    OpenLitHelper.buildOutputMessages(String(outputStr), 'stop')
+                  );
+                }
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+
+  static patchToolInvoke(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const toolName = this?.name || this?.function?.name || this?.func?.name || 'tool';
+        const span = tracer.startSpan(`execute_tool ${toolName}`, {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_TOOLS,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_TOOL_NAME]: toolName,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+
+            if (OpenlitConfig.captureMessageContent && args[0]) {
+              try {
+                const argsStr = typeof args[0] === 'string' ? args[0] : JSON.stringify(args[0]);
+                span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_ARGUMENTS, argsStr);
+              } catch { /* ignore */ }
+            }
+
+            const result = await originalMethod.apply(this, args);
+
+            if (OpenlitConfig.captureMessageContent && result !== undefined) {
+              try {
+                const resultStr = typeof result === 'string' ? result : JSON.stringify(result);
+                span.setAttribute(SemanticConvention.GEN_AI_TOOL_CALL_RESULT, resultStr);
+              } catch { /* ignore */ }
+            }
+
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+
+  static patchWorkflowRun(tracer: Tracer): any {
+    return (originalMethod: (...args: any[]) => any) => {
+      return async function (this: any, ...args: any[]) {
+        const workflowName = this?.name || this?.workflow_id || 'workflow';
+        const span = tracer.startSpan(`invoke_workflow ${workflowName}`, {
+          kind: SpanKind.INTERNAL,
+          attributes: {
+            [SemanticConvention.GEN_AI_OPERATION]: SemanticConvention.GEN_AI_OPERATION_TYPE_FRAMEWORK,
+            [SemanticConvention.GEN_AI_PROVIDER_NAME_OTEL]: AI_SYSTEM,
+            [SemanticConvention.GEN_AI_WORKFLOW_NAME]: workflowName,
+          },
+        });
+
+        return context.with(trace.setSpan(context.active(), span), async () => {
+          try {
+            setCommonAttrs(span);
+            applyCustomSpanAttributes(span);
+            const result = await originalMethod.apply(this, args);
+            span.setStatus({ code: 1 /* OK */ });
+            return result;
+          } catch (e: any) {
+            OpenLitHelper.handleException(span, e);
+            throw e;
+          } finally {
+            span.end();
+          }
+        });
+      };
+    };
+  }
+}
+
+export default AgentFrameworkWrapper;

--- a/sdk/typescript/src/instrumentation/agent-framework/wrapper.ts
+++ b/sdk/typescript/src/instrumentation/agent-framework/wrapper.ts
@@ -2,8 +2,7 @@
  * Microsoft Agent Framework span wrappers.
  *
  * Emits OTel GenAI semantic-convention compliant spans:
- *   create_agent     — Agent construction
- *   invoke_agent     — Agent.run
+ *   invoke_agent     — Agent.run (emits create_agent on first call)
  *   execute_tool     — FunctionTool.invoke
  *   invoke_workflow  — Workflow.run
  *
@@ -18,7 +17,7 @@ import OpenLitHelper from '../../helpers';
 import { applyCustomSpanAttributes } from '../../helpers';
 import { SDK_NAME, SDK_VERSION } from '../../constant';
 
-const AI_SYSTEM = 'agent_framework';
+const AI_SYSTEM = SemanticConvention.GEN_AI_SYSTEM_AGENT_FRAMEWORK;
 
 // Thread-safe agent creation registry (maps agent name -> SpanContext)
 const agentRegistry = new Map<string, SpanContext>();
@@ -44,20 +43,6 @@ function resolveModel(instance: any): string | undefined {
 }
 
 class AgentFrameworkWrapper {
-  /**
-   * Patch Agent class to emit create_agent spans on construction.
-   * We mark the prototype with a sentinel so we only patch once.
-   */
-  static patchAgentInit(AgentClass: any, _tracer: Tracer): void {
-    try {
-      AgentClass.prototype.__openlit_af_init_patched = true;
-      // Emit the create_agent span lazily on first invoke_agent instead of
-      // intercepting the constructor (which is complex in JS). The registry-based
-      // approach is used: the first time Agent.run is called, a create_agent span
-      // is emitted if not already registered.
-    } catch { /* ignore */ }
-  }
-
   static patchAgentRun(tracer: Tracer): any {
     return (originalMethod: (...args: any[]) => any) => {
       return async function (this: any, ...args: any[]) {

--- a/sdk/typescript/src/instrumentation/index.ts
+++ b/sdk/typescript/src/instrumentation/index.ts
@@ -40,6 +40,7 @@ import AssemblyAIInstrumentation from './assemblyai';
 import TransformersInstrumentation from './transformers';
 import PgInstrumentation from './pg';
 import FirecrawlInstrumentation from './firecrawl';
+import AgentFrameworkInstrumentation from './agent-framework';
 
 /**
  * OTel community instrumentations loaded dynamically (like Python SDK).
@@ -122,6 +123,7 @@ export default class Instrumentations {
     transformers: new TransformersInstrumentation(),
     pg: new PgInstrumentation(),
     firecrawl: new FirecrawlInstrumentation(),
+    'agent-framework': new AgentFrameworkInstrumentation(),
   };
 
   static setup(

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -323,6 +323,7 @@ export default class SemanticConvention {
   static GEN_AI_SYSTEM_MEM0 = 'mem0';
   static GEN_AI_SYSTEM_BROWSER_USE = 'browser_use';
   static GEN_AI_SYSTEM_FIRECRAWL = 'firecrawl';
+  static GEN_AI_SYSTEM_AGENT_FRAMEWORK = 'agent_framework';
 
   // ----- MCP (Model Context Protocol) -----
   // Operation types

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -3,7 +3,7 @@ import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { metrics } from '@opentelemetry/api';
 import type { Guard } from './guard/base';
 
-export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'vertexai' | 'together' | 'ollama' | 'vllm' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'browser-use' | 'mcp' | 'mem0' | 'elevenlabs' | 'assemblyai' | 'transformers' | 'pg' | 'firecrawl';
+export type InstrumentationType = 'openai' | 'anthropic' | 'cohere' | 'groq' | 'mistral' | 'google-ai' | 'vertexai' | 'together' | 'ollama' | 'vllm' | 'vercel-ai' | 'langchain' | 'langgraph' | 'pinecone' | 'bedrock' | 'llamaindex' | 'huggingface' | 'replicate' | 'chroma' | 'qdrant' | 'milvus' | 'astra' | 'azure-ai-inference' | 'openai-agents' | 'strands' | 'google-adk' | 'claude-agent-sdk' | 'cursor-sdk' | 'ai21' | 'gradient' | 'browser-use' | 'mcp' | 'mem0' | 'elevenlabs' | 'assemblyai' | 'transformers' | 'pg' | 'firecrawl' | 'agent-framework';
 
 export type OpenlitInstrumentations = Partial<Record<InstrumentationType, any>>;
 


### PR DESCRIPTION
Closes #1240

## Summary

Adds TypeScript auto-instrumentation for the Microsoft Agent Framework (`agent-framework` npm package), achieving parity with the Python SDK's `agent_framework` instrumentation.

## Changes

- Added `sdk/typescript/src/instrumentation/agent-framework/index.ts` — `InstrumentationBase` subclass that patches `Agent.run`, `FunctionTool.invoke`, and `Workflow.run`
- Added `sdk/typescript/src/instrumentation/agent-framework/wrapper.ts` — emits OTel GenAI semconv spans: `create_agent`, `invoke_agent`, `execute_tool` (FunctionTool), `invoke_workflow` (Workflow)
- Added `GEN_AI_SYSTEM_AGENT_FRAMEWORK = 'agent_framework'` constant to `semantic-convention.ts` (mirrors Python SDK value)
- Registered `agent-framework` in `InstrumentationType` union and `Instrumentations.availableInstrumentations`

## Span Coverage

| Method | Span Name | Kind | Notes |
|--------|-----------|------|-------|
| `Agent.run` (first call) | `create_agent {name}` | CLIENT | Lazy create_agent on first invocation; registers span context |
| `Agent.run` | `invoke_agent {name}` | CLIENT | Links back to create_agent span |
| `FunctionTool.invoke` | `execute_tool {name}` | INTERNAL | Captures args/result when `captureMessageContent` enabled |
| `Workflow.run` | `invoke_workflow {name}` | INTERNAL | Multi-agent workflow coordination |

Follows zero-provider-dependency rule; all types are duck-typed. If `agent-framework` is not installed, the instrumentation is a silent no-op.

## Summary by Sourcery

Add OpenTelemetry-based auto-instrumentation for the Microsoft Agent Framework in the TypeScript SDK and register it as a supported instrumentation target.

New Features:
- Introduce AgentFrameworkInstrumentation to auto-instrument Agent, FunctionTool, and Workflow classes from the Microsoft Agent Framework.
- Emit GenAI semantic-convention spans for agent creation, agent invocation, tool execution, and workflow invocation in the TypeScript SDK.
- Expose a new GEN_AI_SYSTEM_AGENT_FRAMEWORK semantic convention identifier for Microsoft Agent Framework spans.
- Register 'agent-framework' as a valid instrumentation type and include it in the available instrumentations map.