### PR TITLE
feat(typescript): add GPU metrics instrumentation (parity with Python gpu instrumentor)

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -208,6 +208,7 @@ Below is a detailed overview of the configuration options available, allowing yo
 | `disabledInstrumentations` | List of instrumentations to disable.                                                    | `undefined`                                                             | No       |
 | `instrumentations`        | Object of instrumentation modules for manual patching                                          | `undefined`                                                            | No       |
 | `pricingJson`           | URL or file path of the pricing JSON file.                                           | `https://github.com/openlit/openlit/blob/main/assets/pricing.json` | No       |
+| `collectGpuStats`       | Collect host GPU metrics (utilization, memory, temperature, power) via `nvidia-smi`. Requires metrics enabled and an NVIDIA GPU host; no-ops elsewhere. Env: `OPENLIT_COLLECT_GPU_STATS`. | `false` | No       |
 
 ### OpenLIT Prompt Hub - `Openlit.getPrompt()`
 

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -20,6 +20,7 @@ import { runEval, runEvalBatch, fetchEvalTypes } from './evals';
 import { logScore } from './score';
 import { TracedSpan, startTrace, trace as traceManual } from './manual-trace';
 import Metrics from './otel/metrics';
+import { setupGpuInstrumentation } from './instrumentation/gpu';
 import SemanticConvention from './semantic-convention';
 import { parseBoolEnv } from './otel/utils';
 import { setupAutoGuards } from './guard/integration';
@@ -98,6 +99,12 @@ function resolveOptions(options?: OpenlitOptions): ResolvedOptions {
     disableEvents = envDisableEvents ?? false;
   }
 
+  let collectGpuStats = o.collectGpuStats ?? undefined;
+  const envCollectGpuStats = parseBoolEnv('OPENLIT_COLLECT_GPU_STATS');
+  if (collectGpuStats === undefined) {
+    collectGpuStats = envCollectGpuStats ?? false;
+  }
+
   const openlitApiKey = o.openlitApiKey ?? process.env.OPENLIT_API_KEY ?? undefined;
   const openlitUrl = o.openlitUrl ?? process.env.OPENLIT_URL ?? undefined;
 
@@ -113,6 +120,7 @@ function resolveOptions(options?: OpenlitOptions): ResolvedOptions {
     instrumentations: o.instrumentations,
     disableMetrics,
     disableEvents,
+    collectGpuStats,
     pricingJson: o.pricingJson,
     maxContentLength: o.maxContentLength ?? null,
     customSpanAttributes: o.customSpanAttributes ?? null,
@@ -199,10 +207,25 @@ class Openlit extends BaseOpenlit {
         const exportIntervalMillis =
           Number(process.env.OTEL_EXPORTER_OTLP_METRICS_EXPORT_INTERVAL ?? 60000) || 60000;
 
-        Metrics.setup({
+        const meter = Metrics.setup({
           ...setupBase,
           exportIntervalMillis,
         });
+
+        // GPU stats ride on the metrics pipeline, so they require metrics to
+        // be enabled. Fire-and-forget: detection shells out to `nvidia-smi`
+        // and no-ops on non-GPU hosts.
+        if (resolved.collectGpuStats && meter) {
+          setupGpuInstrumentation({
+            meter,
+            environment: resolved.environment,
+            applicationName: resolved.applicationName,
+          }).catch((e) => console.error('OpenLIT GPU instrumentation setup failed:', e));
+        }
+      } else if (resolved.collectGpuStats) {
+        console.warn(
+          'OpenLIT: collectGpuStats was enabled but metrics are disabled; GPU stats will not be collected.'
+        );
       }
 
       OpenlitConfig.openlitApiKey = resolved.openlitApiKey;

--- a/sdk/typescript/src/instrumentation/__tests__/gpu-collector.test.ts
+++ b/sdk/typescript/src/instrumentation/__tests__/gpu-collector.test.ts
@@ -1,0 +1,210 @@
+import {
+  parseNumber,
+  parseNvidiaSmiCsv,
+  isNvidiaSmiAvailable,
+  queryNvidiaSmi,
+  NVIDIA_SMI_FIELDS,
+  ExecFileLike,
+} from '../gpu/collector';
+import { setupGpuInstrumentation } from '../gpu';
+import SemanticConvention from '../../semantic-convention';
+
+// A realistic two-GPU `nvidia-smi --format=csv,noheader,nounits` payload.
+// Field order matches NVIDIA_SMI_FIELDS.
+const SAMPLE_CSV = [
+  '0, GPU-aaaaaaaa-1111, NVIDIA A100-SXM4-40GB, 45, 3, 1, 62, 30, 12000, 40536, 28536, 250.35, 400.00',
+  '1, GPU-bbbbbbbb-2222, NVIDIA A100-SXM4-40GB, 0, 0, 0, 40, 0, 40000, 40536, 536, 55.10, 400.00',
+].join('\n');
+
+describe('gpu/collector parseNumber', () => {
+  it('parses numeric strings', () => {
+    expect(parseNumber('45')).toBe(45);
+    expect(parseNumber(' 250.35 ')).toBeCloseTo(250.35);
+  });
+
+  it('coerces non-numeric / unsupported values to 0', () => {
+    expect(parseNumber('[N/A]')).toBe(0);
+    expect(parseNumber('[Not Supported]')).toBe(0);
+    expect(parseNumber('')).toBe(0);
+  });
+});
+
+describe('gpu/collector parseNvidiaSmiCsv', () => {
+  it('parses one row per GPU with correct field mapping', () => {
+    const rows = parseNvidiaSmiCsv(SAMPLE_CSV);
+    expect(rows).toHaveLength(2);
+
+    expect(rows[0]).toEqual({
+      index: '0',
+      uuid: 'GPU-aaaaaaaa-1111',
+      name: 'NVIDIA A100-SXM4-40GB',
+      utilization: 45,
+      utilizationEnc: 3,
+      utilizationDec: 1,
+      temperature: 62,
+      fanSpeed: 30,
+      memoryFree: 12000,
+      memoryTotal: 40536,
+      memoryUsed: 28536,
+      powerDraw: 250.35,
+      powerLimit: 400,
+    });
+    expect(rows[1].index).toBe('1');
+    expect(rows[1].utilization).toBe(0);
+    expect(rows[1].powerDraw).toBeCloseTo(55.1);
+  });
+
+  it('ignores blank lines and malformed rows', () => {
+    const raw = `\n${SAMPLE_CSV}\n\ntoo, few, cols\n`;
+    expect(parseNvidiaSmiCsv(raw)).toHaveLength(2);
+  });
+
+  it('reconstructs GPU names that contain commas', () => {
+    const raw = '0, GPU-xyz, Fancy GPU, Turbo Edition, 10, 0, 0, 50, 0, 100, 200, 100, 30, 60';
+    const rows = parseNvidiaSmiCsv(raw);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe('Fancy GPU, Turbo Edition');
+    expect(rows[0].utilization).toBe(10);
+    expect(rows[0].powerLimit).toBe(60);
+  });
+
+  it('maps unsupported metric cells to 0', () => {
+    const raw = '0, GPU-zzz, NVIDIA T4, [N/A], [Not Supported], 0, 55, [N/A], 8000, 16000, 8000, 40, 70';
+    const rows = parseNvidiaSmiCsv(raw);
+    expect(rows[0].utilization).toBe(0);
+    expect(rows[0].utilizationEnc).toBe(0);
+    expect(rows[0].fanSpeed).toBe(0);
+    expect(rows[0].temperature).toBe(55);
+  });
+});
+
+describe('gpu/collector isNvidiaSmiAvailable', () => {
+  it('resolves true when nvidia-smi -L lists a GPU', async () => {
+    const fakeExec: ExecFileLike = (_file, _args, _opts, cb) =>
+      cb(null, 'GPU 0: NVIDIA A100 (UUID: GPU-aaaa)\n', '');
+    await expect(isNvidiaSmiAvailable(fakeExec)).resolves.toBe(true);
+  });
+
+  it('resolves false when nvidia-smi errors (non-GPU host)', async () => {
+    const fakeExec: ExecFileLike = (_file, _args, _opts, cb) =>
+      cb(new Error('command not found'), '', '');
+    await expect(isNvidiaSmiAvailable(fakeExec)).resolves.toBe(false);
+  });
+
+  it('resolves false when nvidia-smi returns empty output', async () => {
+    const fakeExec: ExecFileLike = (_file, _args, _opts, cb) => cb(null, '   \n', '');
+    await expect(isNvidiaSmiAvailable(fakeExec)).resolves.toBe(false);
+  });
+});
+
+describe('gpu/collector queryNvidiaSmi', () => {
+  it('queries all fields and returns parsed rows', async () => {
+    let requestedArgs: string[] = [];
+    const fakeExec: ExecFileLike = (_file, args, _opts, cb) => {
+      requestedArgs = args;
+      cb(null, SAMPLE_CSV, '');
+    };
+    const rows = await queryNvidiaSmi(fakeExec);
+    expect(rows).toHaveLength(2);
+    expect(requestedArgs[0]).toBe(`--query-gpu=${NVIDIA_SMI_FIELDS.join(',')}`);
+    expect(requestedArgs).toContain('--format=csv,noheader,nounits');
+  });
+
+  it('resolves to [] on error instead of throwing', async () => {
+    const fakeExec: ExecFileLike = (_file, _args, _opts, cb) => cb(new Error('boom'), '', '');
+    await expect(queryNvidiaSmi(fakeExec)).resolves.toEqual([]);
+  });
+});
+
+// Minimal fake meter capturing observable-gauge registration + the batch callback.
+function makeFakeMeter() {
+  const gauges: Array<{ name: string; description?: string }> = [];
+  let batchCallback: ((result: any) => unknown) | undefined;
+  const meter = {
+    createObservableGauge(name: string, opts?: { description?: string }) {
+      const g = { name, description: opts?.description };
+      gauges.push(g);
+      return g as any;
+    },
+    addBatchObservableCallback(cb: (result: any) => unknown, _observables: unknown[]) {
+      batchCallback = cb;
+    },
+  };
+  return { meter, gauges, runBatch: () => batchCallback };
+}
+
+describe('setupGpuInstrumentation', () => {
+  it('no-ops and returns false when no GPU is detected', async () => {
+    const { meter, gauges } = makeFakeMeter();
+    const ok = await setupGpuInstrumentation({
+      meter: meter as any,
+      environment: 'test',
+      applicationName: 'app',
+      detectFn: async () => false,
+      queryFn: async () => [],
+    });
+    expect(ok).toBe(false);
+    expect(gauges).toHaveLength(0);
+  });
+
+  it('registers 11 gauges and observes every metric per GPU', async () => {
+    const { meter, gauges, runBatch } = makeFakeMeter();
+    const ok = await setupGpuInstrumentation({
+      meter: meter as any,
+      environment: 'prod',
+      applicationName: 'inference-svc',
+      detectFn: async () => true,
+      queryFn: async () => parseNvidiaSmiCsv(SAMPLE_CSV),
+    });
+    expect(ok).toBe(true);
+    expect(gauges).toHaveLength(11);
+    expect(gauges.map((g) => g.name)).toContain(SemanticConvention.GPU_UTILIZATION);
+    expect(gauges.map((g) => g.name)).toContain(SemanticConvention.GPU_POWER_LIMIT);
+
+    // Drive the batch callback and capture observations.
+    const observations: Array<{ gauge: any; value: number; attrs: any }> = [];
+    const result = {
+      observe: (gauge: any, value: number, attrs: any) =>
+        observations.push({ gauge, value, attrs }),
+    };
+    await runBatch()!(result);
+
+    // 11 gauges x 2 GPUs = 22 observations.
+    expect(observations).toHaveLength(22);
+
+    // Spot-check GPU 0 utilization observation + its attributes.
+    const utilGauge = gauges.find((g) => g.name === SemanticConvention.GPU_UTILIZATION);
+    const gpu0Util = observations.find(
+      (o) => o.gauge === utilGauge && o.attrs[SemanticConvention.GPU_INDEX] === '0'
+    );
+    expect(gpu0Util?.value).toBe(45);
+    expect(gpu0Util?.attrs[SemanticConvention.GPU_NAME]).toBe('NVIDIA A100-SXM4-40GB');
+    expect(gpu0Util?.attrs[SemanticConvention.GPU_UUID]).toBe('GPU-aaaaaaaa-1111');
+    expect(gpu0Util?.attrs['telemetry.sdk.name']).toBe('openlit');
+    expect(gpu0Util?.attrs['service.name']).toBe('inference-svc');
+
+    // gpu.memory.available maps to free memory (parity with Python).
+    const availGauge = gauges.find((g) => g.name === SemanticConvention.GPU_MEMORY_AVAILABLE);
+    const gpu0Avail = observations.find(
+      (o) => o.gauge === availGauge && o.attrs[SemanticConvention.GPU_INDEX] === '0'
+    );
+    expect(gpu0Avail?.value).toBe(12000);
+  });
+
+  it('swallows query errors during a collection tick without throwing', async () => {
+    const { meter, runBatch } = makeFakeMeter();
+    await setupGpuInstrumentation({
+      meter: meter as any,
+      environment: 'prod',
+      applicationName: 'app',
+      detectFn: async () => true,
+      queryFn: async () => {
+        throw new Error('nvidia-smi vanished');
+      },
+    });
+    const observations: unknown[] = [];
+    const result = { observe: () => observations.push(1) };
+    await expect(runBatch()!(result)).resolves.not.toThrow();
+    expect(observations).toHaveLength(0);
+  });
+});

--- a/sdk/typescript/src/instrumentation/gpu/collector.ts
+++ b/sdk/typescript/src/instrumentation/gpu/collector.ts
@@ -1,0 +1,161 @@
+import { execFile } from 'child_process';
+
+/**
+ * GPU stats collection for the JS SDK.
+ *
+ * Unlike the Python SDK (which binds NVML via `pynvml`/`amdsmi`), the JS SDK
+ * shells out to the `nvidia-smi` CLI — as suggested in the feature request —
+ * so there is no native dependency to build. A single `--query-gpu` call
+ * returns every metric we need for all GPUs at once, which we parse here.
+ *
+ * Everything in this file is pure/dependency-injectable so it can be unit
+ * tested without a real GPU.
+ */
+
+/**
+ * `nvidia-smi --query-gpu` fields, in order. The parser relies on this order.
+ * The trailing 10 fields are always numeric; only `name` (index 2) may contain
+ * commas, so the parser reconstructs it from whatever sits between the two
+ * fixed-width ends.
+ */
+export const NVIDIA_SMI_FIELDS = [
+  'index',
+  'uuid',
+  'name',
+  'utilization.gpu',
+  'utilization.encoder',
+  'utilization.decoder',
+  'temperature.gpu',
+  'fan.speed',
+  'memory.free',
+  'memory.total',
+  'memory.used',
+  'power.draw',
+  'power.limit',
+] as const;
+
+/** Number of trailing numeric columns (everything after `name`). */
+const NUMERIC_COLS = NVIDIA_SMI_FIELDS.length - 3;
+
+export interface GpuStatsRow {
+  index: string;
+  uuid: string;
+  name: string;
+  utilization: number;
+  utilizationEnc: number;
+  utilizationDec: number;
+  temperature: number;
+  fanSpeed: number;
+  memoryFree: number;
+  memoryTotal: number;
+  memoryUsed: number;
+  powerDraw: number;
+  powerLimit: number;
+}
+
+/**
+ * Coerce an `nvidia-smi` cell to a number. Non-numeric values such as
+ * `[N/A]` or `[Not Supported]` (emitted for unsupported metrics) become 0,
+ * matching the Python instrumentor's fallback.
+ */
+export function parseNumber(value: string): number {
+  const n = Number(String(value).trim());
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Parse the CSV output of
+ * `nvidia-smi --query-gpu=... --format=csv,noheader,nounits`
+ * into one {@link GpuStatsRow} per GPU. Pure — safe to unit test.
+ */
+export function parseNvidiaSmiCsv(raw: string): GpuStatsRow[] {
+  const rows: GpuStatsRow[] = [];
+
+  for (const line of String(raw).split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const cols = trimmed.split(',').map((c) => c.trim());
+    if (cols.length < NVIDIA_SMI_FIELDS.length) continue;
+
+    // The last NUMERIC_COLS columns are always numeric; index/uuid never
+    // contain commas. Any extra columns in between belong to a GPU name that
+    // itself contained a comma, so stitch them back together.
+    const numeric = cols.slice(cols.length - NUMERIC_COLS);
+    const name = cols.slice(2, cols.length - NUMERIC_COLS).join(', ');
+
+    rows.push({
+      index: cols[0],
+      uuid: cols[1],
+      name,
+      utilization: parseNumber(numeric[0]),
+      utilizationEnc: parseNumber(numeric[1]),
+      utilizationDec: parseNumber(numeric[2]),
+      temperature: parseNumber(numeric[3]),
+      fanSpeed: parseNumber(numeric[4]),
+      memoryFree: parseNumber(numeric[5]),
+      memoryTotal: parseNumber(numeric[6]),
+      memoryUsed: parseNumber(numeric[7]),
+      powerDraw: parseNumber(numeric[8]),
+      powerLimit: parseNumber(numeric[9]),
+    });
+  }
+
+  return rows;
+}
+
+/** Injectable form of `child_process.execFile` for testing. */
+export type ExecFileLike = (
+  file: string,
+  args: string[],
+  options: { timeout?: number },
+  callback: (error: Error | null, stdout: string, stderr: string) => void
+) => void;
+
+const defaultExecFile: ExecFileLike = (file, args, options, callback) => {
+  execFile(file, args, options, (error, stdout, stderr) =>
+    callback(error, String(stdout), String(stderr))
+  );
+};
+
+/**
+ * Returns true when `nvidia-smi` is present and lists at least one GPU.
+ * Never throws — resolves false on any error (missing binary, non-GPU host).
+ */
+export function isNvidiaSmiAvailable(execFileFn: ExecFileLike = defaultExecFile): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      execFileFn('nvidia-smi', ['-L'], { timeout: 5000 }, (error, stdout) => {
+        resolve(!error && String(stdout).trim().length > 0);
+      });
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/**
+ * Query `nvidia-smi` once and return parsed per-GPU stats. Never throws —
+ * resolves to an empty array on any failure so a transient error during a
+ * metric-export tick simply reports no observations for that tick.
+ */
+export function queryNvidiaSmi(execFileFn: ExecFileLike = defaultExecFile): Promise<GpuStatsRow[]> {
+  return new Promise((resolve) => {
+    try {
+      execFileFn(
+        'nvidia-smi',
+        [`--query-gpu=${NVIDIA_SMI_FIELDS.join(',')}`, '--format=csv,noheader,nounits'],
+        { timeout: 5000 },
+        (error, stdout) => {
+          if (error) {
+            resolve([]);
+            return;
+          }
+          resolve(parseNvidiaSmiCsv(String(stdout)));
+        }
+      );
+    } catch {
+      resolve([]);
+    }
+  });
+}

--- a/sdk/typescript/src/instrumentation/gpu/index.ts
+++ b/sdk/typescript/src/instrumentation/gpu/index.ts
@@ -1,0 +1,107 @@
+import { diag } from '@opentelemetry/api';
+import type { Meter, Attributes } from '@opentelemetry/api';
+import { ATTR_SERVICE_NAME, ATTR_TELEMETRY_SDK_NAME } from '@opentelemetry/semantic-conventions';
+import SemanticConvention from '../../semantic-convention';
+import {
+  GpuStatsRow,
+  isNvidiaSmiAvailable,
+  queryNvidiaSmi,
+} from './collector';
+
+/**
+ * The 11 GPU gauges, mapping each OpenLIT metric name to a field on
+ * {@link GpuStatsRow}. Names are kept identical to the Python `gpu`
+ * instrumentor so both SDKs feed the same OpenLIT dashboards.
+ *
+ * Note: `gpu.memory.available` intentionally maps to free memory, matching
+ * the Python instrumentor (which assumes reserved memory is 0).
+ */
+const GPU_METRICS: ReadonlyArray<{
+  name: string;
+  field: keyof GpuStatsRow;
+  description: string;
+}> = [
+  { name: SemanticConvention.GPU_UTILIZATION, field: 'utilization', description: 'GPU Utilization' },
+  { name: SemanticConvention.GPU_UTILIZATION_ENC, field: 'utilizationEnc', description: 'GPU Utilization Enc' },
+  { name: SemanticConvention.GPU_UTILIZATION_DEC, field: 'utilizationDec', description: 'GPU Utilization Dec' },
+  { name: SemanticConvention.GPU_TEMPERATURE, field: 'temperature', description: 'GPU Temperature' },
+  { name: SemanticConvention.GPU_FAN_SPEED, field: 'fanSpeed', description: 'GPU Fan Speed' },
+  { name: SemanticConvention.GPU_MEMORY_AVAILABLE, field: 'memoryFree', description: 'GPU Memory Available' },
+  { name: SemanticConvention.GPU_MEMORY_TOTAL, field: 'memoryTotal', description: 'GPU Memory Total' },
+  { name: SemanticConvention.GPU_MEMORY_USED, field: 'memoryUsed', description: 'GPU Memory Used' },
+  { name: SemanticConvention.GPU_MEMORY_FREE, field: 'memoryFree', description: 'GPU Memory Free' },
+  { name: SemanticConvention.GPU_POWER_DRAW, field: 'powerDraw', description: 'GPU Power Draw' },
+  { name: SemanticConvention.GPU_POWER_LIMIT, field: 'powerLimit', description: 'GPU Power Limit' },
+];
+
+export interface GpuInstrumentationOptions {
+  meter: Meter;
+  environment: string;
+  applicationName: string;
+  /** Injectable for tests. Defaults to a real `nvidia-smi` query. */
+  queryFn?: () => Promise<GpuStatsRow[]>;
+  /** Injectable for tests. Defaults to a real `nvidia-smi -L` probe. */
+  detectFn?: () => Promise<boolean>;
+}
+
+/**
+ * Register GPU metric collection on the given meter. Detects a GPU once (via
+ * `nvidia-smi`); if none is present it logs and no-ops, mirroring the Python
+ * instrumentor. When present, it registers 11 observable gauges and a single
+ * batch callback that runs one `nvidia-smi` query per export tick and reports
+ * every metric for every GPU.
+ *
+ * @returns true if GPU collection was registered, false if no GPU was found.
+ */
+export async function setupGpuInstrumentation(
+  options: GpuInstrumentationOptions
+): Promise<boolean> {
+  const { meter, environment, applicationName } = options;
+  const detectFn = options.detectFn ?? (() => isNvidiaSmiAvailable());
+  const queryFn = options.queryFn ?? (() => queryNvidiaSmi());
+
+  const available = await detectFn();
+  if (!available) {
+    diag.error(
+      'OpenLIT GPU Instrumentation Error: No supported GPUs found (nvidia-smi unavailable). ' +
+        'If this is a non-GPU host, set `collectGpuStats: false` to disable GPU stats.'
+    );
+    return false;
+  }
+
+  const gauges = GPU_METRICS.map((m) => ({
+    field: m.field,
+    gauge: meter.createObservableGauge(m.name, { description: m.description }),
+  }));
+
+  meter.addBatchObservableCallback(
+    async (result) => {
+      let rows: GpuStatsRow[];
+      try {
+        rows = await queryFn();
+      } catch (e) {
+        diag.error(`OpenLIT GPU Instrumentation: metric collection failed: ${e}`);
+        return;
+      }
+
+      for (const row of rows) {
+        const attributes: Attributes = {
+          [ATTR_TELEMETRY_SDK_NAME]: 'openlit',
+          [ATTR_SERVICE_NAME]: applicationName,
+          [SemanticConvention.ATTR_DEPLOYMENT_ENVIRONMENT]: environment,
+          [SemanticConvention.GPU_INDEX]: String(row.index),
+          [SemanticConvention.GPU_UUID]: row.uuid,
+          [SemanticConvention.GPU_NAME]: row.name,
+        };
+        for (const { gauge, field } of gauges) {
+          result.observe(gauge, row[field] as number, attributes);
+        }
+      }
+    },
+    gauges.map((g) => g.gauge)
+  );
+
+  return true;
+}
+
+export { GpuStatsRow } from './collector';

--- a/sdk/typescript/src/semantic-convention.ts
+++ b/sdk/typescript/src/semantic-convention.ts
@@ -468,6 +468,23 @@ export default class SemanticConvention {
   static GEN_AI_EXECUTION_MODE = 'gen_ai.execution.mode';
   static GEN_AI_CHECKPOINT_ID = 'gen_ai.checkpoint.id';
 
+  // GPU metrics (parity with Python `gpu` instrumentor — keep names identical
+  // so OpenLIT dashboards render Python and JS GPU stats from the same series).
+  static GPU_INDEX = 'gpu.index';
+  static GPU_UUID = 'gpu.uuid';
+  static GPU_NAME = 'gpu.name';
+  static GPU_UTILIZATION = 'gpu.utilization';
+  static GPU_UTILIZATION_ENC = 'gpu.enc.utilization';
+  static GPU_UTILIZATION_DEC = 'gpu.dec.utilization';
+  static GPU_TEMPERATURE = 'gpu.temperature';
+  static GPU_FAN_SPEED = 'gpu.fan_speed';
+  static GPU_MEMORY_AVAILABLE = 'gpu.memory.available';
+  static GPU_MEMORY_TOTAL = 'gpu.memory.total';
+  static GPU_MEMORY_USED = 'gpu.memory.used';
+  static GPU_MEMORY_FREE = 'gpu.memory.free';
+  static GPU_POWER_DRAW = 'gpu.power.draw';
+  static GPU_POWER_LIMIT = 'gpu.power.limit';
+
   // Vector DB
   static DB_REQUESTS = 'db.total.requests';
   static DB_SYSTEM = 'db.system';

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -58,6 +58,12 @@ export type OpenlitOptions = {
   instrumentations?: OpenlitInstrumentations;
   disableMetrics?: boolean;
   disableEvents?: boolean;
+  /**
+   * Collect host GPU metrics (utilization, memory, temperature, power, …) via
+   * `nvidia-smi`. Off by default. Requires metrics to be enabled and a GPU
+   * host; on a non-GPU host it logs and no-ops. Python: `collect_gpu_stats`.
+   */
+  collectGpuStats?: boolean;
   pricingJson?: string | PricingObject;
   maxContentLength?: number | null;
   customSpanAttributes?: Record<string, string> | null;
@@ -82,6 +88,7 @@ export interface ResolvedOptions {
   instrumentations?: OpenlitInstrumentations;
   disableMetrics: boolean;
   disableEvents: boolean;
+  collectGpuStats: boolean;
   pricingJson?: string | PricingObject;
   maxContentLength?: number | null;
   customSpanAttributes?: Record<string, string> | null;


### PR DESCRIPTION
## What

Adds a GPU metrics collector to the **TypeScript SDK**, at parity with the Python `gpu` instrumentor, so Node-based inference services (Triton clients, local model servers, custom CUDA wrappers) can get GPU utilization / memory / temperature / power metrics into OpenLIT.

Fixes #1244

## Approach

This follows the plan discussed on the issue (dependency-free, NVIDIA-only first pass):

- **No native dependency.** Instead of binding NVML (as Python does via `pynvml`/`amdsmi`), the SDK shells out to the driver-provided `nvidia-smi` CLI via `child_process.execFile`. Nothing to compile at install time.
- **One query per collection cycle.** A single `nvidia-smi --query-gpu=...` call returns every metric for all GPUs at once; it runs inside a batch observable callback, so the cost is one process spawn per OTel export tick regardless of GPU count.
- **Shared dashboards.** Emits the same legacy `gpu.*` metric names and `gpu.{index,uuid,name}` attributes as the Python instrumentor (utilization 0–100, memory in MiB), so existing OpenLIT GPU dashboards work unchanged.
- **Opt-out safe.** Detects a GPU once via `nvidia-smi -L`; on a non-GPU host it logs and no-ops rather than throwing. A transient failure during a tick reports no observations for that tick instead of crashing the meter.
- **Testable by construction.** The collector (CSV parsing, number coercion, `execFile` wrapper) is pure and dependency-injectable, so the full path is unit-tested without a real GPU.

Enabled via `collectGpuStats` on `openlit.init()`.

## Scope / follow-ups (called out honestly)

- **NVIDIA only.** AMD (`amd-smi`) and Intel are intentionally out of scope for this PR and would be explicit follow-ups.
- **Legacy `gpu.*` names**, matching the Python instrumentor and current dashboards — *not* the OTel `hw.gpu.*` semantics the standalone Go collector uses. Migrating both SDKs + dashboards to `hw.gpu.*` is a separate, coordinated change.

## How I verified

Full build + test + lint in a **clean `node:20` Docker container** (`npm ci` from lockfile — no local `node_modules`):

- `tsc --build` — clean
- `jest --runInBand` — **576/576 pass, 42 suites** (14 new GPU tests: CSV parsing incl. comma-containing GPU names, `[N/A]`/`[Not Supported]` → 0 coercion, detection true/false/empty, gauge registration + per-GPU observation, and error-swallowing during a tick)
- `eslint src/` — clean

## Files

- `src/instrumentation/gpu/collector.ts` — pure `nvidia-smi` query + CSV parser
- `src/instrumentation/gpu/index.ts` — meter wiring (11 observable gauges + batch callback)
- `src/instrumentation/__tests__/gpu-collector.test.ts` — 14 tests
- `src/index.ts`, `src/types.ts`, `src/semantic-convention.ts` — `collectGpuStats` option + GPU semantic conventions
- `README.md` — documents the option
