### PR TITLE
fix: capture OpenAI reasoning content

### DIFF
--- a/sdk/python/src/openlit/instrumentation/openai/utils.py
+++ b/sdk/python/src/openlit/instrumentation/openai/utils.py
@@ -96,6 +96,14 @@ def handle_not_given(value, default=None):
     return value
 
 
+def extract_reasoning_content(payload):
+    """Return OpenAI-compatible reasoning text from a message or delta payload."""
+    if not isinstance(payload, dict):
+        return ""
+    reasoning = payload.get("reasoning_content") or payload.get("reasoning")
+    return reasoning if isinstance(reasoning, str) else ""
+
+
 def format_content(messages):
     """
     Format the messages into a string for span events.
@@ -676,6 +684,12 @@ def process_chat_chunk(scope, chunk):
         content = delta.get("content")
         if content:
             scope._llmresponse += content
+
+        reasoning_content = extract_reasoning_content(delta)
+        if reasoning_content:
+            if not hasattr(scope, "_reasoning_content"):
+                scope._reasoning_content = ""
+            scope._reasoning_content += reasoning_content
 
         # Handle tool calls in streaming - optimized
         delta_tools = delta.get("tool_calls")
@@ -1583,6 +1597,11 @@ def common_chat_logic(
     # capture is enabled.
     if capture_message_content:
         _set_span_messages_as_array(scope._span, input_msgs, output_msgs)
+        if hasattr(scope, "_reasoning_content") and scope._reasoning_content:
+            scope._span.set_attribute(
+                SemanticConvention.GEN_AI_CONTENT_REASONING,
+                scope._reasoning_content,
+            )
         if system_instr:
             scope._span.set_attribute(
                 SemanticConvention.GEN_AI_SYSTEM_INSTRUCTIONS,
@@ -1734,6 +1753,13 @@ def process_chat_response(
         (choice.get("message", {}).get("content") or "")
         for choice in response_dict.get("choices", [])
     )
+    reasoning_parts = [
+        extract_reasoning_content(choice.get("message", {}))
+        for choice in response_dict.get("choices", [])
+    ]
+    reasoning_content = " ".join(part for part in reasoning_parts if part)
+    if reasoning_content:
+        scope._reasoning_content = reasoning_content
     scope._response_id = response_dict.get("id", "")
     scope._response_model = response_dict.get("model", "")
     scope._input_tokens = response_dict.get("usage", {}).get("prompt_tokens", 0)

--- a/sdk/python/tests/test_openai_error_attributes.py
+++ b/sdk/python/tests/test_openai_error_attributes.py
@@ -11,10 +11,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from openlit.instrumentation.openai.async_openai import async_chat_completions
 from openlit.instrumentation.openai.openai import chat_completions
+from openlit._config import OpenlitConfig
 from openlit.semcov import SemanticConvention
 
 
 def _tracer_and_exporter():
+    OpenlitConfig.reset_to_defaults()
     exporter = InMemorySpanExporter()
     tracer_provider = TracerProvider()
     tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))

--- a/sdk/python/tests/test_openai_reasoning_content.py
+++ b/sdk/python/tests/test_openai_reasoning_content.py
@@ -51,6 +51,7 @@ def _stream_scope(span):
 
 
 def test_streaming_chat_sets_reasoning_content_attribute():
+    """Verify streamed reasoning deltas are captured on the span."""
     tracer, exporter = _tracer_and_exporter()
     span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
     scope = _stream_scope(span)
@@ -97,6 +98,7 @@ def test_streaming_chat_sets_reasoning_content_attribute():
 
 
 def test_streaming_chat_does_not_set_reasoning_when_content_capture_disabled():
+    """Verify streamed reasoning is omitted when content capture is disabled."""
     tracer, exporter = _tracer_and_exporter()
     span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
     scope = _stream_scope(span)
@@ -127,6 +129,7 @@ def test_streaming_chat_does_not_set_reasoning_when_content_capture_disabled():
 
 
 def test_non_streaming_chat_sets_reasoning_content_attribute():
+    """Verify non-streaming message reasoning is captured on the span."""
     tracer, exporter = _tracer_and_exporter()
     span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
     response = {

--- a/sdk/python/tests/test_openai_reasoning_content.py
+++ b/sdk/python/tests/test_openai_reasoning_content.py
@@ -1,0 +1,170 @@
+"""Tests for OpenAI/OpenRouter reasoning content telemetry."""
+
+import time
+from types import SimpleNamespace
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from openlit.instrumentation.openai.utils import (
+    process_chat_chunk,
+    process_chat_response,
+    process_streaming_chat_response,
+)
+from openlit._config import OpenlitConfig
+from openlit.semcov import SemanticConvention
+
+
+def _tracer_and_exporter():
+    OpenlitConfig.reset_to_defaults()
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return tracer_provider.get_tracer("test-openai-reasoning"), exporter
+
+
+def _stream_scope(span):
+    return SimpleNamespace(
+        _span=span,
+        _llmresponse="",
+        _response_id="",
+        _response_model="",
+        _finish_reason="",
+        _system_fingerprint="",
+        _service_tier="auto",
+        _tools=None,
+        _kwargs={
+            "model": "anthropic/claude-sonnet-4.6",
+            "messages": [{"role": "user", "content": "think then answer"}],
+        },
+        _start_time=time.time(),
+        _end_time=None,
+        _timestamps=[],
+        _ttft=0,
+        _tbt=0,
+        _server_address="openrouter.ai",
+        _server_port=443,
+    )
+
+
+def test_streaming_chat_sets_reasoning_content_attribute():
+    tracer, exporter = _tracer_and_exporter()
+    span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
+    scope = _stream_scope(span)
+
+    process_chat_chunk(
+        scope,
+        {
+            "id": "chatcmpl_1",
+            "model": "anthropic/claude-sonnet-4.6",
+            "choices": [{"delta": {"reasoning_content": "Let me "}}],
+        },
+    )
+    process_chat_chunk(
+        scope,
+        {
+            "choices": [
+                {
+                    "delta": {"reasoning": "check the arithmetic."},
+                    "finish_reason": "stop",
+                }
+            ]
+        },
+    )
+
+    with span:
+        process_streaming_chat_response(
+            scope,
+            pricing_info={},
+            environment="test-env",
+            application_name="test-app",
+            metrics=None,
+            capture_message_content=True,
+            disable_metrics=True,
+            version="test-version",
+        )
+
+    finished = exporter.get_finished_spans()
+    assert len(finished) == 1
+    attrs = finished[0].attributes
+    assert (
+        attrs[SemanticConvention.GEN_AI_CONTENT_REASONING]
+        == "Let me check the arithmetic."
+    )
+
+
+def test_streaming_chat_does_not_set_reasoning_when_content_capture_disabled():
+    tracer, exporter = _tracer_and_exporter()
+    span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
+    scope = _stream_scope(span)
+
+    process_chat_chunk(
+        scope,
+        {
+            "choices": [
+                {"delta": {"reasoning_content": "hidden by capture policy"}}
+            ]
+        },
+    )
+
+    with span:
+        process_streaming_chat_response(
+            scope,
+            pricing_info={},
+            environment="test-env",
+            application_name="test-app",
+            metrics=None,
+            capture_message_content=False,
+            disable_metrics=True,
+            version="test-version",
+        )
+
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert SemanticConvention.GEN_AI_CONTENT_REASONING not in attrs
+
+
+def test_non_streaming_chat_sets_reasoning_content_attribute():
+    tracer, exporter = _tracer_and_exporter()
+    span = tracer.start_span("chat anthropic/claude-sonnet-4.6")
+    response = {
+        "id": "chatcmpl_2",
+        "model": "anthropic/claude-sonnet-4.6",
+        "choices": [
+            {
+                "message": {
+                    "content": "The answer is 42.",
+                    "reasoning_content": "I checked the intermediate steps.",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 9},
+    }
+
+    with span:
+        process_chat_response(
+            response,
+            request_model="anthropic/claude-sonnet-4.6",
+            pricing_info={},
+            server_port=443,
+            server_address="openrouter.ai",
+            environment="test-env",
+            application_name="test-app",
+            metrics=None,
+            start_time=time.time(),
+            span=span,
+            capture_message_content=True,
+            disable_metrics=True,
+            version="test-version",
+            model="anthropic/claude-sonnet-4.6",
+            messages=[{"role": "user", "content": "think then answer"}],
+        )
+
+    attrs = exporter.get_finished_spans()[0].attributes
+    assert (
+        attrs[SemanticConvention.GEN_AI_CONTENT_REASONING]
+        == "I checked the intermediate steps."
+    )


### PR DESCRIPTION
## What

Captures returned reasoning text in the OpenAI instrumentation and stores it on the generation span as `gen_ai.content.reasoning`.

## Why

OpenAI-compatible providers such as OpenRouter can return reasoning text in chat completion payloads via `reasoning_content` or `reasoning`. The current OpenAI instrumentation only accumulates `delta.content`, so reasoning text is dropped even when `capture_message_content=True`.

OpenLit already has precedent for this attribute in Azure AI Inference and Cohere instrumentation.

Fixes #1341.

## How

- accumulate `delta.reasoning_content` / `delta.reasoning` during streaming chat completions
- extract `message.reasoning_content` / `message.reasoning` for non-streaming chat completions
- set `SemanticConvention.GEN_AI_CONTENT_REASONING` inside the existing content-capture gate
- add unit tests for streaming, non-streaming, and content-capture-disabled behavior

## Tests

```bash
poetry run pytest tests/test_openai_error_attributes.py tests/test_openai_reasoning_content.py -q
```

## Summary by Sourcery

Capture reasoning content returned by OpenAI-compatible chat completions and expose it as span attributes when message content capture is enabled.

New Features:
- Record reasoning text from streaming and non-streaming OpenAI-compatible chat responses onto spans via the gen_ai.content.reasoning semantic attribute.

Bug Fixes:
- Ensure reasoning content from OpenAI-compatible providers is no longer dropped when capture_message_content is enabled.

Tests:
- Add unit tests covering streaming and non-streaming reasoning content capture and behavior when content capture is disabled.

Chores:
- Reset Openlit configuration to defaults in OpenAI instrumentation tests to avoid cross-test interference.