### PR TITLE
feat: add OCI GenAI instrumentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -265,6 +265,7 @@
                   "latest/sdk/integrations/azure-ai-inference",
                   "latest/sdk/integrations/huggingface",
                   "latest/sdk/integrations/bedrock",
+                  "latest/sdk/integrations/oci",
                   "latest/sdk/integrations/vertexai",
                   "latest/sdk/integrations/google-ai-studio",
                   "latest/sdk/integrations/groq",

--- a/docs/latest/sdk/integrations/oci.mdx
+++ b/docs/latest/sdk/integrations/oci.mdx
@@ -1,0 +1,52 @@
+---
+title: 'Monitor OCI Generative AI using OpenTelemetry'
+sidebarTitle: 'OCI GenAI'
+---
+
+import IntegrationMethods from '/snippets/integration-methods.mdx';
+
+OpenLIT uses OpenTelemetry Auto-Instrumentation to help you monitor LLM applications built using models from Oracle Cloud Infrastructure (OCI) Generative AI. This includes tracking performance, token usage, costs, and how users interact with the application.
+
+Auto-instrumentation means you don't have to set up monitoring manually for different LLMs, frameworks, or databases. By simply adding OpenLIT in your application, all the necessary monitoring configurations are automatically set up.
+
+The integration is compatible with  
+- OCI Python SDK `oci >= 2.100.0`
+
+It instruments the `GenerativeAiInferenceClient` `chat`, `generate_text`, and `embed_text` calls, covering both the direct OCI SDK and LangChain's `ChatOCIGenAI` / `OCIGenAI` wrappers.
+
+## Get started 
+
+<Steps>
+  <Step title="Install OpenLIT">
+    Open your command line or terminal and run:
+    <Tabs>
+      <Tab title="Python">
+        ```shell
+        pip install openlit
+        ```
+      </Tab>
+    </Tabs>
+  </Step>
+  <IntegrationMethods />
+</Steps>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Quickstart: LLM Observability" href="/latest/sdk/quickstart-ai-observability" icon='bolt'>
+    Production-ready AI monitoring setup in 2 simple steps with zero code changes
+  </Card>
+  <Card title="Configuration" href="/latest/sdk/configuration" icon='bolt'>
+    Configure the OpenLIT SDK according to you requirements.
+  </Card>
+  <Card title="Destinations" href="/latest/sdk/destinations/overview" icon='link'>
+    Send telemetry to Datadog, Grafana, New Relic, and other observability stacks
+  </Card>
+</CardGroup>
+<Card
+    title="Zero-code observability with the OpenLIT Controller"
+    icon="tower-broadcast"
+    href="/latest/controller/overview"
+  >
+  Discover and instrument LLM traffic across Kubernetes, Docker, and Linux using eBPF — no code changes required.
+  </Card>

--- a/docs/latest/sdk/integrations/overview.mdx
+++ b/docs/latest/sdk/integrations/overview.mdx
@@ -401,6 +401,18 @@ Start integrating and monitoring your applications with OpenLIT in just one line
 
   </Card>
   <Card
+      title="OCI GenAI"
+      href="/latest/sdk/integrations/oci"
+      icon={
+        <img src="https://cdn.simpleicons.org/oracle/F80000" width="24" height="24" alt="OCI GenAI" title="OCI GenAI" />
+      }
+    >
+    <div style={{position: "absolute", top: "12px", right: "12px", display: "flex", gap: "4px"}}>
+      <img src="https://cdn.simpleicons.org/python/ffa500" width="16" height="16" alt="Python SDK" title="Python SDK" />
+    </div>
+
+  </Card>
+  <Card
       title="Vertex AI"
       href="/latest/sdk/integrations/vertexai"
       icon={

--- a/sdk/python/src/openlit/__helpers.py
+++ b/sdk/python/src/openlit/__helpers.py
@@ -648,6 +648,7 @@ PROVIDER_DEFAULT_ENDPOINTS = {
     "perplexity": ("api.perplexity.ai", 443),
     "deepinfra": ("api.deepinfra.com", 443),
     "aws.bedrock": ("bedrock-runtime.amazonaws.com", 443),
+    "oci_genai": ("inference.generativeai.us-chicago-1.oci.oraclecloud.com", 443),
     "azure": ("openai.azure.com", 443),
     "azure.ai.openai": ("openai.azure.com", 443),
     "azure.ai.inference": ("inference.ai.azure.com", 443),

--- a/sdk/python/src/openlit/__init__.py
+++ b/sdk/python/src/openlit/__init__.py
@@ -78,6 +78,7 @@ CONTROLLER_MANAGED_DISABLED_INSTRUMENTORS = [
     "cohere",
     "mistral",
     "bedrock",
+    "oci",
     "vertexai",
     "groq",
     "ollama",

--- a/sdk/python/src/openlit/_instrumentors.py
+++ b/sdk/python/src/openlit/_instrumentors.py
@@ -12,6 +12,7 @@ MODULE_NAME_MAP = {
     "cohere": "cohere",
     "mistral": "mistralai",
     "bedrock": "boto3",
+    "oci": "oci",
     "vertexai": "vertexai",
     "groq": "groq",
     "ollama": "ollama",
@@ -85,6 +86,8 @@ MODULE_NAME_MAP = {
 # differ from the canonical hyphenated keys used in MODULE_NAME_MAP.
 INSTRUMENTOR_ALIASES = {
     "aiohttp": "aiohttp-client",
+    "oci_genai": "oci",
+    "oci-genai": "oci",
     "openai_agents": "openai-agents",
     "google_ai_studio": "google-ai-studio",
     "azure_ai_inference": "azure-ai-inference",
@@ -133,6 +136,7 @@ INSTRUMENTOR_MAP = {
     "cohere": "openlit.instrumentation.cohere.CohereInstrumentor",
     "mistral": "openlit.instrumentation.mistral.MistralInstrumentor",
     "bedrock": "openlit.instrumentation.bedrock.BedrockInstrumentor",
+    "oci": "openlit.instrumentation.oci_genai.OCIGenAIInstrumentor",
     "vertexai": "openlit.instrumentation.vertexai.VertexAIInstrumentor",
     "groq": "openlit.instrumentation.groq.GroqInstrumentor",
     "ollama": "openlit.instrumentation.ollama.OllamaInstrumentor",

--- a/sdk/python/src/openlit/instrumentation/langchain/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/langchain/__init__.py
@@ -148,6 +148,7 @@ MODEL_PATTERNS = [
     ("VLLM", "model", None),
     ("Xinference", "model_uid", None),
     ("ChatOCIGenAI", "model_id", None),
+    ("OCIGenAI", "model_id", None),
     ("DeepInfra", "model_id", None),
 ]
 
@@ -327,6 +328,7 @@ PROVIDER_MAP = {
     "google_vertexai": "google",
     "groq": "groq",
     "mistralai": "mistral_ai",
+    "oci_generative_ai": "oci_genai",
     "ollama": "ollama",
     "openai": "openai",
     "together": "together",

--- a/sdk/python/src/openlit/instrumentation/oci_genai/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/oci_genai/__init__.py
@@ -1,0 +1,85 @@
+"""Initializer of Auto Instrumentation of OCI GenAI Functions"""
+
+from typing import Collection
+import importlib.metadata
+from opentelemetry import trace, _logs
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from wrapt import wrap_function_wrapper
+
+from openlit._config import OpenlitConfig
+from openlit.instrumentation.oci_genai.oci_genai import chat, generate_text, embed
+
+_instruments = ("oci >= 2.100.0",)
+
+
+class OCIGenAIInstrumentor(BaseInstrumentor):
+    """
+    An instrumentor for Oracle Cloud Infrastructure (OCI) GenAI client library.
+    """
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        version = importlib.metadata.version("oci")
+        environment = kwargs.get("environment", "default")
+        application_name = kwargs.get("application_name", "default")
+        tracer = trace.get_tracer(__name__)
+        pricing_info = kwargs.get("pricing_info", {})
+        capture_message_content = kwargs.get("capture_message_content", False)
+        metrics = OpenlitConfig.metrics_dict
+        disable_metrics = kwargs.get("disable_metrics")
+        event_provider = _logs.get_logger_provider().get_logger(__name__)
+
+        # sync chat
+        wrap_function_wrapper(
+            "oci.generative_ai_inference",
+            "GenerativeAiInferenceClient.chat",
+            chat(
+                version,
+                environment,
+                application_name,
+                tracer,
+                pricing_info,
+                capture_message_content,
+                metrics,
+                disable_metrics,
+                event_provider,
+            ),
+        )
+
+        # sync generate_text (legacy completion API)
+        wrap_function_wrapper(
+            "oci.generative_ai_inference",
+            "GenerativeAiInferenceClient.generate_text",
+            generate_text(
+                version,
+                environment,
+                application_name,
+                tracer,
+                pricing_info,
+                capture_message_content,
+                metrics,
+                disable_metrics,
+                event_provider,
+            ),
+        )
+
+        # sync embeddings
+        wrap_function_wrapper(
+            "oci.generative_ai_inference",
+            "GenerativeAiInferenceClient.embed_text",
+            embed(
+                version,
+                environment,
+                application_name,
+                tracer,
+                pricing_info,
+                capture_message_content,
+                metrics,
+                disable_metrics,
+            ),
+        )
+
+    def _uninstrument(self, **kwargs):
+        pass

--- a/sdk/python/src/openlit/instrumentation/oci_genai/oci_genai.py
+++ b/sdk/python/src/openlit/instrumentation/oci_genai/oci_genai.py
@@ -1,0 +1,293 @@
+"""
+Module for monitoring OCI GenAI API calls.
+"""
+
+import time
+from urllib.parse import urlparse
+
+from opentelemetry.trace import SpanKind
+
+from openlit.__helpers import (
+    handle_exception,
+    is_framework_llm_active,
+    record_completion_metrics,
+    record_embedding_metrics,
+)
+from openlit.instrumentation.oci_genai.utils import (
+    _serving_model_id,
+    process_chat_response,
+    process_generate_text_response,
+    process_embedding_response,
+)
+from openlit.semcov import SemanticConvention
+
+# Default OCI GenAI inference host used when the client endpoint is unavailable.
+_DEFAULT_OCI_HOST = "inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+_DEFAULT_OCI_PORT = 443
+
+
+def _resolve_details(args, kwargs, key):
+    """Resolve an OCI *Details request object passed positionally or by keyword."""
+    if key in kwargs:
+        return kwargs.get(key)
+    return args[0] if args else None
+
+
+def _server_address_and_port(instance):
+    """Derive (address, port) from the OCI client endpoint (base_client.endpoint)."""
+    endpoint = getattr(getattr(instance, "base_client", None), "endpoint", None)
+    if isinstance(endpoint, str) and endpoint:
+        parsed = urlparse(endpoint if "://" in endpoint else "https://" + endpoint)
+        return (
+            parsed.hostname or _DEFAULT_OCI_HOST,
+            parsed.port if parsed.port is not None else _DEFAULT_OCI_PORT,
+        )
+    return _DEFAULT_OCI_HOST, _DEFAULT_OCI_PORT
+
+
+def chat(
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+    event_provider=None,
+):
+    """
+    Generates a telemetry wrapper for GenAI chat function call.
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the OCI GenAI chat function call.
+        """
+
+        # The LangChain instrumentor owns (and enriches) the LLM span; skip the
+        # SDK-level span to avoid duplicates.
+        if is_framework_llm_active():
+            return wrapped(*args, **kwargs)
+
+        details = _resolve_details(args, kwargs, "chat_details")
+        chat_request = getattr(details, "chat_request", None)
+
+        # Streaming is not instrumented in this version; pass through untouched.
+        if getattr(chat_request, "is_stream", False):
+            return wrapped(*args, **kwargs)
+
+        request_model = _serving_model_id(details)
+        server_address, server_port = _server_address_and_port(instance)
+        span_name = f"{SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT} {request_model}"
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
+            try:
+                response = wrapped(*args, **kwargs)
+            except Exception as e:
+                handle_exception(span, e)
+                if not disable_metrics and metrics:
+                    record_completion_metrics(
+                        metrics,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+                        SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+                        server_address,
+                        server_port,
+                        request_model,
+                        "unknown",
+                        environment,
+                        application_name,
+                        start_time,
+                        time.time(),
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        error_type=type(e).__name__ or "_OTHER",
+                    )
+                raise
+
+            # Telemetry processing self-handles its own errors and never raises.
+            response = process_chat_response(
+                response=response,
+                request=chat_request,
+                request_model=request_model,
+                pricing_info=pricing_info,
+                server_port=server_port,
+                server_address=server_address,
+                environment=environment,
+                application_name=application_name,
+                metrics=metrics,
+                start_time=start_time,
+                span=span,
+                capture_message_content=capture_message_content,
+                disable_metrics=disable_metrics,
+                version=version,
+            )
+
+        return response
+
+    return wrapper
+
+
+def generate_text(
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+    event_provider=None,
+):
+    """
+    Generates a telemetry wrapper for GenAI generate_text (legacy) function call.
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the OCI GenAI generate_text function call.
+        """
+
+        if is_framework_llm_active():
+            return wrapped(*args, **kwargs)
+
+        details = _resolve_details(args, kwargs, "generate_text_details")
+        inference_request = getattr(details, "inference_request", None)
+
+        if getattr(inference_request, "is_stream", False):
+            return wrapped(*args, **kwargs)
+
+        request_model = _serving_model_id(details)
+        server_address, server_port = _server_address_and_port(instance)
+        span_name = (
+            f"{SemanticConvention.GEN_AI_OPERATION_TYPE_TEXT_COMPLETION} "
+            f"{request_model}"
+        )
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
+            try:
+                response = wrapped(*args, **kwargs)
+            except Exception as e:
+                handle_exception(span, e)
+                if not disable_metrics and metrics:
+                    record_completion_metrics(
+                        metrics,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_TEXT_COMPLETION,
+                        SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+                        server_address,
+                        server_port,
+                        request_model,
+                        "unknown",
+                        environment,
+                        application_name,
+                        start_time,
+                        time.time(),
+                        0,
+                        0,
+                        0,
+                        0,
+                        None,
+                        error_type=type(e).__name__ or "_OTHER",
+                    )
+                raise
+
+            # Telemetry processing self-handles its own errors and never raises.
+            response = process_generate_text_response(
+                response=response,
+                request=details,
+                request_model=request_model,
+                pricing_info=pricing_info,
+                server_port=server_port,
+                server_address=server_address,
+                environment=environment,
+                application_name=application_name,
+                metrics=metrics,
+                start_time=start_time,
+                span=span,
+                capture_message_content=capture_message_content,
+                disable_metrics=disable_metrics,
+                version=version,
+            )
+
+        return response
+
+    return wrapper
+
+
+def embed(
+    version,
+    environment,
+    application_name,
+    tracer,
+    pricing_info,
+    capture_message_content,
+    metrics,
+    disable_metrics,
+):
+    """
+    Generates a telemetry wrapper for GenAI embedding function call.
+    """
+
+    def wrapper(wrapped, instance, args, kwargs):
+        """
+        Wraps the OCI GenAI embed_text function call.
+        """
+
+        details = _resolve_details(args, kwargs, "embed_text_details")
+        request_model = _serving_model_id(details)
+        server_address, server_port = _server_address_and_port(instance)
+        span_name = (
+            f"{SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING} {request_model}"
+        )
+
+        with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+            start_time = time.time()
+            try:
+                response = wrapped(*args, **kwargs)
+            except Exception as e:
+                handle_exception(span, e)
+                if not disable_metrics and metrics:
+                    record_embedding_metrics(
+                        metrics,
+                        SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                        SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+                        server_address,
+                        server_port,
+                        request_model,
+                        "unknown",
+                        environment,
+                        application_name,
+                        start_time,
+                        time.time(),
+                        0,
+                        0,
+                        error_type=type(e).__name__ or "_OTHER",
+                    )
+                raise
+
+            # Telemetry processing self-handles its own errors and never raises.
+            response = process_embedding_response(
+                response=response,
+                request=details,
+                request_model=request_model,
+                pricing_info=pricing_info,
+                server_port=server_port,
+                server_address=server_address,
+                environment=environment,
+                application_name=application_name,
+                metrics=metrics,
+                start_time=start_time,
+                span=span,
+                capture_message_content=capture_message_content,
+                disable_metrics=disable_metrics,
+                version=version,
+            )
+
+            return response
+
+    return wrapper

--- a/sdk/python/src/openlit/instrumentation/oci_genai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/oci_genai/utils.py
@@ -1,0 +1,486 @@
+"""
+OCI GenAI OpenTelemetry instrumentation utility functions
+"""
+
+import json
+import logging
+import time
+
+from opentelemetry.trace import Status, StatusCode
+
+from openlit.__helpers import (
+    get_chat_model_cost,
+    get_embed_model_cost,
+    common_span_attributes,
+    record_completion_metrics,
+    record_embedding_metrics,
+    general_tokens,
+    handle_exception,
+)
+from openlit.semcov import SemanticConvention
+
+logger = logging.getLogger(__name__)
+
+# OCI GenAI finish reasons -> OTel standard finish reasons
+_FINISH_REASON_MAP = {
+    "COMPLETE": "stop",
+    "complete": "stop",
+    "stop": "stop",
+    "MAX_TOKENS": "max_tokens",
+    "max_tokens": "max_tokens",
+    "length": "max_tokens",
+    "tool_calls": "tool_calls",
+    "TOOL_CALLS": "tool_calls",
+    "ERROR": "error",
+    "content_filter": "content_filter",
+}
+
+
+def _map_finish_reason(finish_reason):
+    """Map an OCI finish reason to the OTel standard value."""
+    if not finish_reason:
+        return ""
+    return _FINISH_REASON_MAP.get(finish_reason, finish_reason)
+
+
+def _serving_model_id(details, default="unknown"):
+    """Resolve the request model id from an OCI *Details request object."""
+    serving_mode = getattr(details, "serving_mode", None)
+    return (
+        getattr(serving_mode, "model_id", None)
+        or getattr(serving_mode, "endpoint_id", None)
+        or default
+    )
+
+
+def _extract_generic_chat(chat_response):
+    """Extract (text, finish_reason) from a GenericChatResponse."""
+    text = ""
+    finish_reason = ""
+    choices = getattr(chat_response, "choices", None) or []
+    if choices:
+        choice = choices[0]
+        finish_reason = getattr(choice, "finish_reason", "") or ""
+        message = getattr(choice, "message", None)
+        content = getattr(message, "content", None) or []
+        for part in content:
+            part_text = getattr(part, "text", None)
+            if part_text:
+                text += part_text
+    return text, finish_reason
+
+
+def _extract_cohere_chat(chat_response):
+    """Extract (text, finish_reason) from a CohereChatResponse."""
+    text = getattr(chat_response, "text", "") or ""
+    finish_reason = getattr(chat_response, "finish_reason", "") or ""
+    return text, finish_reason
+
+
+def _extract_prompt_text(request):
+    """Best-effort prompt string for content capture (GENERIC or COHERE request)."""
+    if request is None:
+        return ""
+    # Cohere chat request carries a single prompt string.
+    message = getattr(request, "message", None)
+    if isinstance(message, str) and message:
+        return message
+    # Generic/Llama chat request carries a list of messages.
+    parts = []
+    for msg in getattr(request, "messages", None) or []:
+        content = getattr(msg, "content", None) or []
+        if isinstance(content, str):
+            parts.append(content)
+            continue
+        for part in content:
+            part_text = getattr(part, "text", None)
+            if part_text:
+                parts.append(part_text)
+    return "\n".join(parts)
+
+
+def _set_content(span, prompt_text, response_text):
+    """Set gen_ai input/output message attributes (JSON arrays) when capturing content."""
+    input_messages = [
+        {"role": "user", "parts": [{"type": "text", "content": prompt_text}]}
+    ]
+    output_messages = [
+        {
+            "role": "assistant",
+            "parts": [{"type": "text", "content": response_text}],
+        }
+    ]
+    span.set_attribute(
+        SemanticConvention.GEN_AI_INPUT_MESSAGES, json.dumps(input_messages)
+    )
+    span.set_attribute(
+        SemanticConvention.GEN_AI_OUTPUT_MESSAGES, json.dumps(output_messages)
+    )
+
+
+def _set_request_params(span, request):
+    """Set request-parameter span attributes present on the OCI chat request."""
+    param_map = [
+        (SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS, "max_tokens"),
+        (SemanticConvention.GEN_AI_REQUEST_TEMPERATURE, "temperature"),
+        (SemanticConvention.GEN_AI_REQUEST_TOP_P, "top_p"),
+        (SemanticConvention.GEN_AI_REQUEST_TOP_K, "top_k"),
+        (SemanticConvention.GEN_AI_REQUEST_FREQUENCY_PENALTY, "frequency_penalty"),
+        (SemanticConvention.GEN_AI_REQUEST_PRESENCE_PENALTY, "presence_penalty"),
+        (SemanticConvention.GEN_AI_REQUEST_SEED, "seed"),
+    ]
+    for attribute, attr_name in param_map:
+        value = getattr(request, attr_name, None)
+        if value is not None:
+            span.set_attribute(attribute, value)
+
+
+def common_chat_logic(
+    scope,
+    request_model,
+    pricing_info,
+    environment,
+    application_name,
+    metrics,
+    capture_message_content,
+    disable_metrics,
+    version,
+    operation_type,
+):
+    """Set common chat/completion span attributes, cost, and metrics."""
+    scope._end_time = getattr(scope, "_end_time", None) or time.time()
+
+    cost = get_chat_model_cost(
+        request_model, pricing_info, scope._input_tokens, scope._output_tokens
+    )
+
+    common_span_attributes(
+        scope,
+        operation_type,
+        SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+        scope._server_address,
+        scope._server_port,
+        request_model,
+        scope._response_model,
+        environment,
+        application_name,
+        False,
+        0,
+        scope._ttft,
+        version,
+    )
+
+    _set_request_params(scope._span, getattr(scope, "_request", None))
+
+    # Response parameters
+    if getattr(scope, "_response_id", None):
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_RESPONSE_ID, scope._response_id
+        )
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_RESPONSE_FINISH_REASON,
+        [_map_finish_reason(scope._finish_reason)],
+    )
+    scope._span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "text")
+
+    # Tokens and cost
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, scope._input_tokens
+    )
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS, scope._output_tokens
+    )
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE,
+        scope._input_tokens + scope._output_tokens,
+    )
+    scope._span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
+
+    # OCI has no cache-token concept today; stamp 0 for parity with other providers.
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS, 0
+    )
+    scope._span.set_attribute(
+        SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS, 0
+    )
+
+    if capture_message_content:
+        _set_content(
+            scope._span,
+            getattr(scope, "_prompt", ""),
+            scope._llmresponse,
+        )
+
+    scope._span.set_status(Status(StatusCode.OK))
+
+    if not disable_metrics and metrics:
+        record_completion_metrics(
+            metrics,
+            operation_type,
+            SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+            scope._server_address,
+            scope._server_port,
+            request_model,
+            scope._response_model,
+            environment,
+            application_name,
+            scope._start_time,
+            scope._end_time,
+            scope._input_tokens,
+            scope._output_tokens,
+            cost,
+            0,
+            scope._ttft,
+            is_stream=False,
+        )
+
+
+def process_chat_response(
+    response,
+    request,
+    request_model,
+    pricing_info,
+    server_port,
+    server_address,
+    environment,
+    application_name,
+    metrics,
+    start_time,
+    span,
+    capture_message_content=False,
+    disable_metrics=False,
+    version="1.0.0",
+):
+    """Process a non-streaming OCI chat response and generate telemetry."""
+    try:
+        data = getattr(response, "data", None)
+        chat_response = getattr(data, "chat_response", None)
+        api_format = getattr(chat_response, "api_format", None)
+
+        if api_format == "COHERE":
+            llmresponse, finish_reason = _extract_cohere_chat(chat_response)
+        else:
+            llmresponse, finish_reason = _extract_generic_chat(chat_response)
+
+        usage = getattr(chat_response, "usage", None)
+        input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+        output_tokens = getattr(usage, "completion_tokens", 0) or 0
+
+        scope = type("GenericScope", (), {})()
+        scope._start_time = start_time
+        scope._end_time = time.time()
+        scope._span = span
+        scope._llmresponse = llmresponse
+        scope._finish_reason = finish_reason
+        scope._response_id = getattr(data, "id", "") or ""
+        scope._response_model = getattr(data, "model_id", None) or request_model
+        scope._input_tokens = input_tokens
+        scope._output_tokens = output_tokens
+        scope._ttft = scope._end_time - scope._start_time
+        scope._server_address, scope._server_port = server_address, server_port
+        scope._request = request
+        scope._prompt = (
+            _extract_prompt_text(request) if capture_message_content else ""
+        )
+
+        common_chat_logic(
+            scope,
+            request_model,
+            pricing_info,
+            environment,
+            application_name,
+            metrics,
+            capture_message_content,
+            disable_metrics,
+            version,
+            SemanticConvention.GEN_AI_OPERATION_TYPE_CHAT,
+        )
+        return response
+    except Exception as e:
+        # Telemetry processing must never break the caller's API call.
+        handle_exception(span, e)
+        return response
+
+
+def process_generate_text_response(
+    response,
+    request,
+    request_model,
+    pricing_info,
+    server_port,
+    server_address,
+    environment,
+    application_name,
+    metrics,
+    start_time,
+    span,
+    capture_message_content=False,
+    disable_metrics=False,
+    version="1.0.0",
+):
+    """Process a non-streaming OCI generate_text (legacy completion) response."""
+    try:
+        data = getattr(response, "data", None)
+        inference_response = getattr(data, "inference_response", None)
+        runtime_type = getattr(inference_response, "runtime_type", None)
+
+        llmresponse = ""
+        finish_reason = ""
+        if runtime_type == "COHERE":
+            generated = getattr(inference_response, "generated_texts", None) or []
+            if generated:
+                llmresponse = getattr(generated[0], "text", "") or ""
+                finish_reason = getattr(generated[0], "finish_reason", "") or ""
+        else:
+            # Llama / other legacy runtimes expose OpenAI-style choices; read
+            # defensively so an unexpected shape degrades to best-effort text.
+            choices = getattr(inference_response, "choices", None) or []
+            if choices:
+                choice = choices[0]
+                finish_reason = getattr(choice, "finish_reason", "") or ""
+                message = getattr(choice, "message", None)
+                content = getattr(message, "content", None)
+                if isinstance(content, str):
+                    llmresponse = content
+                elif content:
+                    for part in content:
+                        part_text = getattr(part, "text", None)
+                        if part_text:
+                            llmresponse += part_text
+                else:
+                    llmresponse = getattr(choice, "text", "") or ""
+
+        # generate_text carries the prompt on the inference_request, not on
+        # a chat-style messages/message field.
+        inference_request = getattr(request, "inference_request", None)
+        prompt_text = getattr(inference_request, "prompt", "") or ""
+        # generate_text responses do not carry token usage; estimate.
+        input_tokens = general_tokens(prompt_text) if prompt_text else 0
+        output_tokens = general_tokens(llmresponse) if llmresponse else 0
+
+        scope = type("GenericScope", (), {})()
+        scope._start_time = start_time
+        scope._end_time = time.time()
+        scope._span = span
+        scope._llmresponse = llmresponse
+        scope._finish_reason = finish_reason
+        scope._response_id = getattr(data, "id", "")
+        scope._response_model = getattr(data, "model_id", None) or request_model
+        scope._input_tokens = input_tokens
+        scope._output_tokens = output_tokens
+        scope._ttft = scope._end_time - scope._start_time
+        scope._server_address, scope._server_port = server_address, server_port
+        scope._request = inference_request
+        scope._prompt = prompt_text if capture_message_content else ""
+
+        common_chat_logic(
+            scope,
+            request_model,
+            pricing_info,
+            environment,
+            application_name,
+            metrics,
+            capture_message_content,
+            disable_metrics,
+            version,
+            SemanticConvention.GEN_AI_OPERATION_TYPE_TEXT_COMPLETION,
+        )
+        return response
+    except Exception as e:
+        # Telemetry processing must never break the caller's API call.
+        handle_exception(span, e)
+        return response
+
+
+def process_embedding_response(
+    response,
+    request,
+    request_model,
+    pricing_info,
+    server_port,
+    server_address,
+    environment,
+    application_name,
+    metrics,
+    start_time,
+    span,
+    capture_message_content=False,
+    disable_metrics=False,
+    version="1.0.0",
+):
+    """Process an OCI embed_text response and generate telemetry."""
+    try:
+        data = getattr(response, "data", None)
+        usage = getattr(data, "usage", None)
+        inputs = getattr(request, "inputs", None) or []
+
+        input_tokens = getattr(usage, "prompt_tokens", None)
+        if input_tokens is None:
+            input_tokens = sum(
+                general_tokens(text) for text in inputs if isinstance(text, str)
+            )
+
+        response_model = getattr(data, "model_id", None) or request_model
+        cost = get_embed_model_cost(request_model, pricing_info, input_tokens)
+
+        scope = type("GenericScope", (), {})()
+        scope._start_time = start_time
+        scope._end_time = time.time()
+        scope._span = span
+        scope._response_model = response_model
+        scope._ttft = scope._end_time - scope._start_time
+        scope._server_address, scope._server_port = server_address, server_port
+
+        common_span_attributes(
+            scope,
+            SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+            SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+            server_address,
+            server_port,
+            request_model,
+            response_model,
+            environment,
+            application_name,
+            False,
+            0,
+            scope._ttft,
+            version,
+        )
+
+        span.set_attribute(
+            SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS, input_tokens
+        )
+        span.set_attribute(
+            SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE, input_tokens
+        )
+        span.set_attribute(SemanticConvention.GEN_AI_USAGE_COST, cost)
+        span.set_attribute(SemanticConvention.GEN_AI_OUTPUT_TYPE, "float")
+
+        if capture_message_content:
+            span.set_attribute(
+                SemanticConvention.GEN_AI_INPUT_MESSAGES, str(inputs)
+            )
+
+        span.set_status(Status(StatusCode.OK))
+
+        if not disable_metrics and metrics:
+            record_embedding_metrics(
+                metrics,
+                SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING,
+                SemanticConvention.GEN_AI_SYSTEM_OCI_GENAI,
+                server_address,
+                server_port,
+                request_model,
+                response_model,
+                environment,
+                application_name,
+                scope._start_time,
+                scope._end_time,
+                input_tokens,
+                cost,
+            )
+        return response
+    except Exception as e:
+        # Telemetry processing must never break the caller's API call.
+        handle_exception(span, e)
+        return response

--- a/sdk/python/src/openlit/semcov/__init__.py
+++ b/sdk/python/src/openlit/semcov/__init__.py
@@ -304,6 +304,7 @@ class SemanticConvention:
     GEN_AI_SYSTEM_GROQ = "groq"
     GEN_AI_SYSTEM_IBM_WATSON = "ibm.watson.ai"
     GEN_AI_SYSTEM_MISTRAL = "mistral_ai"
+    GEN_AI_SYSTEM_OCI_GENAI = "oci_genai"
     GEN_AI_SYSTEM_OPENAI = "openai"
     GEN_AI_SYSTEM_PERPLEXITY = "perplexity"
     GEN_AI_SYSTEM_VERTEXAI = "vertex_ai"

--- a/sdk/python/tests/requirements.txt
+++ b/sdk/python/tests/requirements.txt
@@ -17,6 +17,7 @@ anthropic
 mistralai
 boto3
 botocore
+oci
 google-genai
 azure-ai-inference
 assemblyai

--- a/sdk/python/tests/test_oci_genai.py
+++ b/sdk/python/tests/test_oci_genai.py
@@ -1,0 +1,506 @@
+"""
+Keyless tests for OCI GenAI instrumentation.
+
+These build real `oci` SDK model objects (no credentials or network needed) and
+drive the instrumentation's processing / wrapper code directly, asserting the
+emitted OpenTelemetry span attributes.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from oci.response import Response
+from oci.generative_ai_inference.models import (
+    ChatResult,
+    GenericChatResponse,
+    CohereChatResponse,
+    ChatChoice,
+    AssistantMessage,
+    TextContent,
+    Usage,
+    ChatDetails,
+    GenericChatRequest,
+    CohereChatRequest,
+    OnDemandServingMode,
+    GenerateTextDetails,
+    GenerateTextResult,
+    CohereLlmInferenceRequest,
+    CohereLlmInferenceResponse,
+    GeneratedText,
+    EmbedTextDetails,
+    EmbedTextResult,
+)
+
+from openlit.semcov import SemanticConvention
+from openlit.__helpers import (
+    set_framework_llm_active,
+    reset_framework_llm_active,
+)
+from openlit.instrumentation.oci_genai import oci_genai as oci_wrappers
+from openlit.instrumentation.oci_genai.utils import (
+    process_chat_response,
+    process_generate_text_response,
+    process_embedding_response,
+)
+import openlit.instrumentation.langchain as lc
+from openlit.__helpers import get_server_address_for_provider
+from openlit._config import OpenlitConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_openlit_config():
+    """Initialize OpenlitConfig class attributes without a full openlit.init()."""
+    OpenlitConfig.reset_to_defaults()
+    yield
+
+
+def _tracer():
+    """Tracer."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer("test"), exporter
+
+
+def _generic_chat_response(text="hi there", finish="stop"):
+    """Generic chat response."""
+    usage = Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    generic = GenericChatResponse(
+        api_format="GENERIC",
+        choices=[
+            ChatChoice(
+                index=0,
+                finish_reason=finish,
+                message=AssistantMessage(
+                    role="ASSISTANT",
+                    content=[TextContent(type="TEXT", text=text)],
+                ),
+            )
+        ],
+        usage=usage,
+    )
+    data = ChatResult(
+        model_id="meta.llama-3.3-70b-instruct",
+        model_version="1.0",
+        chat_response=generic,
+    )
+    return Response(200, {}, data, None)
+
+
+def _cohere_chat_response(text="cohere reply", finish="COMPLETE"):
+    """Cohere chat response."""
+    usage = Usage(prompt_tokens=7, completion_tokens=3, total_tokens=10)
+    cohere = CohereChatResponse(
+        api_format="COHERE", text=text, finish_reason=finish, usage=usage
+    )
+    data = ChatResult(
+        model_id="cohere.command-a-03-2025",
+        model_version="1.0",
+        chat_response=cohere,
+    )
+    return Response(200, {}, data, None)
+
+
+# --------------------------------------------------------------------------- #
+# process_* (utils) tests
+# --------------------------------------------------------------------------- #
+
+
+def test_generic_chat_span_attributes():
+    """Test generic chat span attributes."""
+    tracer, exporter = _tracer()
+    request = GenericChatRequest(
+        api_format="GENERIC", is_stream=False, max_tokens=128, temperature=0.7
+    )
+    with tracer.start_as_current_span("chat test") as span:
+        process_chat_response(
+            response=_generic_chat_response(),
+            request=request,
+            request_model="meta.llama-3.3-70b-instruct",
+            pricing_info={},
+            server_port=443,
+            server_address="inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+            environment="test-env",
+            application_name="test-app",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=True,
+            disable_metrics=True,
+            version="9.9.9",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert attrs["telemetry.sdk.name"] == "openlit"
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+    assert attrs[SemanticConvention.GEN_AI_OPERATION] == "chat"
+    assert attrs["deployment.environment"] == "test-env"
+    assert attrs["service.name"] == "test-app"
+    assert attrs[SemanticConvention.GEN_AI_SDK_VERSION] == "9.9.9"
+    assert (
+        attrs[SemanticConvention.GEN_AI_REQUEST_MODEL]
+        == "meta.llama-3.3-70b-instruct"
+    )
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] == 10
+    assert attrs[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] == 5
+    assert attrs[SemanticConvention.GEN_AI_CLIENT_TOKEN_USAGE] == 15
+    assert SemanticConvention.GEN_AI_USAGE_COST in attrs
+    assert attrs[SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 0
+    assert attrs[SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] == 0
+    assert attrs[SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS] == 128
+
+
+def test_cohere_chat_span_attributes():
+    """Test cohere chat span attributes."""
+    tracer, exporter = _tracer()
+    request = CohereChatRequest(api_format="COHERE", message="hello", is_stream=False)
+    with tracer.start_as_current_span("chat test") as span:
+        process_chat_response(
+            response=_cohere_chat_response(),
+            request=request,
+            request_model="cohere.command-a-03-2025",
+            pricing_info={},
+            server_port=443,
+            server_address="host",
+            environment="e",
+            application_name="a",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=False,
+            disable_metrics=True,
+            version="1.0.0",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+    assert (
+        attrs[SemanticConvention.GEN_AI_REQUEST_MODEL] == "cohere.command-a-03-2025"
+    )
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] == 7
+    assert attrs[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] == 3
+
+
+def test_generate_text_span_attributes():
+    """Test generate text span attributes."""
+    tracer, exporter = _tracer()
+    request = GenerateTextDetails(
+        compartment_id="c",
+        serving_mode=OnDemandServingMode(model_id="cohere.command"),
+        inference_request=CohereLlmInferenceRequest(prompt="say hi", is_stream=False),
+    )
+    inference_response = CohereLlmInferenceResponse(
+        runtime_type="COHERE",
+        generated_texts=[GeneratedText(text="hi from cohere", finish_reason="COMPLETE")],
+    )
+    data = GenerateTextResult(
+        model_id="cohere.command", inference_response=inference_response
+    )
+    response = Response(200, {}, data, None)
+    with tracer.start_as_current_span("gen test") as span:
+        process_generate_text_response(
+            response=response,
+            request=request,
+            request_model="cohere.command",
+            pricing_info={},
+            server_port=443,
+            server_address="host",
+            environment="e",
+            application_name="a",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=False,
+            disable_metrics=True,
+            version="1.0.0",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+    assert (
+        attrs[SemanticConvention.GEN_AI_OPERATION]
+        == SemanticConvention.GEN_AI_OPERATION_TYPE_TEXT_COMPLETION
+    )
+    assert attrs[SemanticConvention.GEN_AI_REQUEST_MODEL] == "cohere.command"
+    # generate_text has no usage; tokens are estimated (> 0 for non-empty text).
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] > 0
+    assert attrs[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] > 0
+
+
+def test_embedding_span_attributes():
+    """Test embedding span attributes."""
+    tracer, exporter = _tracer()
+    request = EmbedTextDetails(
+        inputs=["hello world", "second"],
+        serving_mode=OnDemandServingMode(model_id="cohere.embed-v4.0"),
+        compartment_id="c",
+    )
+    usage = Usage(prompt_tokens=4, completion_tokens=0, total_tokens=4)
+    data = EmbedTextResult(
+        embeddings=[[0.1, 0.2], [0.3, 0.4]],
+        model_id="cohere.embed-v4.0",
+        usage=usage,
+    )
+    response = Response(200, {}, data, None)
+    with tracer.start_as_current_span("embed test") as span:
+        process_embedding_response(
+            response=response,
+            request=request,
+            request_model="cohere.embed-v4.0",
+            pricing_info={},
+            server_port=443,
+            server_address="host",
+            environment="e",
+            application_name="a",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=False,
+            disable_metrics=True,
+            version="1.0.0",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+    assert (
+        attrs[SemanticConvention.GEN_AI_OPERATION]
+        == SemanticConvention.GEN_AI_OPERATION_TYPE_EMBEDDING
+    )
+    assert attrs[SemanticConvention.GEN_AI_REQUEST_MODEL] == "cohere.embed-v4.0"
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] == 4
+
+
+# --------------------------------------------------------------------------- #
+# wrapper (oci_genai.py) tests: pass-through + resolution
+# --------------------------------------------------------------------------- #
+
+
+def _chat_wrapper():
+    """Chat wrapper."""
+    tracer, exporter = _tracer()
+    wrapper = oci_wrappers.chat(
+        version="1.0.0",
+        environment="e",
+        application_name="a",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+    instance = SimpleNamespace(
+        base_client=SimpleNamespace(
+            endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+        )
+    )
+    return wrapper, instance, exporter
+
+
+def _non_stream_chat_details():
+    """Non stream chat details."""
+    return ChatDetails(
+        compartment_id="c",
+        serving_mode=OnDemandServingMode(model_id="meta.llama-3.3-70b-instruct"),
+        chat_request=GenericChatRequest(api_format="GENERIC", is_stream=False),
+    )
+
+
+def test_wrapper_positional_and_keyword_resolution():
+    """Test wrapper positional and keyword resolution."""
+    wrapper, instance, exporter = _chat_wrapper()
+    details = _non_stream_chat_details()
+    called = {"n": 0}
+
+    def wrapped(*args, **kwargs):
+        """Wrapped."""
+        called["n"] += 1
+        return _generic_chat_response()
+
+    # positional
+    wrapper(wrapped, instance, (details,), {})
+    # keyword
+    wrapper(wrapped, instance, (), {"chat_details": details})
+    assert called["n"] == 2
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    for span in spans:
+        assert span.attributes[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+        assert (
+            span.attributes["server.address"]
+            == "inference.generativeai.us-chicago-1.oci.oraclecloud.com"
+        )
+
+
+def test_wrapper_stream_passthrough_emits_no_span():
+    """Test wrapper stream passthrough emits no span."""
+    wrapper, instance, exporter = _chat_wrapper()
+    details = ChatDetails(
+        compartment_id="c",
+        serving_mode=OnDemandServingMode(model_id="m"),
+        chat_request=GenericChatRequest(api_format="GENERIC", is_stream=True),
+    )
+    sentinel = object()
+
+    def wrapped(*args, **kwargs):
+        """Wrapped."""
+        return sentinel
+
+    result = wrapper(wrapped, instance, (details,), {})
+    assert result is sentinel
+    assert not exporter.get_finished_spans()
+
+
+def test_wrapper_framework_active_passthrough_emits_no_span():
+    """Test wrapper framework active passthrough emits no span."""
+    wrapper, instance, exporter = _chat_wrapper()
+    details = _non_stream_chat_details()
+    sentinel = object()
+
+    def wrapped(*args, **kwargs):
+        """Wrapped."""
+        return sentinel
+
+    token = set_framework_llm_active()
+    try:
+        result = wrapper(wrapped, instance, (details,), {})
+    finally:
+        reset_framework_llm_active(token)
+    assert result is sentinel
+    assert not exporter.get_finished_spans()
+
+
+# --------------------------------------------------------------------------- #
+# LangChain OCI detection (the #522 reporter's path)
+# --------------------------------------------------------------------------- #
+
+
+def test_langchain_detects_oci_provider_and_model():
+    """Test langchain detects oci provider and model."""
+    chat_ser = {
+        "id": [
+            "langchain_community",
+            "chat_models",
+            "oci_generative_ai",
+            "ChatOCIGenAI",
+        ],
+        "kwargs": {"model_id": "cohere.command-a-03-2025"},
+    }
+    llm_ser = {
+        "id": ["langchain_community", "llms", "oci_generative_ai", "OCIGenAI"],
+        "kwargs": {"model_id": "meta.llama-3.3-70b-instruct"},
+    }
+    assert lc.detect_provider(chat_ser) == "oci_genai"
+    assert lc.detect_provider(llm_ser) == "oci_genai"
+    assert (
+        lc.extract_model_name(chat_ser, {"invocation_params": {"model_id": "cohere.command-a-03-2025"}})
+        == "cohere.command-a-03-2025"
+    )
+    assert (
+        lc.extract_model_name(llm_ser, {"kwargs": {"model_id": "meta.llama-3.3-70b-instruct"}})
+        == "meta.llama-3.3-70b-instruct"
+    )
+    assert get_server_address_for_provider("oci_genai") == (
+        "inference.generativeai.us-chicago-1.oci.oraclecloud.com",
+        443,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Fallback / error branches
+# --------------------------------------------------------------------------- #
+
+
+def test_generate_text_llama_runtime_defensive_path():
+    """Test generate text Llama runtime defensive path."""
+    tracer, exporter = _tracer()
+    request = SimpleNamespace(
+        inference_request=SimpleNamespace(prompt="hello llama", is_stream=False)
+    )
+    inference_response = SimpleNamespace(
+        runtime_type="LLAMA",
+        choices=[SimpleNamespace(finish_reason="stop", text="llama out")],
+    )
+    data = SimpleNamespace(
+        model_id="meta.llama-3.3-70b-instruct",
+        inference_response=inference_response,
+        id="",
+    )
+    response = Response(200, {}, data, None)
+    with tracer.start_as_current_span("gen llama") as span:
+        process_generate_text_response(
+            response=response,
+            request=request,
+            request_model="meta.llama-3.3-70b-instruct",
+            pricing_info={},
+            server_port=443,
+            server_address="host",
+            environment="e",
+            application_name="a",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=True,
+            disable_metrics=True,
+            version="1.0.0",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert attrs[SemanticConvention.GEN_AI_PROVIDER_NAME] == "oci_genai"
+    # prompt + completion both estimated (> 0) since the response has no usage.
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] > 0
+    assert attrs[SemanticConvention.GEN_AI_USAGE_OUTPUT_TOKENS] > 0
+
+
+def test_embedding_usage_missing_falls_back_to_estimate():
+    """Test embedding usage missing falls back to estimate."""
+    tracer, exporter = _tracer()
+    request = EmbedTextDetails(
+        inputs=["hello world"],
+        serving_mode=OnDemandServingMode(model_id="cohere.embed-v4.0"),
+        compartment_id="c",
+    )
+    data = EmbedTextResult(
+        embeddings=[[0.1, 0.2]], model_id="cohere.embed-v4.0", usage=None
+    )
+    response = Response(200, {}, data, None)
+    with tracer.start_as_current_span("embed test") as span:
+        process_embedding_response(
+            response=response,
+            request=request,
+            request_model="cohere.embed-v4.0",
+            pricing_info={},
+            server_port=443,
+            server_address="host",
+            environment="e",
+            application_name="a",
+            metrics=None,
+            start_time=0.0,
+            span=span,
+            capture_message_content=False,
+            disable_metrics=True,
+            version="1.0.0",
+        )
+    attrs = exporter.get_finished_spans()[0].attributes
+    # No usage on the response -> tokens estimated from the input text (> 0).
+    assert attrs[SemanticConvention.GEN_AI_USAGE_INPUT_TOKENS] > 0
+
+
+def test_wrapper_reraises_sdk_error():
+    """Test wrapper reraises sdk error."""
+    wrapper, instance, exporter = _chat_wrapper()
+    details = _non_stream_chat_details()
+
+    class _Boom(RuntimeError):
+        """Simulated OCI SDK failure."""
+
+    def wrapped(*args, **kwargs):
+        raise _Boom("service unavailable")
+
+    with pytest.raises(_Boom):
+        wrapper(wrapped, instance, (details,), {})
+    # A span is still produced and marked with an error status.
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].status.status_code.name == "ERROR"

--- a/sdk/python/tests/test_oci_genai.py
+++ b/sdk/python/tests/test_oci_genai.py
@@ -6,6 +6,7 @@ drive the instrumentation's processing / wrapper code directly, asserting the
 emitted OpenTelemetry span attributes.
 """
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -23,6 +24,7 @@ from oci.generative_ai_inference.models import (
     CohereChatResponse,
     ChatChoice,
     AssistantMessage,
+    UserMessage,
     TextContent,
     Usage,
     ChatDetails,
@@ -117,7 +119,16 @@ def test_generic_chat_span_attributes():
     """Test generic chat span attributes."""
     tracer, exporter = _tracer()
     request = GenericChatRequest(
-        api_format="GENERIC", is_stream=False, max_tokens=128, temperature=0.7
+        api_format="GENERIC",
+        is_stream=False,
+        max_tokens=128,
+        temperature=0.7,
+        messages=[
+            UserMessage(
+                role="USER",
+                content=[TextContent(type="TEXT", text="hello there")],
+            )
+        ],
     )
     with tracer.start_as_current_span("chat test") as span:
         process_chat_response(
@@ -154,6 +165,15 @@ def test_generic_chat_span_attributes():
     assert attrs[SemanticConvention.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS] == 0
     assert attrs[SemanticConvention.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS] == 0
     assert attrs[SemanticConvention.GEN_AI_REQUEST_MAX_TOKENS] == 128
+
+    # Content capture: input/output messages are JSON arrays following the
+    # nested {"role", "parts": [{"type", "content"}]} schema _set_content emits.
+    input_messages = json.loads(attrs[SemanticConvention.GEN_AI_INPUT_MESSAGES])
+    output_messages = json.loads(attrs[SemanticConvention.GEN_AI_OUTPUT_MESSAGES])
+    assert isinstance(input_messages, list)
+    assert isinstance(output_messages, list)
+    assert input_messages[0]["parts"][0]["content"] == "hello there"
+    assert output_messages[0]["parts"][0]["content"] == "hi there"
 
 
 def test_cohere_chat_span_attributes():


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**: #522

### Change description:

**What** — Adds an `oci_genai` instrumentor for OCI Generative AI and teaches the LangChain instrumentor to recognize `ChatOCIGenAI` and `OCIGenAI`.

**Why** — Today OCI GenAI produces no useful telemetry and is misread as `gpt-4`, especially through LangChain (#522).

**How** — The new module wraps `GenerativeAiInferenceClient.chat`, `generate_text`, and `embed_text` with the standard OTel GenAI span attributes (provider, model, tokens, cost). The LangChain `PROVIDER_MAP`, `MODEL_PATTERNS`, and default-endpoint map gain OCI entries so framework-owned spans report `oci_genai` and the resolved model. Streaming is a follow-up. Keyless tests cover both paths.

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [x] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Add OCI Generative AI auto-instrumentation to the Python SDK and wire it into LangChain detection and documentation.

New Features:
- Introduce an OCI GenAI instrumentor that traces chat, generate_text, and embed_text calls from the OCI Python SDK with OpenTelemetry GenAI semantics.
- Support LangChain ChatOCIGenAI and OCIGenAI wrappers so OCI GenAI usage is correctly attributed and modeled in framework-owned spans.
- Expose OCI GenAI as a documented integration in the SDK docs, including a dedicated integration page and overview card.

Enhancements:
- Register OCI GenAI as a first-class provider in helper maps, semantic conventions, and default server address resolution so telemetry uses consistent provider and endpoint identifiers.

Documentation:
- Add user-facing documentation page for monitoring OCI Generative AI with OpenLIT and link it from the integrations overview.

Tests:
- Add keyless tests validating OCI GenAI chat, completion, and embedding span attributes, error handling, LangChain provider/model detection, and defensive paths for missing usage data.