### PR TITLE
fix: broken agents page

### DIFF
--- a/src/client/scripts/agents/materialize.js
+++ b/src/client/scripts/agents/materialize.js
@@ -22,7 +22,10 @@ async function tick() {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"X-CRON-JOB": "true",
+				// Matches the middleware cron-auth check: send the configured
+				// secret when present, else the literal "true" the keyless
+				// self-hosted path accepts.
+				"X-CRON-JOB": process.env.CRON_JOB_SECRET || "true",
 				"X-CRON-ID": CRON_ID,
 			},
 			body: JSON.stringify({ cronId: CRON_ID }),

--- a/src/client/scripts/evaluation/auto.js
+++ b/src/client/scripts/evaluation/auto.js
@@ -26,7 +26,10 @@ async function callApi() {
 			body: payload,
 			headers: {
 				"Content-Type": "application/json",
-				"X-CRON-JOB": "true",
+				// Matches the middleware cron-auth check: send the configured
+				// secret when present, else the literal "true" the keyless
+				// self-hosted path accepts.
+				"X-CRON-JOB": process.env.CRON_JOB_SECRET || "true",
 			},
 		});
 

--- a/src/client/scripts/pricing/auto.js
+++ b/src/client/scripts/pricing/auto.js
@@ -26,7 +26,10 @@ async function callApi() {
 			body: payload,
 			headers: {
 				"Content-Type": "application/json",
-				"X-CRON-JOB": "true",
+				// Matches the middleware cron-auth check: send the configured
+				// secret when present, else the literal "true" the keyless
+				// self-hosted path accepts.
+				"X-CRON-JOB": process.env.CRON_JOB_SECRET || "true",
 			},
 		});
 

--- a/src/client/src/__tests__/components/project-page-header.test.tsx
+++ b/src/client/src/__tests__/components/project-page-header.test.tsx
@@ -3,8 +3,9 @@ import ProjectPageHeader from "@/components/(playground)/organisation/project-pa
 
 jest.mock("@/components/(playground)/feature-page-header", () => ({
 	__esModule: true,
-	default: ({ title, description, actions }: any) => (
+	default: ({ title, description, leading, actions }: any) => (
 		<div>
+			{leading}
 			<h1>{title}</h1>
 			<p>{description}</p>
 			{actions}
@@ -13,7 +14,7 @@ jest.mock("@/components/(playground)/feature-page-header", () => ({
 }));
 
 describe("ProjectPageHeader", () => {
-	it("renders project identity, navigation, and status badges", () => {
+	it("renders project identity, left back control, and status badges", () => {
 		render(<ProjectPageHeader project={{ name: "Production", isCurrent: true, isDefault: true }} />);
 
 		expect(screen.getByRole("heading", { name: "Production" })).toBeInTheDocument();

--- a/src/client/src/__tests__/middleware/check-auth.test.ts
+++ b/src/client/src/__tests__/middleware/check-auth.test.ts
@@ -44,22 +44,29 @@ describe('checkAuth', () => {
     middleware = checkAuth(nextHandler as any);
   });
 
-  it('passes through _next static routes', async () => {
+  // Static assets must short-circuit with a direct NextResponse.next()
+  // pass-through, NOT by invoking the chain terminus as next(request, event)
+  // — the terminus IS NextResponse.next, and calling it with the request as
+  // the response init throws and 500s every /images and /static request.
+  it('passes through _next static routes with NextResponse.next()', async () => {
     const req = makeRequest('GET', '/_next/static/chunk.js');
     await middleware(req as any, makeFetchEvent());
-    expect(nextHandler).toHaveBeenCalledWith(req, expect.anything());
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(nextHandler).not.toHaveBeenCalled();
   });
 
-  it('passes through /static routes', async () => {
+  it('passes through /static routes with NextResponse.next()', async () => {
     const req = makeRequest('GET', '/static/logo.png');
     await middleware(req as any, makeFetchEvent());
-    expect(nextHandler).toHaveBeenCalledWith(req, expect.anything());
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(nextHandler).not.toHaveBeenCalled();
   });
 
-  it('passes through /images routes', async () => {
+  it('passes through /images routes with NextResponse.next()', async () => {
     const req = makeRequest('GET', '/images/banner.png');
     await middleware(req as any, makeFetchEvent());
-    expect(nextHandler).toHaveBeenCalledWith(req, expect.anything());
+    expect(NextResponse.next).toHaveBeenCalled();
+    expect(nextHandler).not.toHaveBeenCalled();
   });
 
   describe('auth page (/login)', () => {
@@ -107,6 +114,35 @@ describe('checkAuth', () => {
     it('allows CRON job route with valid token header', async () => {
       (getToken as jest.Mock).mockResolvedValue(null);
       const req = makeRequest('GET', '/api/evaluation/auto', '', { 'X-CRON-JOB': 'secret-token' });
+      await middleware(req as any, makeFetchEvent());
+      expect(NextResponse.next).toHaveBeenCalled();
+    });
+
+    it('rejects CRON job route with 403 when token does not match configured secret', async () => {
+      (getToken as jest.Mock).mockResolvedValue(null);
+      // With a secret configured, the keyless "true" sentinel must NOT pass.
+      const req = makeRequest('GET', '/api/evaluation/auto', '', { 'X-CRON-JOB': 'true' });
+      await middleware(req as any, makeFetchEvent());
+      expect(NextResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(String) }),
+        { status: 403 }
+      );
+      expect(NextResponse.next).not.toHaveBeenCalled();
+    });
+
+    it('accepts CRON job route with "true" sentinel when no secret is configured', async () => {
+      // Self-hosted/dev default: CRON_JOB_SECRET unset, scripts send "true".
+      delete process.env.CRON_JOB_SECRET;
+      middleware = checkAuth(nextHandler as any);
+      (getToken as jest.Mock).mockResolvedValue(null);
+      const req = makeRequest('GET', '/api/evaluation/auto', '', { 'X-CRON-JOB': 'true' });
+      await middleware(req as any, makeFetchEvent());
+      expect(NextResponse.next).toHaveBeenCalled();
+    });
+
+    it('reads the lowercase x-cron-job header', async () => {
+      (getToken as jest.Mock).mockResolvedValue(null);
+      const req = makeRequest('GET', '/api/evaluation/auto', '', { 'x-cron-job': 'secret-token' });
       await middleware(req as any, makeFetchEvent());
       expect(NextResponse.next).toHaveBeenCalled();
     });

--- a/src/client/src/__tests__/middleware/middleware.test.ts
+++ b/src/client/src/__tests__/middleware/middleware.test.ts
@@ -48,4 +48,32 @@ describe('middleware', () => {
     expect(config.matcher).not.toContain('/audit-logs');
     expect(config.matcher).not.toContain('/audit-logs/:path*');
   });
+
+  it('matches the agents routes', () => {
+    expect(config.matcher).toContain('/agents');
+    expect(config.matcher).toContain('/agents/:path*');
+  });
+
+  // Regression guard for the `^/.*$` fallback: Next.js can't statically
+  // analyze a spread of an imported binding in `config.matcher`, so it
+  // silently matches every route — which made middleware run on static
+  // assets (/images, /static → 500) and public files (/robots.txt →
+  // redirect to /login). The matcher must stay a literal list of explicit
+  // route patterns with no catch-all entry.
+  it('has no catch-all matcher entry', () => {
+    const catchAlls = ['/', '/:path*', '/(.*)', '/:path', '/*'];
+    for (const entry of config.matcher) {
+      expect(typeof entry).toBe('string');
+      expect(catchAlls).not.toContain(entry);
+    }
+  });
+
+  it('does not match static asset or public-file prefixes', () => {
+    const shouldNeverMatch = ['/images', '/static', '/_next', '/favicon.ico', '/robots.txt'];
+    for (const entry of config.matcher) {
+      for (const asset of shouldNeverMatch) {
+        expect(entry.startsWith(asset)).toBe(false);
+      }
+    }
+  });
 });

--- a/src/client/src/app/(playground)/agents/[agentKey]/page.tsx
+++ b/src/client/src/app/(playground)/agents/[agentKey]/page.tsx
@@ -3,33 +3,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import {
-	Activity,
-	BookText,
-	LayoutDashboard,
-	LayoutGrid,
-	Loader2,
-	Settings,
-} from "lucide-react";
-import {
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
-} from "@/components/ui/tabs";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { useDynamicBreadcrumbs } from "@/utils/hooks/useBreadcrumbs";
 import getMessage from "@/constants/messages";
 import type { AgentVersion, UnifiedAgent } from "@/types/agents";
 import type { VersionFilter } from "@/types/store/filter";
 import { useAgentIntent } from "@/selectors/agents-instrumentation";
 import { getObservabilityView } from "@/lib/platform/agents/observability-view";
-import AgentHeader from "@/components/(playground)/agents/agent-header";
+import AgentHeader, {
+	AgentPillTab,
+} from "@/components/(playground)/agents/agent-header";
 import AgentScopeProvider from "@/components/(playground)/agents/agent-scope-provider";
 import AgentOverviewTab from "@/components/(playground)/agents/agent-overview-tab";
 import LifecycleActions from "@/components/(playground)/agents/lifecycle-actions";
-import VersionTimeline, {
-	VersionChooser,
-} from "@/components/(playground)/agents/version-timeline";
+import { VersionChooser } from "@/components/(playground)/agents/version-timeline";
 
 // Heavy tabs are dynamically imported so the initial detail-page payload
 // only loads what the Overview tab needs. LLMDashboard pulls echarts +
@@ -323,9 +311,14 @@ export default function AgentDetailPage() {
 
 	if (loading && !agent) {
 		return (
-			<div className="flex items-center justify-center h-full text-stone-500 dark:text-stone-400 text-sm gap-2">
-				<Loader2 className="w-4 h-4 animate-spin" />
-				{getMessage().AGENTS_LOADING_SERVICE_DETAILS}
+			<div className="flex h-full w-full flex-col overflow-hidden">
+				<div className="border-b border-stone-200 px-4 py-3 dark:border-stone-800">
+					<div className="h-8 w-48 animate-pulse rounded bg-stone-100 dark:bg-stone-800" />
+				</div>
+				<div className="flex flex-1 items-center justify-center gap-2 p-4 text-sm text-stone-500 dark:text-stone-400">
+					<Loader2 className="h-4 w-4 animate-spin" />
+					{getMessage().AGENTS_LOADING_SERVICE_DETAILS}
+				</div>
 			</div>
 		);
 	}
@@ -342,14 +335,20 @@ export default function AgentDetailPage() {
 					? "/agents?tab=controllers"
 					: "/agents";
 		return (
-			<div className="flex flex-col items-center justify-center h-full text-stone-500 dark:text-stone-400 text-sm gap-3">
-				<div>{error || "Agent not found"}</div>
-				<button
-					onClick={() => router.push(backHref)}
-					className="text-stone-700 dark:text-stone-200 underline"
-				>
-					{getMessage().AGENTS_BACK_TO_HUB}
-				</button>
+			<div className="flex h-full w-full flex-col overflow-hidden">
+				<div className="border-b border-stone-200 px-4 py-3 dark:border-stone-800">
+					<button
+						onClick={() => router.push(backHref)}
+						className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-stone-200 bg-stone-50 text-stone-600 transition hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+						title={getMessage().AGENTS_BACK_TO_HUB}
+						aria-label={getMessage().AGENTS_BACK_TO_HUB}
+					>
+						<ArrowLeft className="h-3.5 w-3.5" />
+					</button>
+				</div>
+				<div className="flex flex-1 flex-col items-center justify-center gap-3 p-4 text-sm text-stone-500 dark:text-stone-400">
+					<div>{error || "Agent not found"}</div>
+				</div>
 			</div>
 		);
 	}
@@ -369,16 +368,69 @@ export default function AgentDetailPage() {
 		(agent.request_count_24h ?? 0) === 0 &&
 		versions.length === 0;
 
+	const traditionalTabs = (
+		<div className="flex flex-wrap items-center gap-2">
+			{(
+				[
+					{ id: "overview", label: getMessage().AGENTS_TAB_OVERVIEW },
+					{ id: "dashboard", label: getMessage().AGENTS_TAB_DASHBOARD },
+					{ id: "monitoring", label: getMessage().AGENTS_TAB_MONITORING },
+					{ id: "definition", label: getMessage().AGENTS_TAB_DEFINITION },
+					{
+						id: "configuration",
+						label: getMessage().AGENTS_TAB_CONFIGURATION,
+						indicator: needsInstrumentation,
+						indicatorTooltip:
+							getMessage().AGENTS_TAB_CONFIGURATION_NEEDS_INSTRUMENTATION,
+					},
+				] as const
+			).map((tab) => (
+				<AgentPillTab
+					key={tab.id}
+					active={urlTab === tab.id}
+					label={tab.label}
+					onClick={() => handleTabChange(tab.id)}
+					indicator={"indicator" in tab ? tab.indicator : undefined}
+					indicatorTooltip={
+						"indicatorTooltip" in tab ? tab.indicatorTooltip : undefined
+					}
+				/>
+			))}
+		</div>
+	);
+
+	const codingTabs = (
+		<div className="flex flex-wrap items-center gap-2">
+			{(
+				[
+					{ id: "overview", label: getMessage().AGENTS_TAB_OVERVIEW },
+					{ id: "sessions", label: getMessage().AGENTS_CODING_TAB_SESSIONS },
+					{ id: "users", label: getMessage().AGENTS_CODING_USERS_SHORT_LABEL },
+				] as const
+			).map((tab) => (
+				<AgentPillTab
+					key={tab.id}
+					active={urlTab === tab.id}
+					label={tab.label}
+					onClick={() => handleTabChange(tab.id)}
+				/>
+			))}
+		</div>
+	);
+
 	return (
 		<AgentScopeProvider
 			serviceName={agent.service_name}
 			environment={agent.environment}
 			versionFilter={scopedVersionFilter}
 		>
-			<div className="flex flex-col w-full h-full gap-5 overflow-y-auto p-1 pb-8">
+			{/* Match the agents hub chrome: FeaturePageHeader (full-bleed
+			    top bar with pill tabs) + p-4 padded content below. */}
+			<div className="flex h-full w-full flex-col overflow-hidden">
 				<AgentHeader
 					agent={agent}
 					onRefresh={fetchAgent}
+					tabs={isCodingAgent ? codingTabs : traditionalTabs}
 					rightSlot={
 						isCodingAgent ? null : (
 							<div className="flex items-center gap-2">
@@ -398,19 +450,14 @@ export default function AgentDetailPage() {
 					}
 				/>
 
-				{isCodingAgent ? (
-					<CodingAgentDetail
-						agent={agent}
-						tab={urlTab}
-						onTabChange={handleTabChange}
-					/>
-				) : (
-					<>
-						<VersionTimeline
-							agentKey={agent.agent_key}
-							versions={versions}
-							selectedHash={urlVersionHash}
+				<section className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+					{isCodingAgent ? (
+						<CodingAgentDetail
+							agent={agent}
+							tab={urlTab}
+							onTabChange={handleTabChange}
 						/>
+					) : (
 						<TraditionalAgentTabs
 							agent={agent}
 							versions={versions}
@@ -419,13 +466,12 @@ export default function AgentDetailPage() {
 							handleTabChange={handleTabChange}
 							effectiveVersionHash={effectiveVersionHash}
 							activeVersion={activeVersion}
-							needsInstrumentation={needsInstrumentation}
 							fetchAgent={fetchAgent}
 							versionsOpen={versionsOpen}
 							setVersionsOpen={setVersionsOpen}
 						/>
-					</>
-				)}
+					)}
+				</section>
 			</div>
 		</AgentScopeProvider>
 	);
@@ -439,7 +485,6 @@ interface TraditionalAgentTabsProps {
 	handleTabChange: (value: string) => void;
 	effectiveVersionHash: string | null;
 	activeVersion: AgentVersion | null;
-	needsInstrumentation: boolean;
 	fetchAgent: () => Promise<void>;
 	versionsOpen: boolean;
 	setVersionsOpen: (open: boolean) => void;
@@ -452,83 +497,52 @@ function TraditionalAgentTabs({
 	handleTabChange,
 	effectiveVersionHash,
 	activeVersion,
-	needsInstrumentation,
 	fetchAgent,
 	versionsOpen,
 	setVersionsOpen,
 }: TraditionalAgentTabsProps) {
+	// Tab pills live in FeaturePageHeader (same surface as the agents
+	// hub). This component only owns the tab panels.
 	return (
 		<>
 			<Tabs
-					value={urlTab}
-					onValueChange={handleTabChange}
-					className="w-full"
-				>
-					<TabsList className="h-auto rounded-none border-b border-stone-200 dark:border-stone-800 bg-transparent p-0 w-full justify-start gap-1">
-						<UnderlineTab
-							value="overview"
-							icon={<LayoutGrid className="w-3.5 h-3.5" />}
-							label={getMessage().AGENTS_TAB_OVERVIEW}
-						/>
-						<UnderlineTab
-							value="dashboard"
-							icon={<LayoutDashboard className="w-3.5 h-3.5" />}
-							label={getMessage().AGENTS_TAB_DASHBOARD}
-						/>
-						<UnderlineTab
-							value="monitoring"
-							icon={<Activity className="w-3.5 h-3.5" />}
-							label={getMessage().AGENTS_TAB_MONITORING}
-						/>
-						<UnderlineTab
-							value="definition"
-							icon={<BookText className="w-3.5 h-3.5" />}
-							label={getMessage().AGENTS_TAB_DEFINITION}
-						/>
-						<UnderlineTab
-							value="configuration"
-							icon={<Settings className="w-3.5 h-3.5" />}
-							label={getMessage().AGENTS_TAB_CONFIGURATION}
-							indicator={needsInstrumentation}
-							indicatorTooltip={
-								getMessage().AGENTS_TAB_CONFIGURATION_NEEDS_INSTRUMENTATION
-							}
-						/>
-					</TabsList>
+				value={urlTab}
+				onValueChange={handleTabChange}
+				className="w-full"
+			>
+				<TabsContent value="overview" className="mt-0">
+					<AgentOverviewTab
+						agent={agent}
+						versionHash={effectiveVersionHash}
+					/>
+				</TabsContent>
 
-					<TabsContent value="overview" className="mt-4">
-						<AgentOverviewTab
-							agent={agent}
-							versionHash={effectiveVersionHash}
-						/>
-					</TabsContent>
+				<TabsContent value="dashboard" className="mt-0">
+					<div className="space-y-3">
+						<Filter />
+						<LLMDashboard />
+					</div>
+				</TabsContent>
 
-					<TabsContent value="dashboard" className="mt-4">
-						<div className="space-y-3">
-							<Filter />
-							<LLMDashboard />
+				<TabsContent value="monitoring" className="mt-0">
+					<RequestsPage />
+				</TabsContent>
+
+				<TabsContent value="definition" className="mt-0">
+					{activeVersion ? (
+						<div className="space-y-4">
+							<SystemPromptCard prompt={activeVersion.system_prompt} />
+							<ToolsCard tools={activeVersion.tools} />
 						</div>
-					</TabsContent>
+					) : (
+						<EmptyVersion />
+					)}
+				</TabsContent>
 
-					<TabsContent value="monitoring" className="mt-4">
-						<RequestsPage />
-					</TabsContent>
-
-					<TabsContent value="definition" className="mt-4">
-						{activeVersion ? (
-							<div className="space-y-4">
-								<SystemPromptCard prompt={activeVersion.system_prompt} />
-								<ToolsCard tools={activeVersion.tools} />
-							</div>
-						) : (
-							<EmptyVersion />
-						)}
-					</TabsContent>
-
-					<TabsContent value="configuration" className="mt-4">
-						<AgentConfigurationTab agent={agent} onRefresh={fetchAgent} />
-					</TabsContent>
-				</Tabs>
+				<TabsContent value="configuration" className="mt-0">
+					<AgentConfigurationTab agent={agent} onRefresh={fetchAgent} />
+				</TabsContent>
+			</Tabs>
 
 			<VersionDrawer
 				agentKey={agent.agent_key}
@@ -537,38 +551,6 @@ function TraditionalAgentTabs({
 				initialVersions={versions}
 			/>
 		</>
-	);
-}
-
-function UnderlineTab({
-	value,
-	icon,
-	label,
-	indicator,
-	indicatorTooltip,
-}: {
-	value: string;
-	icon: React.ReactNode;
-	label: string;
-	indicator?: boolean;
-	indicatorTooltip?: string;
-}) {
-	return (
-		<TabsTrigger
-			value={value}
-			className="rounded-none border-b-2 border-transparent bg-transparent shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-stone-900 dark:data-[state=active]:text-stone-100 data-[state=active]:shadow-none px-3 py-2 text-sm text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 -mb-px flex items-center gap-1.5 relative"
-		>
-			{icon}
-			{label}
-			{indicator && (
-				<span
-					role="status"
-					aria-label={indicatorTooltip}
-					title={indicatorTooltip}
-					className="ml-1 inline-flex w-2 h-2 rounded-full bg-orange-500 motion-safe:animate-pulse"
-				/>
-			)}
-		</TabsTrigger>
 	);
 }
 

--- a/src/client/src/app/(playground)/agents/controller/[instance_id]/page.tsx
+++ b/src/client/src/app/(playground)/agents/controller/[instance_id]/page.tsx
@@ -178,13 +178,14 @@ export default function ControllerDetailPage() {
 
 	if (instanceError || !instance) {
 		return (
-			<div className="flex flex-col w-full gap-4 p-1">
+			<div className="flex flex-col w-full gap-4 p-4">
 				<button
 					onClick={() => router.push("/agents?tab=controllers")}
-					className="flex items-center gap-2 text-sm text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 w-fit transition-colors"
+					className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-stone-200 bg-stone-50 text-stone-600 transition hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+					title={getMessage().AGENTS_BACK_TO_HUB}
+					aria-label={getMessage().AGENTS_BACK_TO_HUB}
 				>
-					<ArrowLeft className="w-4 h-4" />
-					{getMessage().AGENTS_BACK_TO_HUB}
+					<ArrowLeft className="h-3.5 w-3.5" />
 				</button>
 				<div className="text-center py-16 text-stone-500 dark:text-stone-400">
 					Controller not found or failed to load.
@@ -194,13 +195,14 @@ export default function ControllerDetailPage() {
 	}
 
 	return (
-		<div className="flex flex-col w-full gap-4 p-1 overflow-y-auto">
+		<div className="flex flex-col w-full gap-4 overflow-y-auto p-4">
 			<button
 				onClick={() => router.push("/agents?tab=controllers")}
-				className="flex items-center gap-2 text-sm text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 w-fit transition-colors"
+				className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-stone-200 bg-stone-50 text-stone-600 transition hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+				title={getMessage().AGENTS_BACK_TO_HUB}
+				aria-label={getMessage().AGENTS_BACK_TO_HUB}
 			>
-				<ArrowLeft className="w-4 h-4" />
-				{getMessage().AGENTS_BACK_TO_HUB}
+				<ArrowLeft className="h-3.5 w-3.5" />
 			</button>
 			<ControllerHeader instance={instance} />
 			<ControllerConfigEditor instance={instance} />

--- a/src/client/src/app/(playground)/agents/no-coding-agents.tsx
+++ b/src/client/src/app/(playground)/agents/no-coding-agents.tsx
@@ -481,7 +481,7 @@ export default function NoCodingAgents({ compact = false }: NoCodingAgentsProps)
 							Full reference (env vars, content-capture modes,
 							marketplace install):{" "}
 							<a
-								href="https://docs.openlit.io/latest/features/coding-agents/onboarding"
+								href="https://docs.openlit.io/latest/openlit/coding-agents/onboarding"
 								target="_blank"
 								rel="noreferrer"
 								className="text-primary hover:underline"

--- a/src/client/src/app/(playground)/agents/page.tsx
+++ b/src/client/src/app/(playground)/agents/page.tsx
@@ -32,6 +32,10 @@ import {
 import ComboDropdown from "@/components/(playground)/filter/combo-dropdown";
 import Filter from "@/components/(playground)/filter";
 import FeaturePageHeader from "@/components/(playground)/feature-page-header";
+import {
+	AgentPillTab,
+	AGENTS_HEADER_TONE,
+} from "@/components/(playground)/agents/agent-header";
 import getMessage from "@/constants/messages";
 import NoController from "./no-controller";
 import NoCodingAgents from "./no-coding-agents";
@@ -604,10 +608,16 @@ export default function AgentsPage() {
 	return (
 		<div className="flex h-full w-full flex-col overflow-hidden">
 			<FeaturePageHeader
-				eyebrow="Monitoring"
-				title={getMessage().FEATURE_AGENTS}
-				icon={<Bot className="h-4 w-4" />}
-				tone="border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900/70 dark:bg-teal-950/40 dark:text-teal-300"
+				eyebrow={getMessage().FEATURE_AGENTS}
+				title={
+					activeTab === "coding"
+						? getMessage().AGENTS_TAB_CODING
+						: activeTab === "controllers"
+							? getMessage().AGENTS_TAB_CONTROLLERS
+							: getMessage().AGENTS_TAB_SERVICES
+				}
+				icon={<Bot className="h-5 w-5" />}
+				tone={AGENTS_HEADER_TONE}
 				actions={(
 					<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
 						<div className="flex flex-wrap items-center gap-2">
@@ -618,24 +628,19 @@ export default function AgentsPage() {
 									{ id: "controllers", label: getMessage().AGENTS_TAB_CONTROLLERS },
 								] as const
 							).map((tab) => (
-								<button
+								<AgentPillTab
 									key={tab.id}
+									active={activeTab === tab.id}
+									label={tab.label}
 									onClick={() => setActiveTab(tab.id)}
-									className={`inline-flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs transition ${
-										activeTab === tab.id
-											? "border-teal-200 bg-teal-50 text-teal-700 dark:border-teal-900/70 dark:bg-teal-950/40 dark:text-teal-300"
-											: "border-stone-200 bg-stone-50 text-stone-600 hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
-									}`}
-								>
-									<span className="font-medium">{tab.label}</span>
-								</button>
+								/>
 							))}
 						</div>
 						{activeTab === "controllers" && (
 							<Button
-								variant="outline"
+								variant="secondary"
 								size="sm"
-								className="h-8"
+								className="h-8 bg-primary text-stone-100 hover:bg-primary dark:bg-primary dark:text-stone-100 dark:hover:bg-primary"
 								onClick={() => setSetupModal("controller")}
 							>
 								<Plus className="w-3 h-3 mr-1.5" />
@@ -644,9 +649,9 @@ export default function AgentsPage() {
 						)}
 						{activeTab === "coding" && (
 							<Button
-								variant="outline"
+								variant="secondary"
 								size="sm"
-								className="h-8"
+								className="h-8 bg-primary text-stone-100 hover:bg-primary dark:bg-primary dark:text-stone-100 dark:hover:bg-primary"
 								onClick={() => setSetupModal("coding")}
 							>
 								<Plus className="w-3 h-3 mr-1.5" />
@@ -781,78 +786,78 @@ export default function AgentsPage() {
 						   tab switch — number + label only, no
 						   subtitle line. Order is Total Coding
 						   agents → Total users → Total cost. */
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-3 gap-2">
 							<button
 								onClick={handleCodingStatClick}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100">
+								<div className="text-lg font-semibold leading-tight text-stone-900 dark:text-stone-100">
 									{codingVendorsUsed}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_CODING_VENDORS}
 								</div>
 							</button>
 							<button
 								onClick={handleCodingStatClick}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100 tabular-nums">
+								<div className="text-lg font-semibold leading-tight tabular-nums text-stone-900 dark:text-stone-100">
 									{codingTotalUsers.toLocaleString()}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_CODING_USERS}
 								</div>
 							</button>
 							<button
 								onClick={handleCodingStatClick}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100 tabular-nums">
+								<div className="text-lg font-semibold leading-tight tabular-nums text-stone-900 dark:text-stone-100">
 									${codingTotalCost.toFixed(2)}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_CODING_COST}
 								</div>
 							</button>
 						</div>
 					) : (
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-3 gap-2">
 							<button
 								onClick={() => handleLegacyStatClick("controllers")}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100">
+								<div className="text-lg font-semibold leading-tight text-stone-900 dark:text-stone-100">
 									{activeControllers.length}
 									{staleCount > 0 && (
-										<span className="text-sm font-normal text-stone-400 dark:text-stone-500 ml-1.5">
+										<span className="ml-1.5 text-xs font-normal text-stone-400 dark:text-stone-500">
 											({staleCount} stale)
 										</span>
 									)}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_CONTROLLERS}
 								</div>
 							</button>
 							<button
 								onClick={() => handleLegacyStatClick("discovered")}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100">
+								<div className="text-lg font-semibold leading-tight text-stone-900 dark:text-stone-100">
 									{totalServices}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_DISCOVERED_SERVICES}
 								</div>
 							</button>
 							<button
 								onClick={() => handleLegacyStatClick("instrumented")}
-								className="border dark:border-stone-800 rounded-lg p-4 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-800/50"
+								className="rounded-md border border-stone-200 px-3 py-2 text-left transition-colors hover:bg-stone-50 dark:border-stone-800 dark:hover:bg-stone-800/50"
 							>
-								<div className="text-2xl font-semibold text-stone-900 dark:text-stone-100">
+								<div className="text-lg font-semibold leading-tight text-stone-900 dark:text-stone-100">
 									{instrumentedServices}
 								</div>
-								<div className="text-sm text-stone-500 dark:text-stone-400">
+								<div className="text-xs text-stone-500 dark:text-stone-400">
 									{getMessage().AGENTS_STAT_INSTRUMENTED_SERVICES}
 								</div>
 							</button>

--- a/src/client/src/app/(playground)/fleet-hub/[id]/agent.tsx
+++ b/src/client/src/app/(playground)/fleet-hub/[id]/agent.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Clock, HeartPulse, Package, Server } from "lucide-react"
+import { ArrowLeft, Clock, HeartPulse, Package, Server } from "lucide-react"
+import Link from "next/link"
 import { Agent } from "@/types/fleet-hub"
 import { formatDate } from "@/utils/date"
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion"
@@ -20,6 +21,7 @@ import { CLIENT_EVENTS } from "@/constants/events"
 import { toast } from "sonner"
 import FeaturePageHeader from "@/components/(playground)/feature-page-header"
 import OpenTelemetrySvg from "@/components/svg/opentelemetry"
+import getMessage from "@/constants/messages"
 
 interface AgentDetailProps {
   agent: Agent,
@@ -44,47 +46,59 @@ export default function AgentDetail({ agent, fetchAgentInfo }: AgentDetailProps)
     })
   }, [agent, setHeader]);
 
+  const backLabel = getMessage().FLEET_HUB_BACK_TO_LIST;
+  const serviceName = getAttributeValue(agent, "Status.agent_description.identifying_attributes", "service.name");
+
   return (
     <div className="flex h-full w-full flex-col overflow-hidden">
       <FeaturePageHeader
-        eyebrow="Monitoring"
-        title={getAttributeValue(agent, "Status.agent_description.identifying_attributes", "service.name")}
-        icon={<OpenTelemetrySvg className="h-4 w-4" />}
+        eyebrow={getMessage().FEATURE_FLEET_HUB}
+        title={serviceName}
+        icon={<OpenTelemetrySvg className="h-5 w-5" />}
         tone="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300"
+        leading={(
+          <Button
+            asChild
+            variant="outline"
+            size="sm"
+            className="h-8 w-8 shrink-0 p-0"
+          >
+            <Link href="/fleet-hub" title={backLabel} aria-label={backLabel}>
+              <ArrowLeft className="h-3.5 w-3.5" />
+            </Link>
+          </Button>
+        )}
       />
-      <div className="space-y-6 overflow-auto w-full flex flex-col grow p-4">
+      <div className="space-y-4 overflow-auto w-full flex flex-col grow p-4">
       <Card>
-        <CardHeader className="flex flex-row items-center gap-8 space-y-0 p-4">
-          <CardTitle>{getAttributeValue(agent, "Status.agent_description.identifying_attributes", "service.name")}</CardTitle>
-        </CardHeader>
-        <CardContent className="p-4 pt-0">
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-stone-200/50 dark:bg-stone-700/50">
-              <Package className="h-4 w-4 text-primary" />
-              <div>
-                <p className="text-xs text-muted-foreground">Version</p>
-                <p className="font-mono text-sm font-medium">{getAttributeValue(agent, "Status.agent_description.identifying_attributes", "service.version")}</p>
+        <CardContent className="p-3">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2">
+            <div className="flex items-center gap-2 rounded-md border border-stone-200 bg-stone-50 px-2.5 py-2 dark:border-stone-800 dark:bg-stone-900/40">
+              <Package className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <p className="text-[11px] leading-none text-muted-foreground">Version</p>
+                <p className="truncate font-mono text-sm font-medium">{getAttributeValue(agent, "Status.agent_description.identifying_attributes", "service.version")}</p>
               </div>
             </div>
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-stone-200/50 dark:bg-stone-700/50">
-              <Clock className="h-4 w-4 text-primary" />
-              <div>
-                <p className="text-xs text-muted-foreground">Started At</p>
-                <p className="font-mono text-sm font-medium">{formatDate(agent.StartedAt, { time: true })}</p>
+            <div className="flex items-center gap-2 rounded-md border border-stone-200 bg-stone-50 px-2.5 py-2 dark:border-stone-800 dark:bg-stone-900/40">
+              <Clock className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <p className="text-[11px] leading-none text-muted-foreground">Started At</p>
+                <p className="truncate font-mono text-sm font-medium">{formatDate(agent.StartedAt, { time: true })}</p>
               </div>
             </div>
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-stone-200/50 dark:bg-stone-700/50">
-              <Server className="h-4 w-4 text-primary" />
-              <div>
-                <p className="text-xs text-muted-foreground">Host Name</p>
-                <p className="font-mono text-sm font-medium">{getAttributeValue(agent, "Status.agent_description.non_identifying_attributes", "host.name")}</p>
+            <div className="flex items-center gap-2 rounded-md border border-stone-200 bg-stone-50 px-2.5 py-2 dark:border-stone-800 dark:bg-stone-900/40">
+              <Server className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <p className="text-[11px] leading-none text-muted-foreground">Host Name</p>
+                <p className="truncate font-mono text-sm font-medium">{getAttributeValue(agent, "Status.agent_description.non_identifying_attributes", "host.name")}</p>
               </div>
             </div>
-            <div className="flex items-center gap-3 p-3 rounded-lg bg-stone-200/50 dark:bg-stone-700/50">
-              <HeartPulse className="h-4 w-4 text-primary" />
-              <div>
-                <p className="text-xs text-muted-foreground">Health Status</p>
-                <p className={`font-mono text-xs font-medium px-2 text-center ${agent.Status.health.healthy ? "bg-green-500 text-white dark:bg-green-500 dark:text-white" : "bg-red-500 text-white dark:bg-red-500 dark:text-white"}`}>{agent.Status.health.status || "Error"}</p>
+            <div className="flex items-center gap-2 rounded-md border border-stone-200 bg-stone-50 px-2.5 py-2 dark:border-stone-800 dark:bg-stone-900/40">
+              <HeartPulse className="h-3.5 w-3.5 shrink-0 text-primary" />
+              <div className="min-w-0">
+                <p className="text-[11px] leading-none text-muted-foreground">Health Status</p>
+                <p className={`mt-0.5 inline-block font-mono text-xs font-medium px-1.5 ${agent.Status.health.healthy ? "bg-green-500 text-white dark:bg-green-500 dark:text-white" : "bg-red-500 text-white dark:bg-red-500 dark:text-white"}`}>{agent.Status.health.status || "Error"}</p>
               </div>
             </div>
             {

--- a/src/client/src/app/(playground)/fleet-hub/list.tsx
+++ b/src/client/src/app/(playground)/fleet-hub/list.tsx
@@ -140,7 +140,7 @@ export default function List({ agents, isLoading, isFetched }: {
 
 	return (
 		<div className="flex flex-col w-full h-full">
-			<FeaturePageHeader eyebrow="Monitoring" title={getMessage().FEATURE_FLEET_HUB} icon={<OpenTelemetrySvg className="h-4 w-4" />} tone="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300" actions={<VisibilityColumns columns={columns} pageName={"fleethub"} />} />
+			<FeaturePageHeader eyebrow={getMessage().FEATURE_FLEET_HUB} title={getMessage().FEATURE_FLEET_HUB} icon={<OpenTelemetrySvg className="h-5 w-5" />} tone="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300" actions={<VisibilityColumns columns={columns} pageName={"fleethub"} />} />
 			<div className="flex flex-col w-full h-full p-4">
 				<DataTable
 					columns={columns}

--- a/src/client/src/app/(playground)/prompt-hub/[id]/page.tsx
+++ b/src/client/src/app/(playground)/prompt-hub/[id]/page.tsx
@@ -210,14 +210,23 @@ export default function PromptHub() {
 
 	return (
 		<div className="flex flex-col w-full h-full">
-			<PromptHubHeader createNew={false} title={`Prompt : ${data.name}`} promptUsage={false} extraButtons={(
-				<>
-					<Button variant="outline" size="sm" className="h-8" onClick={() => router.push("/prompt-hub")}>
-						<ArrowLeftIcon className="mr-1.5 size-3.5" />
-						{getMessage().BACK}
+			<PromptHubHeader
+				createNew={false}
+				title={`Prompt : ${data.name}`}
+				promptUsage={false}
+				leading={(
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-8 w-8 shrink-0 p-0"
+						onClick={() => router.push("/prompt-hub")}
+						title={getMessage().BACK}
+						aria-label={getMessage().BACK}
+					>
+						<ArrowLeftIcon className="size-3.5" />
 					</Button>
-				</>
-			)} />
+				)}
+			/>
 			<div className="grid grid-cols-3 w-full h-full overflow-hidden gap-4 p-4">
 				{/* Left: prompt details */}
 				<Card className="grow col-span-2 overflow-hidden flex flex-col border border-stone-200 dark:border-stone-800">

--- a/src/client/src/app/(playground)/rule-engine/[id]/page.tsx
+++ b/src/client/src/app/(playground)/rule-engine/[id]/page.tsx
@@ -188,12 +188,24 @@ export default function RuleDetailPage() {
 
 	return (
 		<div className="flex h-full w-full flex-col overflow-hidden">
-			<FeaturePageHeader eyebrow="Resources" title={r.name} icon={<SlidersHorizontal className="h-4 w-4" />} tone={ruleHeaderTone} actions={(
-				<Button variant="outline" size="sm" className="h-8" onClick={() => router.push("/rule-engine")}>
-					<ArrowLeftIcon className="mr-1.5 size-3.5" />
-					{getMessage().BACK}
-				</Button>
-			)} />
+			<FeaturePageHeader
+				eyebrow="Resources"
+				title={r.name}
+				icon={<SlidersHorizontal className="h-4 w-4" />}
+				tone={ruleHeaderTone}
+				leading={(
+					<Button
+						variant="outline"
+						size="sm"
+						className="h-8 w-8 shrink-0 p-0"
+						onClick={() => router.push("/rule-engine")}
+						title={getMessage().BACK}
+						aria-label={getMessage().BACK}
+					>
+						<ArrowLeftIcon className="size-3.5" />
+					</Button>
+				)}
+			/>
 			<div className="grid grid-cols-3 w-full h-full overflow-hidden gap-4 p-4">
 				{/* Left: Rule info + condition builder */}
 				<Card className="col-span-2 overflow-hidden flex flex-col border border-stone-200 dark:border-stone-800">

--- a/src/client/src/components/(playground)/agents/agent-header.tsx
+++ b/src/client/src/components/(playground)/agents/agent-header.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { ArrowLeft, RefreshCw } from "lucide-react";
+import { ArrowLeft, Bot, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import FeaturePageHeader from "@/components/(playground)/feature-page-header";
 import getMessage from "@/constants/messages";
 import type { UnifiedAgent } from "@/types/agents";
 import {
@@ -16,7 +18,9 @@ import {
 interface AgentHeaderProps {
 	agent: UnifiedAgent;
 	onRefresh: () => void;
-	rightSlot?: React.ReactNode;
+	/** Pill tab switcher — same surface as the agents hub header actions. */
+	tabs?: ReactNode;
+	rightSlot?: ReactNode;
 }
 
 // Map a `?from=<tab>` source the table click stamped on the
@@ -38,9 +42,18 @@ function buildBackHref(
 	return tab === "services" ? "/agents" : `/agents?tab=${tab}`;
 }
 
+/** Soft sky chip — matches Telemetry Traces active tone, not solid teal. */
+export const AGENTS_HEADER_TONE =
+	"border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300";
+
+/** Active pill tab — same soft sky treatment as Telemetry signal toggles. */
+export const AGENTS_PILL_TAB_ACTIVE =
+	"border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900 dark:bg-sky-950/40 dark:text-sky-400";
+
 export default function AgentHeader({
 	agent,
 	onRefresh,
+	tabs,
 	rightSlot,
 }: AgentHeaderProps) {
 	const [isRefreshing, setIsRefreshing] = useState(false);
@@ -70,53 +83,105 @@ export default function AgentHeader({
 		}
 	}, [agent.agent_key, onRefresh]);
 
-	return (
-		<div className="space-y-2">
-			<div className="flex items-center justify-between gap-3">
-				<Link
-					href={backHref}
-					className="flex items-center gap-1.5 text-sm text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100"
-				>
-					<ArrowLeft className="w-4 h-4" />
-					{getMessage().AGENTS_BACK_TO_HUB}
-				</Link>
-				<button
-					onClick={handleRefresh}
-					disabled={isRefreshing}
-					className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-md border border-stone-200 dark:border-stone-700 text-stone-600 dark:text-stone-300 hover:bg-stone-50 dark:hover:bg-stone-800 disabled:opacity-50"
-				>
-					<RefreshCw
-						className={`w-3 h-3 ${isRefreshing ? "animate-spin" : ""}`}
-					/>
-					{isRefreshing
-						? getMessage().AGENTS_REFRESHING
-						: getMessage().AGENTS_REFRESH}
-				</button>
-			</div>
+	const isCoding = agent.source === "coding";
+	const title =
+		isCoding && hasCodingAgentVendorIcon(agent.coding_agent_vendor)
+			? codingAgentVendorLabel(agent.coding_agent_vendor)
+			: agent.service_name;
 
-			<div className="flex items-center justify-between gap-3 flex-wrap">
-				{/* For coding-agent rows we render the vendor logo + the
-				    pretty vendor label (e.g. "Claude Code" instead of
-				    the raw `claude-code` service name). For services /
-				    controllers we keep the existing service_name
-				    rendering — no logo, no transformation. */}
-				<h1 className="text-2xl font-semibold text-stone-900 dark:text-stone-100 inline-flex items-center gap-2">
-					{hasCodingAgentVendorIcon(agent.coding_agent_vendor) ? (
-						<>
-							<CodingAgentVendorIcon
-								vendor={agent.coding_agent_vendor}
-								className="h-7 w-7 shrink-0"
-							/>
-							<span>
-								{codingAgentVendorLabel(agent.coding_agent_vendor)}
-							</span>
-						</>
-					) : (
-						agent.service_name
-					)}
-				</h1>
-				{rightSlot && <div className="shrink-0">{rightSlot}</div>}
-			</div>
-		</div>
+	const icon =
+		isCoding && hasCodingAgentVendorIcon(agent.coding_agent_vendor) ? (
+			<CodingAgentVendorIcon
+				vendor={agent.coding_agent_vendor}
+				className="h-5 w-5"
+			/>
+		) : (
+			<Bot className="h-5 w-5" />
+		);
+
+	const backLabel = getMessage().AGENTS_BACK_TO_HUB;
+
+	return (
+		<FeaturePageHeader
+			eyebrow={getMessage().FEATURE_AGENTS}
+			title={title}
+			icon={icon}
+			tone={AGENTS_HEADER_TONE}
+			leading={
+				<Button
+					asChild
+					variant="outline"
+					size="sm"
+					className="h-8 w-8 shrink-0 p-0"
+				>
+					<Link href={backHref} title={backLabel} aria-label={backLabel}>
+						<ArrowLeft className="h-3.5 w-3.5" />
+					</Link>
+				</Button>
+			}
+			actions={
+				<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
+					{tabs}
+					{rightSlot}
+					<button
+						onClick={handleRefresh}
+						disabled={isRefreshing}
+						title={
+							isRefreshing
+								? getMessage().AGENTS_REFRESHING
+								: getMessage().AGENTS_REFRESH
+						}
+						aria-label={
+							isRefreshing
+								? getMessage().AGENTS_REFRESHING
+								: getMessage().AGENTS_REFRESH
+						}
+						className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-stone-200 bg-stone-50 text-stone-600 transition hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800 disabled:opacity-50"
+					>
+						<RefreshCw
+							className={`h-3.5 w-3.5 ${isRefreshing ? "animate-spin" : ""}`}
+						/>
+					</button>
+				</div>
+			}
+		/>
+	);
+}
+
+/** Shared pill-tab button used by the agents hub and detail pages. */
+export function AgentPillTab({
+	active,
+	label,
+	onClick,
+	indicator,
+	indicatorTooltip,
+}: {
+	active: boolean;
+	label: string;
+	onClick: () => void;
+	indicator?: boolean;
+	indicatorTooltip?: string;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onClick}
+			aria-pressed={active}
+			className={`inline-flex items-center gap-2 rounded-md border px-2.5 py-1.5 text-xs font-medium transition ${
+				active
+					? AGENTS_PILL_TAB_ACTIVE
+					: "border-stone-200 bg-stone-50 text-stone-600 hover:bg-stone-100 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-300 dark:hover:bg-stone-800"
+			}`}
+		>
+			<span>{label}</span>
+			{indicator ? (
+				<span
+					role="status"
+					aria-label={indicatorTooltip}
+					title={indicatorTooltip}
+					className="inline-flex h-2 w-2 rounded-full bg-orange-500 motion-safe:animate-pulse"
+				/>
+			) : null}
+		</button>
 	);
 }

--- a/src/client/src/components/(playground)/coding-agents/coding-agent-detail.tsx
+++ b/src/client/src/components/(playground)/coding-agents/coding-agent-detail.tsx
@@ -2,39 +2,18 @@
 
 /**
  * Coding-agent detail view rendered when /agents/[agentKey] resolves to a
- * row with `source === "coding"`. We keep the same outer chrome (header,
- * breadcrumbs) as the SDK/controller detail page but swap the body for a
- * tab set that's relevant to a fleet of coding-agent users:
+ * row with `source === "coding"`. The outer chrome (FeaturePageHeader +
+ * pill tabs) lives on the parent detail page so it matches the agents
+ * hub. This component only owns the tab panels:
  *
- *   - Overview   — rollups (sessions, cost, active users, top
- *                  models / tools / repos) over the time window
- *                  selected in the global filter picker — no fixed
- *                  24h fallback. The Overview tab body is the
- *                  embedded seeded dashboard; its widgets read
- *                  `{{filter.timeLimit.*}}` so they move with the
- *                  picker too.
+ *   - Overview   — embedded seeded dashboard for this vendor.
  *   - Sessions   — recent sessions with drill-in to per-session detail.
- *   - Dashboard  — embedded seeded board for this vendor.
- *
- * Sessions and Dashboard are scaffolded here and wired up by the
- * queries-lib + api-routes + dashboard-seed todos. The Overview pulls
- * from the materialized rollups already on UnifiedAgent so it's live the
- * moment the materializer runs.
+ *   - Users      — per-user rollups.
  */
 
 import dynamic from "next/dynamic";
-import {
-	LayoutGrid,
-	List,
-	Loader2,
-	Users,
-} from "lucide-react";
-import {
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
-} from "@/components/ui/tabs";
+import { Loader2 } from "lucide-react";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import getMessage from "@/constants/messages";
 import type { UnifiedAgent } from "@/types/agents";
 
@@ -74,62 +53,22 @@ export default function CodingAgentDetail({
 	tab,
 	onTabChange,
 }: CodingAgentDetailProps) {
-	// Overview is just the embedded "Coding Agents" board. The earlier
-	// StatTile cluster + Client info card duplicated values that
-	// already live on the board (cost, sessions, users) so we removed
-	// them; the dashboard widgets + the page header carry that data.
+	// Pill tabs live in FeaturePageHeader on the parent page (same
+	// surface as the agents hub). This component only owns the panels.
 	return (
 		<Tabs value={tab} onValueChange={onTabChange} className="w-full">
-			<TabsList className="h-auto rounded-none border-b border-stone-200 dark:border-stone-800 bg-transparent p-0 w-full justify-start gap-1">
-				<UnderlineTab
-					value="overview"
-					icon={<LayoutGrid className="w-3.5 h-3.5" />}
-					label={getMessage().AGENTS_TAB_OVERVIEW}
-				/>
-				<UnderlineTab
-					value="sessions"
-					icon={<List className="w-3.5 h-3.5" />}
-					label={getMessage().AGENTS_CODING_TAB_SESSIONS}
-				/>
-				<UnderlineTab
-					value="users"
-					icon={<Users className="w-3.5 h-3.5" />}
-					label={getMessage().AGENTS_CODING_USERS_SHORT_LABEL}
-				/>
-			</TabsList>
-
-			<TabsContent value="overview" className="mt-4">
+			<TabsContent value="overview" className="mt-0">
 				<CodingDashboardTab agent={agent} />
 			</TabsContent>
 
-			<TabsContent value="sessions" className="mt-4">
+			<TabsContent value="sessions" className="mt-0">
 				<CodingSessionsTab agent={agent} />
 			</TabsContent>
 
-			<TabsContent value="users" className="mt-4">
+			<TabsContent value="users" className="mt-0">
 				<CodingUsersTab agent={agent} />
 			</TabsContent>
 		</Tabs>
-	);
-}
-
-function UnderlineTab({
-	value,
-	icon,
-	label,
-}: {
-	value: string;
-	icon: React.ReactNode;
-	label: string;
-}) {
-	return (
-		<TabsTrigger
-			value={value}
-			className="rounded-none border-b-2 border-transparent bg-transparent shadow-none data-[state=active]:border-primary data-[state=active]:bg-transparent data-[state=active]:text-stone-900 dark:data-[state=active]:text-stone-100 data-[state=active]:shadow-none px-3 py-2 text-sm text-stone-500 dark:text-stone-400 hover:text-stone-700 dark:hover:text-stone-200 -mb-px flex items-center gap-1.5 relative"
-		>
-			{icon}
-			{label}
-		</TabsTrigger>
 	);
 }
 

--- a/src/client/src/components/(playground)/coding-agents/coding-dashboard-tab.tsx
+++ b/src/client/src/components/(playground)/coding-agents/coding-dashboard-tab.tsx
@@ -20,13 +20,8 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { ArrowUpRight, HelpCircle, Loader2, X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import Dashboard from "@/components/(playground)/manage-dashboard/board-creator";
-import {
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-} from "@/components/ui/popover";
 import {
 	DashboardConfig,
 	Widget,
@@ -85,7 +80,6 @@ export default function CodingDashboardTab({
 	// page navigation. Falls back to the pinned prop (used by the
 	// dedicated `/coding-agents/users/[userId]` page).
 	const activeUser = searchParams?.get("user") || pinnedUser || null;
-	const [boardId, setBoardId] = useState<string | null>(null);
 	const [config, setConfig] = useState<DashboardConfig | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
@@ -108,7 +102,6 @@ export default function CodingDashboardTab({
 					setError("not_seeded");
 					return;
 				}
-				setBoardId(match.id);
 				const { response: layoutRes, error: layoutErr } = await fireRequest({
 					url: `/api/manage-dashboard/board/${match.id}/layout`,
 					requestType: "GET",
@@ -214,30 +207,18 @@ export default function CodingDashboardTab({
 
 	return (
 		<div className="space-y-3">
-			<div className="flex items-center justify-between gap-2">
-				<div className="flex items-center gap-3">
-					<ClassificationHelpPopover />
-					{showUserPill && (
-						<Link
-							href={typeof window !== "undefined" ? window.location.pathname : "."}
-							className="inline-flex items-center gap-1.5 rounded-full border border-violet-200 bg-violet-50 px-2 py-1 text-xs font-medium text-violet-700 hover:bg-violet-100 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300 dark:hover:bg-violet-900/40"
-							title="Clear user filter"
-						>
-							<span className="font-mono">@{activeUser}</span>
-							<X className="h-3 w-3" />
-						</Link>
-					)}
-				</div>
-				{boardId && (
+			{showUserPill ? (
+				<div className="flex items-center gap-2">
 					<Link
-						href={`/d/${boardId}`}
-						className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+						href={typeof window !== "undefined" ? window.location.pathname : "."}
+						className="inline-flex items-center gap-1.5 rounded-full border border-violet-200 bg-violet-50 px-2 py-1 text-xs font-medium text-violet-700 hover:bg-violet-100 dark:border-violet-900 dark:bg-violet-950/40 dark:text-violet-300 dark:hover:bg-violet-900/40"
+						title="Clear user filter"
 					>
-						{getMessage().AGENTS_CODING_DASHBOARD_OPEN}
-						<ArrowUpRight className="w-3.5 h-3.5" />
+						<span className="font-mono">@{activeUser}</span>
+						<X className="h-3 w-3" />
 					</Link>
-				)}
-			</div>
+				</div>
+			) : null}
 			<Dashboard
 				className="overflow-visible"
 				initialConfig={config}
@@ -249,93 +230,5 @@ export default function CodingDashboardTab({
 				runFilters={runFilters}
 			/>
 		</div>
-	);
-}
-
-/**
- * Inline explainer for the "Personal vs work classification" donut on
- * the Coding Agents dashboard. Users (rightly) ask "how was this
- * decided?" — the answer is below. The rules mirror
- * `cli/internal/coding/classify/classify.go`; if that file's branch
- * order changes, update this copy.
- */
-function ClassificationHelpPopover() {
-	return (
-		<Popover>
-			<PopoverTrigger asChild>
-				<button
-					type="button"
-					className="inline-flex items-center gap-1.5 text-xs text-stone-500 dark:text-stone-400 hover:text-stone-900 dark:hover:text-stone-100 transition-colors"
-				>
-					<HelpCircle className="w-3.5 h-3.5" />
-					How is classification computed?
-				</button>
-			</PopoverTrigger>
-			<PopoverContent
-				align="start"
-				className="w-[420px] text-xs leading-relaxed"
-			>
-				<div className="space-y-3">
-					<div className="font-medium text-stone-900 dark:text-stone-100 text-sm">
-						Work vs personal classification
-					</div>
-					<p className="text-stone-600 dark:text-stone-400">
-						Each session is labelled <code>work</code>,{" "}
-						<code>personal</code>, or <code>unknown</code> based on two
-						high-confidence signals — never on keystroke timing or
-						hours-of-day.
-					</p>
-					<ol className="list-decimal pl-4 space-y-1.5 text-stone-600 dark:text-stone-400">
-						<li>
-							<strong>Repo origin.</strong> The session&rsquo;s git
-							remote is matched against{" "}
-							<code>OPENLIT_CODING_REPO_ALLOWLIST</code> (a
-							comma-separated list of substring patterns).
-						</li>
-						<li>
-							<strong>API-key allowlist.</strong> The OpenLit org can
-							register which API keys are work identities. v1 ships
-							without that surface, so currently the repo signal
-							carries the call.
-						</li>
-					</ol>
-					<div className="rounded border border-stone-200 dark:border-stone-800 p-2 space-y-1.5">
-						<div className="font-medium text-stone-900 dark:text-stone-100">
-							Decision rules (in order)
-						</div>
-						<ul className="text-stone-600 dark:text-stone-400 space-y-1">
-							<li>
-								<span className="text-emerald-600 dark:text-emerald-400">
-									work
-								</span>{" "}
-								— repo on allowlist (with or without API-key signal).
-							</li>
-							<li>
-								<span className="text-amber-600 dark:text-amber-400">
-									personal
-								</span>{" "}
-								— allowlist exists and repo is not on it; or
-								API-key is positively not on the org allowlist while
-								the repo is.
-							</li>
-							<li>
-								<span className="text-stone-500 dark:text-stone-400">
-									unknown
-								</span>{" "}
-								— no allowlist configured, or signals conflict (e.g.
-								work API-key on a non-allowlisted repo). Surfaces in
-								the dispute UI.
-							</li>
-						</ul>
-					</div>
-					<p className="text-stone-500 dark:text-stone-500 text-[11px]">
-						Disagree with a classification? File a dispute via the
-						platform API — surfacing it from the Sessions tab is
-						planned for the next release. Disputes survive future
-						re-classifications.
-					</p>
-				</div>
-			</PopoverContent>
-		</Popover>
 	);
 }

--- a/src/client/src/components/(playground)/feature-page-header.tsx
+++ b/src/client/src/components/(playground)/feature-page-header.tsx
@@ -6,6 +6,8 @@ type FeaturePageHeaderProps = {
 	description?: string;
 	icon: ReactNode;
 	tone?: string;
+	/** Left-side control (typically an icon-only back button on detail pages). */
+	leading?: ReactNode;
 	actions?: ReactNode;
 };
 
@@ -15,6 +17,7 @@ export default function FeaturePageHeader({
 	description,
 	icon,
 	tone = "border-stone-200 bg-stone-50 text-stone-700 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-200",
+	leading,
 	actions,
 }: FeaturePageHeaderProps) {
 	return (
@@ -22,14 +25,15 @@ export default function FeaturePageHeader({
 			<div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
 				<div className="min-w-0">
 					<div className="flex items-center gap-2">
-						<span className={`rounded-md border p-1.5 ${tone}`}>
+						{leading ? <div className="shrink-0">{leading}</div> : null}
+						<span className={`inline-flex shrink-0 items-center justify-center rounded-md border p-2 ${tone}`}>
 							{icon}
 						</span>
-						<div>
+						<div className="min-w-0">
 							<p className="text-[11px] uppercase tracking-wide text-stone-500 dark:text-stone-400">
 								{eyebrow}
 							</p>
-							<h1 className="text-sm font-semibold leading-tight text-stone-950 dark:text-stone-50">
+							<h1 className="truncate text-sm font-semibold leading-tight text-stone-950 dark:text-stone-50">
 								{title}
 							</h1>
 							{description ? (

--- a/src/client/src/components/(playground)/organisation/project-page-header.tsx
+++ b/src/client/src/components/(playground)/organisation/project-page-header.tsx
@@ -7,7 +7,44 @@ import { Button } from "@/components/ui/button";
 import FeaturePageHeader from "@/components/(playground)/feature-page-header";
 import getMessage from "@/constants/messages";
 
-export default function ProjectPageHeader({ project }: { project?: { name?: string; isCurrent?: boolean; isDefault?: boolean } }) {
+export default function ProjectPageHeader({
+	project,
+}: {
+	project?: { name?: string; isCurrent?: boolean; isDefault?: boolean };
+}) {
 	const messages = getMessage();
-	return <FeaturePageHeader eyebrow={messages.ORGANISATION} title={project?.name || messages.LOADING_PROJECT} icon={<FolderKanban className="h-4 w-4" />} tone="border-primary/20 bg-primary/10 text-primary dark:border-primary/30" actions={<div className="flex flex-wrap items-center gap-2"><Button asChild variant="outline" size="sm" className="h-8"><Link href="/organisation"><ArrowLeft className="mr-1.5 h-3.5 w-3.5" />{messages.BACK_TO_ORGANISATION}</Link></Button>{project?.isCurrent ? <Badge className="h-6">{messages.CURRENT}</Badge> : null}{project?.isDefault ? <Badge variant="outline" className="h-6">{messages.DEFAULT_PROJECT}</Badge> : null}</div>} />;
+	const backLabel = messages.BACK_TO_ORGANISATION;
+
+	return (
+		<FeaturePageHeader
+			eyebrow={messages.ORGANISATION}
+			title={project?.name || messages.LOADING_PROJECT}
+			icon={<FolderKanban className="h-4 w-4" />}
+			tone="border-primary/20 bg-primary/10 text-primary dark:border-primary/30"
+			leading={
+				<Button
+					asChild
+					variant="outline"
+					size="sm"
+					className="h-8 w-8 shrink-0 p-0"
+				>
+					<Link href="/organisation" title={backLabel} aria-label={backLabel}>
+						<ArrowLeft className="h-3.5 w-3.5" />
+					</Link>
+				</Button>
+			}
+			actions={
+				<div className="flex flex-wrap items-center gap-2">
+					{project?.isCurrent ? (
+						<Badge className="h-6">{messages.CURRENT}</Badge>
+					) : null}
+					{project?.isDefault ? (
+						<Badge variant="outline" className="h-6">
+							{messages.DEFAULT_PROJECT}
+						</Badge>
+					) : null}
+				</div>
+			}
+		/>
+	);
 }

--- a/src/client/src/components/(playground)/prompt-hub/header.tsx
+++ b/src/client/src/components/(playground)/prompt-hub/header.tsx
@@ -7,18 +7,22 @@ import PromptUsage from "./usage";
 import Link from "next/link";
 import FeaturePageHeader from "@/components/(playground)/feature-page-header";
 import { Component } from "lucide-react";
+import type { ReactNode } from "react";
 
 export default function PromptHubHeader({
 	title,
 	createNew,
 	className = "flex w-full items-center justify-end gap-3",
 	extraButtons,
+	leading,
 	promptUsage = true,
 }: {
 	title?: string;
 	createNew?: boolean;
 	className?: string;
 	extraButtons?: JSX.Element;
+	/** Left-side control (icon-only back on detail pages). */
+	leading?: ReactNode;
 	promptUsage?: boolean;
 }) {
 	const m = getMessage();
@@ -40,5 +44,14 @@ export default function PromptHubHeader({
 		</div>
 	);
 
-	return <FeaturePageHeader eyebrow="Resources" title={pageHeaderTitle} icon={<Component className="h-4 w-4" />} tone="border-pink-200 bg-pink-50 text-pink-700 dark:border-pink-900/70 dark:bg-pink-950/40 dark:text-pink-300" actions={actions} />;
+	return (
+		<FeaturePageHeader
+			eyebrow="Resources"
+			title={pageHeaderTitle}
+			icon={<Component className="h-4 w-4" />}
+			tone="border-pink-200 bg-pink-50 text-pink-700 dark:border-pink-900/70 dark:bg-pink-950/40 dark:text-pink-300"
+			leading={leading}
+			actions={actions}
+		/>
+	);
 }

--- a/src/client/src/constants/messages/en.ts
+++ b/src/client/src/constants/messages/en.ts
@@ -490,6 +490,7 @@ export const FEATURE_OPENGROUND = "Openground";
 export const FEATURE_PROMPTS = "Prompt Hub";
 export const FEATURE_VAULT = "Vault";
 export const FEATURE_FLEET_HUB = "Fleet Hub";
+export const FLEET_HUB_BACK_TO_LIST = "Back to Fleet Hub";
 export const FEATURE_AGENTS = "Agents";
 
 // Agents

--- a/src/client/src/helpers/server/cron.ts
+++ b/src/client/src/helpers/server/cron.ts
@@ -52,7 +52,19 @@ export default class Cron {
 			(line) => !line.includes(`CRON_ID=${job.cronId}`)
 		);
 
-		const envVars = Object.entries(job.cronEnvVars)
+		// Cron runs with a minimal environment and does NOT inherit the
+		// container's env vars, so the API auth secret has to be written into
+		// the crontab entry itself. We inject CRON_JOB_SECRET centrally here
+		// (rather than in every cron config) so the materialize / evaluation /
+		// pricing scripts can send it on the X-CRON-JOB header and clear the
+		// middleware's cron-auth check. When it isn't set we omit it and the
+		// scripts fall back to the literal "true" (see check-auth.ts).
+		const cronEnvVars: Record<string, string> = { ...job.cronEnvVars };
+		if (process.env.CRON_JOB_SECRET) {
+			cronEnvVars.CRON_JOB_SECRET = process.env.CRON_JOB_SECRET;
+		}
+
+		const envVars = Object.entries(cronEnvVars)
 			.map(([key, value]) => `${key}=${value}`)
 			.join(" ");
 

--- a/src/client/src/middleware.ts
+++ b/src/client/src/middleware.ts
@@ -2,7 +2,6 @@ import { chain } from "@/middleware/chain";
 import checkAuth from "@/middleware/check-auth";
 import checkCsrf from "@/middleware/check-csrf";
 import checkDemoAccount from "@/middleware/check-demo-account";
-import { ENTERPRISE_MIDDLEWARE_MATCHERS } from "@/middleware/enterprise-matchers";
 
 export const middleware = chain([
 	checkCsrf,
@@ -11,6 +10,16 @@ export const middleware = chain([
 	checkAuth,
 ]);
 
+// IMPORTANT: `config.matcher` MUST be a compile-time constant. Next.js
+// statically analyzes this array at build time and silently falls back to a
+// match-everything matcher (`^/.*$`) if it can't — which makes the whole
+// middleware stack (CSRF, auth, rate-limit) run on every request, including
+// static assets under /images and /static (those then 500 on the static-asset
+// short-circuit) and public files like /robots.txt (those redirect to /login).
+// Do NOT spread an imported binding (e.g. a shared/enterprise matcher array)
+// in here — that is exactly what breaks the static analysis. The enterprise
+// build extends the matched routes by overriding this filesystem-routed file
+// with its own static literal, not by injecting values at runtime.
 export const config = {
 	matcher: [
 		"/api/:path*",
@@ -20,7 +29,6 @@ export const config = {
 		"/dashboard",
 		"/telemetry",
 		"/telemetry/:path*",
-		...ENTERPRISE_MIDDLEWARE_MATCHERS,
 		"/observability",
 		"/observability/:path*",
 		"/requests",

--- a/src/client/src/middleware/check-auth.ts
+++ b/src/client/src/middleware/check-auth.ts
@@ -17,11 +17,18 @@ import {
 } from "@/constants/route";
 
 function isValidCronJobRequest(request: NextRequest) {
-	const expectedToken = process.env.CRON_JOB_SECRET;
+	// Self-hosted / dev installs run the cron in the same container and do
+	// not set CRON_JOB_SECRET. Fall back to the literal "true" the cron
+	// scripts send so the materialize / evaluation / pricing crons work out
+	// of the box (this matches the documented `-H 'X-CRON-JOB: true'` call).
+	// When an operator DOES set CRON_JOB_SECRET, both this check and the cron
+	// scripts use it, so the endpoints require the secret and can't be
+	// triggered without it.
+	const expectedToken = process.env.CRON_JOB_SECRET || "true";
 	const cronJobToken =
 		request.headers.get("X-CRON-JOB") ?? request.headers.get("x-cron-job");
 
-	return Boolean(expectedToken && cronJobToken === expectedToken);
+	return cronJobToken === expectedToken;
 }
 
 const rateLimitWindows = new Map<string, { count: number; resetAt: number }>();
@@ -88,7 +95,15 @@ export default function checkAuth(next: NextMiddleware) {
 				pathname.startsWith("/static") ||
 				pathname.startsWith("/images")
 			) {
-				return next(request, _next);
+				// Static assets: skip all auth logic and let the request
+				// continue to the underlying resource. We must return a
+				// pass-through response directly here — this middleware is the
+				// chain terminus, so its `next` is `NextResponse.next` itself,
+				// and calling it as `next(request, event)` uses the request as
+				// the response init and throws ("middleware accepts an async
+				// API directly"), which surfaces as a 500 on every /images/*
+				// (and /static) request.
+				return NextResponse.next();
 			}
 
 			try {

--- a/src/client/src/middleware/enterprise-matchers.ts
+++ b/src/client/src/middleware/enterprise-matchers.ts
@@ -1,1 +1,14 @@
+/**
+ * Neutral, OSS-safe placeholder for enterprise-only middleware matcher
+ * routes. Empty in CE.
+ *
+ * WARNING: Do NOT spread this into `config.matcher` in `src/middleware.ts`.
+ * Next.js statically analyzes the matcher at build time and cannot resolve a
+ * spread of an imported binding, so it silently falls back to a
+ * match-everything matcher (`^/.*$`). That makes the entire middleware stack
+ * run on every request (static assets 500, public files redirect to /login).
+ * Because Next requires a compile-time-constant matcher, the enterprise build
+ * extends matched routes by overriding the filesystem-routed `src/middleware.ts`
+ * with its own static literal — not by injecting values through this array.
+ */
 export const ENTERPRISE_MIDDLEWARE_MATCHERS: string[] = [];


### PR DESCRIPTION
> [!IMPORTANT]  
> 1. We strictly follow a issue-first approach, please first open an [issue](https://github.com/openlit/openlit/issues) relating to this Pull Request.
> 2. PR name follows conventional commit format: `feat: ...` or `fix: ....`

**Issue number**:

### Change description:
<!-- What does this PR do? -->

### Checklist

If your change doesn't seem to apply, please leave them unchecked.
* [ ] PR name follows conventional commit format: `feat: ...` or `fix: ....`
* [ ] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Align agents-related detail pages and middleware behavior with the hub chrome while hardening cron auth and static asset handling.

New Features:
- Introduce shared AgentPillTab component and header tone so agents hub and agent detail views share consistent pill-tab navigation.
- Expose icon-only back controls on feature headers (agents, fleet hub, projects, rule engine, prompt hub) via a new leading slot for improved navigation.

Bug Fixes:
- Fix agents detail page layout and tabs by moving tab pills into the header, correcting content padding, and ensuring coding agents render correctly.
- Prevent middleware from running on static assets and public files by using a literal matcher list and directly returning NextResponse.next for asset routes.
- Ensure cron evaluation/materialize/pricing endpoints accept the documented X-CRON-JOB header both with and without a configured CRON_JOB_SECRET, and read case-insensitive header names.
- Correct Coding Agents empty-state documentation link to the updated onboarding URL.

Enhancements:
- Refresh agents hub, fleet hub, and detail page headers to use consistent feature titles, icons, and soft sky tones.
- Simplify coding dashboard header UI and remove the classification help popover in favor of a leaner layout.
- Refine fleet hub agent summary cards for better truncation, spacing, and health status display.
- Update project page header and prompt hub header to use icon-only back buttons and separate status badges/actions from navigation.

Build:
- Inject CRON_JOB_SECRET into generated crontab entries for client cron jobs when configured, keeping self-hosted defaults working without extra env setup.

Tests:
- Extend middleware and auth tests to cover agents route matching, absence of catch-all matchers, cron header behavior, and static asset pass-through.
- Update project page header tests to assert presence of the left-side back control in the feature header.