### PR TITLE
fix: skip coverage PR comments for fork pull requests

### DIFF
--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -80,27 +80,43 @@ jobs:
                 : []),
             ].join('\n');
 
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
+            const fromFork =
+              context.payload.pull_request?.head?.repo?.full_name !==
+              context.repo.owner + '/' + context.repo.repo;
 
-            const existing = comments.find((c) => c.body.includes(MARKER));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
+            if (!fromFork) {
+              try {
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                });
+
+                const existing = comments.find((c) => c.body.includes(MARKER));
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    body,
+                  });
+                }
+              } catch (error) {
+                core.warning(
+                  `Could not post coverage comment: ${error.message}`
+                );
+              }
             } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
+              core.info(
+                'Skipping PR coverage comment: fork PRs cannot write comments with GITHUB_TOKEN.'
+              );
             }
 
             if (overall < 80) {


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Skip posting UI test coverage PR comments on forked pull requests and add logging for failures.

Bug Fixes:
- Prevent workflow failures by avoiding coverage comment posting on forked pull requests that cannot use GITHUB_TOKEN.

Enhancements:
- Add informative logging when coverage comments cannot be posted or are intentionally skipped.