### PR TITLE
fix: add CE-safe RBAC/audit/route-access seams and restore gutted route bodies

### DIFF
--- a/src/client/src/__tests__/clickhouse/migrations/encrypt-vault-values-migration.test.ts
+++ b/src/client/src/__tests__/clickhouse/migrations/encrypt-vault-values-migration.test.ts
@@ -12,7 +12,7 @@ jest.mock("@/utils/crypto", () => ({
 }));
 
 jest.mock("@/lib/db-config", () => ({
-	getDBConfigById: jest.fn(),
+	getDBConfigByIdInternal: jest.fn(),
 	getDBConfigByUser: jest.fn(),
 }));
 

--- a/src/client/src/__tests__/lib/access/route-access.test.ts
+++ b/src/client/src/__tests__/lib/access/route-access.test.ts
@@ -1,6 +1,17 @@
+const mockWithDbConfigAccess = jest.fn((handler: any) => handler);
+
+jest.mock("@/lib/rbac/route", () => ({
+	withDbConfigAccess: (...args: Parameters<typeof mockWithDbConfigAccess>) =>
+		mockWithDbConfigAccess(...args),
+}));
+
 import { requireRouteAccess, withRouteAccess } from "@/lib/access/route-access";
 
 describe("CE route access fallback", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
 	it("keeps handlers unchanged and has no enterprise access decision", async () => {
 		const handler = jest.fn().mockResolvedValue({ status: 204 });
 		const wrapped = withRouteAccess("prompt.create", handler);
@@ -8,6 +19,15 @@ describe("CE route access fallback", () => {
 		await wrapped({} as Request, {});
 
 		expect(handler).toHaveBeenCalledTimes(1);
+		expect(mockWithDbConfigAccess).not.toHaveBeenCalled();
 		await expect(requireRouteAccess("prompt.create")).resolves.toBeNull();
+	});
+
+	it("wraps handlers with DB config access when requested", () => {
+		const handler = jest.fn();
+
+		withRouteAccess("vault.read", handler, { requireDbConfig: true });
+
+		expect(mockWithDbConfigAccess).toHaveBeenCalledWith(handler);
 	});
 });

--- a/src/client/src/__tests__/lib/db-config.test.ts
+++ b/src/client/src/__tests__/lib/db-config.test.ts
@@ -67,6 +67,8 @@ jest.mock('@/utils/log', () => ({
 import {
   getDBConfigByUser,
   getDBConfigById,
+  getDBConfigByIdInternal,
+  getDBConfigByIdForUser,
   upsertDBConfig,
   deleteDBConfig,
   setCurrentDBConfig,
@@ -168,16 +170,68 @@ describe('getDBConfigByUser', () => {
 });
 
 describe('getDBConfigById', () => {
-  it('returns the db config by id', async () => {
-    (prisma.databaseConfig.findUnique as jest.Mock).mockResolvedValue(mockDbConfig);
+  it('throws when user is not authenticated', async () => {
+    (getCurrentUser as jest.Mock).mockResolvedValue(null);
+    await expect(getDBConfigById({ id: 'db1' })).rejects.toThrow('Unauthorized');
+  });
+
+  it('returns the db config only when the current user has project-scoped access', async () => {
+    (prisma.databaseConfigUser.findFirst as jest.Mock).mockResolvedValue({
+      databaseConfig: mockDbConfig,
+    });
     const result = await getDBConfigById({ id: 'db1' });
+    expect(result).toEqual(mockDbConfig);
+    expect(prisma.databaseConfigUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'u1',
+          databaseConfigId: 'db1',
+          databaseConfig: { projectId: 'project1' },
+        }),
+      })
+    );
+  });
+
+  it('returns null when the user cannot access the config', async () => {
+    const result = await getDBConfigById({ id: 'nonexistent' });
+    expect(result).toBeNull();
+  });
+});
+
+describe('getDBConfigByIdInternal', () => {
+  it('returns the db config by id without user scoping for trusted internal callers', async () => {
+    (prisma.databaseConfig.findUnique as jest.Mock).mockResolvedValue(mockDbConfig);
+    const result = await getDBConfigByIdInternal({ id: 'db1' });
     expect(result).toEqual(mockDbConfig);
     expect(prisma.databaseConfig.findUnique).toHaveBeenCalledWith({ where: { id: 'db1' } });
   });
+});
 
-  it('returns null when not found', async () => {
-    const result = await getDBConfigById({ id: 'nonexistent' });
+describe('getDBConfigByIdForUser', () => {
+  it('returns null when the current organisation has no accessible project', async () => {
+    (getCurrentProjectForOrganisation as jest.Mock).mockResolvedValue(null);
+    const result = await getDBConfigByIdForUser({ id: 'db1', userId: 'u1' });
     expect(result).toBeNull();
+    expect(prisma.databaseConfigUser.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('filters explicit db config access by user and current project', async () => {
+    (prisma.databaseConfigUser.findFirst as jest.Mock).mockResolvedValue({
+      databaseConfig: mockDbConfig,
+    });
+
+    const result = await getDBConfigByIdForUser({ id: 'db1', userId: 'u1' });
+
+    expect(result).toEqual(mockDbConfig);
+    expect(prisma.databaseConfigUser.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          userId: 'u1',
+          databaseConfigId: 'db1',
+          databaseConfig: { projectId: 'project1' },
+        }),
+      })
+    );
   });
 });
 

--- a/src/client/src/__tests__/lib/platform/common.test.ts
+++ b/src/client/src/__tests__/lib/platform/common.test.ts
@@ -1,6 +1,10 @@
 jest.mock('@/lib/db-config', () => ({
   getDBConfigByUser: jest.fn(),
-  getDBConfigById: jest.fn(),
+  getDBConfigByIdInternal: jest.fn(),
+  getDBConfigByIdForUser: jest.fn(),
+}));
+jest.mock('@/lib/session', () => ({
+  getCurrentUser: jest.fn(),
 }));
 jest.mock('@/lib/platform/clickhouse/clickhouse-client', () => ({
   __esModule: true,
@@ -11,6 +15,7 @@ jest.mock('@/utils/asaw', () => jest.fn());
 import { dataCollector } from '@/lib/platform/common';
 import createClickhousePool from '@/lib/platform/clickhouse/clickhouse-client';
 import asaw from '@/utils/asaw';
+import { getCurrentUser } from '@/lib/session';
 
 const mockDbConfig = { id: 'db-1', host: 'localhost', port: '8123' };
 
@@ -37,10 +42,23 @@ describe('dataCollector', () => {
       expect(result.data).toEqual([]);
     });
 
-    it('uses getDBConfigById when dbConfigId is provided', async () => {
-      (asaw as jest.Mock).mockResolvedValue(['DB config error', null]);
+    it('uses internal DB config lookup when dbConfigId is provided without a session', async () => {
+      (asaw as jest.Mock)
+        .mockResolvedValueOnce([new Error('No session'), null])
+        .mockResolvedValueOnce(['DB config error', null]);
       const result = await dataCollector({ query: 'SELECT 1' }, 'query', 'db-config-id');
       expect(result.err).toBe('DB config error');
+    });
+
+    it('checks user scoped db config access when dbConfigId is provided with a session', async () => {
+      (asaw as jest.Mock)
+        .mockResolvedValueOnce([null, { id: 'user-1' }])
+        .mockResolvedValueOnce(['DB config denied', null]);
+
+      const result = await dataCollector({ query: 'SELECT 1' }, 'query', 'db-config-id');
+
+      expect(result.err).toBe('DB config denied');
+      expect(getCurrentUser).toHaveBeenCalled();
     });
   });
 

--- a/src/client/src/__tests__/lib/platform/evaluation/evaluation.test.ts
+++ b/src/client/src/__tests__/lib/platform/evaluation/evaluation.test.ts
@@ -45,7 +45,7 @@ jest.mock('@/lib/platform/cron-log', () => ({
   insertCronLog: jest.fn(),
 }));
 jest.mock('@/lib/db-config', () => ({
-  getDBConfigById: jest.fn(),
+  getDBConfigByIdInternal: jest.fn(),
 }));
 jest.mock('@/lib/platform/request', () => ({
   getRequestViaSpanId: jest.fn(),
@@ -80,7 +80,6 @@ import { dataCollector } from '@/lib/platform/common';
 import { getCurrentUser } from '@/lib/session';
 import { getEvaluationConfig, getEvaluationConfigById } from '@/lib/platform/evaluation/config';
 import { getLastRunCronLogByCronId, getLastFailureCronLogBySpanId, insertCronLog } from '@/lib/platform/cron-log';
-import { getDBConfigById } from '@/lib/db-config';
 import { getRequestViaSpanId } from '@/lib/platform/request';
 import asaw from '@/utils/asaw';
 import { runEvaluation } from '@/lib/platform/evaluation/run-evaluation';

--- a/src/client/src/__tests__/lib/platform/pricing/pricing.test.ts
+++ b/src/client/src/__tests__/lib/platform/pricing/pricing.test.ts
@@ -63,7 +63,7 @@ jest.mock('@/lib/platform/cron-log', () => ({
   insertCronLog: jest.fn().mockResolvedValue({ err: null }),
 }));
 jest.mock('@/lib/db-config', () => ({
-  getDBConfigById: jest.fn(),
+  getDBConfigByIdInternal: jest.fn(),
   getDBConfigByUser: jest.fn(),
 }));
 jest.mock('date-fns', () => ({
@@ -85,7 +85,6 @@ import { dataCollector } from '@/lib/platform/common';
 import { getRequestViaSpanId } from '@/lib/platform/request';
 import { ProviderRegistry } from '@/lib/platform/providers/provider-registry';
 import { getPricingConfigById } from '@/lib/platform/pricing/config';
-import { getDBConfigById } from '@/lib/db-config';
 import { insertCronLog } from '@/lib/platform/cron-log';
 import getMessage from '@/constants/messages';
 import { throwIfError } from '@/utils/error';

--- a/src/client/src/app/(playground)/context/page.tsx
+++ b/src/client/src/app/(playground)/context/page.tsx
@@ -133,7 +133,7 @@ export default function ContextPage() {
 	return (
 		<div className="flex flex-col w-full h-full">
 			<ContextHeader />
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={data || []}

--- a/src/client/src/app/(playground)/fleet-hub/list.tsx
+++ b/src/client/src/app/(playground)/fleet-hub/list.tsx
@@ -141,7 +141,7 @@ export default function List({ agents, isLoading, isFetched }: {
 	return (
 		<div className="flex flex-col w-full h-full">
 			<FeaturePageHeader eyebrow={getMessage().FEATURE_FLEET_HUB} title={getMessage().FEATURE_FLEET_HUB} icon={<OpenTelemetrySvg className="h-5 w-5" />} tone="border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/70 dark:bg-sky-950/40 dark:text-sky-300" actions={<VisibilityColumns columns={columns} pageName={"fleethub"} />} />
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={agents}

--- a/src/client/src/app/(playground)/openground/page.tsx
+++ b/src/client/src/app/(playground)/openground/page.tsx
@@ -193,7 +193,7 @@ export default function Openground() {
 		<div className="flex flex-col w-full h-full">
 			<OpengroundHeader validateResponse={false} />
 
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={data || []}

--- a/src/client/src/app/(playground)/prompt-hub/page.tsx
+++ b/src/client/src/app/(playground)/prompt-hub/page.tsx
@@ -147,7 +147,7 @@ export default function PromptHub() {
 	return (
 		<div className="flex flex-col w-full h-full">
 			<PromptHubHeader createNew />
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={data || []}

--- a/src/client/src/app/(playground)/rule-engine/page.tsx
+++ b/src/client/src/app/(playground)/rule-engine/page.tsx
@@ -145,7 +145,7 @@ export default function RuleEnginePage() {
 	return (
 		<div className="flex flex-col w-full h-full">
 			<RuleEngineHeader successCallback={fetchData} />
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={data || []}

--- a/src/client/src/app/(playground)/vault/page.tsx
+++ b/src/client/src/app/(playground)/vault/page.tsx
@@ -119,7 +119,7 @@ export default function Vault() {
 	return (
 		<div className="flex flex-col w-full h-full">
 			<VaultHeader successCallback={fetchData} />
-			<div className="flex flex-col w-full h-full p-4">
+			<div className="flex flex-col w-full h-full p-4 overflow-hidden">
 				<DataTable
 					columns={columns}
 					data={data || []}

--- a/src/client/src/app/api/alerts/condition-values/route.ts
+++ b/src/client/src/app/api/alerts/condition-values/route.ts
@@ -1,0 +1,1 @@
+export { GET } from "@/lib/rbac/routes/api/alerts/condition-values/route";

--- a/src/client/src/app/api/api-key/[id]/route.ts
+++ b/src/client/src/app/api/api-key/[id]/route.ts
@@ -1,6 +1,15 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { deleteAPIKey } from "@/lib/platform/api-keys/index";
+import asaw from "@/utils/asaw";
+import { errorResponse } from "@/utils/api-response";
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("api_key:delete")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const { id } = context.params;
 	const [err, res] = await deleteAPIKey(id);
 	if (err) {
@@ -11,3 +20,5 @@ export async function DELETE(_: Request, context: any) {
 
 	return Response.json(res);
 }
+
+export const DELETE = withAudit(DELETEHandler);

--- a/src/client/src/app/api/api-key/route.ts
+++ b/src/client/src/app/api/api-key/route.ts
@@ -1,12 +1,25 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { generateAPIKey, getAllAPIKeys } from "@/lib/platform/api-keys";
 import asaw from "@/utils/asaw";
+import { errorResponse } from "@/utils/api-response";
 
 export async function GET() {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("api_key:read")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const res: any = await getAllAPIKeys();
 	return Response.json(res);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("api_key:create")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const formData = await request.json();
 	const name = formData.name;
 
@@ -20,3 +33,5 @@ export async function POST(request: Request) {
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(POSTHandler);

--- a/src/client/src/app/api/chat/improvement/[spanId]/route.ts
+++ b/src/client/src/app/api/chat/improvement/[spanId]/route.ts
@@ -4,6 +4,10 @@ import {
 	getTraceImprovement,
 	streamTraceImprovementAnalysis,
 } from "@/lib/platform/chat/improvement";
+import {
+	withOtterDbChatAccess,
+	withOtterDbReadAccess,
+} from "@/lib/chat/access";
 import { getCurrentUser } from "@/lib/session";
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
@@ -26,7 +30,7 @@ function getScope(request: Request) {
 	return scope === "span" ? "span" : "trace";
 }
 
-export async function GET(request: Request, context: any) {
+async function getHandler(request: Request, context: any) {
 	const user = await getCurrentUser();
 	if (!user) {
 		logRoute("get_unauthorized", {});
@@ -57,7 +61,7 @@ export async function GET(request: Request, context: any) {
 	return Response.json({ data: data || null });
 }
 
-export async function POST(request: Request, context: any) {
+async function postHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const user = await getCurrentUser();
 	if (!user) {
@@ -118,3 +122,6 @@ export async function POST(request: Request, context: any) {
 
 	return response;
 }
+
+export const GET = withOtterDbReadAccess(getHandler);
+export const POST = withOtterDbChatAccess(postHandler);

--- a/src/client/src/app/api/coding-agents/classification/dispute/route.ts
+++ b/src/client/src/app/api/coding-agents/classification/dispute/route.ts
@@ -15,6 +15,7 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import {
 	DisputeError,
 	submitClassificationDispute,
@@ -27,7 +28,7 @@ import {
 
 export const dynamic = "force-dynamic";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	let auth;
 	try {
 		auth = await requireCodingAgentAuth();
@@ -82,3 +83,5 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Internal error" }, { status: 500 });
 	}
 }
+
+export const POST = withCurrentOrganisationPermission("coding_agents:dispute", POSTHandler);

--- a/src/client/src/app/api/coding-agents/sessions/[sessionId]/digest/route.ts
+++ b/src/client/src/app/api/coding-agents/sessions/[sessionId]/digest/route.ts
@@ -23,11 +23,12 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getCodingSessionDigest } from "@/lib/platform/coding-agents/queries";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(
+async function GETHandler(
 	_request: Request,
 	context: { params: { sessionId: string } },
 ) {
@@ -57,3 +58,5 @@ export async function GET(
 		return Response.json({ error: "Internal error" }, { status: 500 });
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("coding_agents:read", GETHandler);

--- a/src/client/src/app/api/coding-agents/sessions/route.ts
+++ b/src/client/src/app/api/coding-agents/sessions/route.ts
@@ -23,6 +23,7 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { isCodingAgentClassification } from "@/lib/platform/coding-agents/classifier";
 
 export const dynamic = "force-dynamic";
@@ -81,7 +82,7 @@ function defaultSince(): Date {
 	return new Date(Date.now() - DEFAULT_WINDOW_HOURS * 60 * 60 * 1000);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	let auth;
 	try {
 		auth = await requireCodingAgentAuth();
@@ -136,3 +137,5 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Internal error" }, { status: 500 });
 	}
 }
+
+export const POST = withCurrentOrganisationPermission("coding_agents:read", POSTHandler);

--- a/src/client/src/app/api/coding-agents/sessions/summary/route.ts
+++ b/src/client/src/app/api/coding-agents/sessions/summary/route.ts
@@ -14,6 +14,7 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { dataCollector } from "@/lib/platform/common";
 import {
 	CODING_AGENT_ATTR,
@@ -55,7 +56,7 @@ function pickBucket(start: Date | null, end: Date | null) {
 	return { bucket: "month", label: "%Y/%m" };
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	try {
 		await requireCodingAgentAuth();
 	} catch (err) {
@@ -148,3 +149,5 @@ export async function POST(request: Request) {
 
 	return Response.json({ bucket, buckets, total, peak });
 }
+
+export const POST = withCurrentOrganisationPermission("coding_agents:read", POSTHandler);

--- a/src/client/src/app/api/coding-agents/users/[userId]/route.ts
+++ b/src/client/src/app/api/coding-agents/users/[userId]/route.ts
@@ -13,11 +13,12 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getCodingUserDigest } from "@/lib/platform/coding-agents/queries";
 
 export const dynamic = "force-dynamic";
 
-export async function GET(
+async function GETHandler(
 	request: Request,
 	context: { params: { userId: string } }
 ) {
@@ -78,3 +79,5 @@ export async function GET(
 		return Response.json({ error: "Internal error" }, { status: 500 });
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("coding_agents:read", GETHandler);

--- a/src/client/src/app/api/coding-agents/users/route.ts
+++ b/src/client/src/app/api/coding-agents/users/route.ts
@@ -15,6 +15,7 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import {
 	listCodingUsers,
 	type CodingUsersSortBy,
@@ -63,7 +64,7 @@ function defaultSince(): Date {
 	return new Date(Date.now() - DEFAULT_WINDOW_HOURS * 60 * 60 * 1000);
 }
 
-export async function GET(request: Request) {
+async function GETHandler(request: Request) {
 	let auth;
 	try {
 		auth = await requireCodingAgentAuth();
@@ -107,7 +108,7 @@ interface UsersListBody {
 	runFilters?: Record<string, unknown>;
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	let auth;
 	try {
 		auth = await requireCodingAgentAuth();
@@ -157,3 +158,6 @@ export async function POST(request: Request) {
 		return Response.json({ error: "Internal error" }, { status: 500 });
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("coding_agents:read", GETHandler);
+export const POST = withCurrentOrganisationPermission("coding_agents:read", POSTHandler);

--- a/src/client/src/app/api/coding-agents/users/summary/route.ts
+++ b/src/client/src/app/api/coding-agents/users/summary/route.ts
@@ -14,6 +14,7 @@ import {
 	requireCodingAgentAuth,
 	CodingAgentUnauthorizedError,
 } from "@/lib/platform/coding-agents/auth";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { dataCollector } from "@/lib/platform/common";
 import {
 	CODING_AGENT_ATTR,
@@ -67,7 +68,7 @@ const USER_EXPR = `
 	)
 `;
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	try {
 		await requireCodingAgentAuth();
 	} catch (err) {
@@ -143,3 +144,5 @@ export async function POST(request: Request) {
 
 	return Response.json({ bucket, buckets, total, peak });
 }
+
+export const POST = withCurrentOrganisationPermission("coding_agents:read", POSTHandler);

--- a/src/client/src/app/api/context/[id]/route.ts
+++ b/src/client/src/app/api/context/[id]/route.ts
@@ -1,10 +1,12 @@
+import { withAudit } from "@/lib/audit/route";
 import { SERVER_EVENTS } from "@/constants/events";
 import { ContextInput } from "@/types/context";
 import { getContextById, updateContext, deleteContext } from "@/lib/platform/context";
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
+import { withRouteAccess } from "@/lib/access/route-access";
 
-export async function GET(_: Request, context: any) {
+async function GETHandler(_: Request, context: any) {
 	const { id } = context.params;
 	const { err, data }: any = await getContextById(id);
 	if (err) {
@@ -14,7 +16,7 @@ export async function GET(_: Request, context: any) {
 	return Response.json(data);
 }
 
-export async function PUT(request: Request, context: any) {
+async function PUTHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const formData = await request.json();
@@ -44,7 +46,7 @@ export async function PUT(request: Request, context: any) {
 	return Response.json(res);
 }
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const [err, res] = await deleteContext(id);
@@ -62,3 +64,7 @@ export async function DELETE(_: Request, context: any) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withRouteAccess("context.read", GETHandler);
+export const PUT = withAudit(withRouteAccess("context.update", PUTHandler));
+export const DELETE = withAudit(withRouteAccess("context.delete", DELETEHandler));

--- a/src/client/src/app/api/context/route.ts
+++ b/src/client/src/app/api/context/route.ts
@@ -1,10 +1,12 @@
+import { withAudit } from "@/lib/audit/route";
 import { SERVER_EVENTS } from "@/constants/events";
 import { ContextInput } from "@/types/context";
 import { getContexts, createContext } from "@/lib/platform/context";
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
+import { withRouteAccess } from "@/lib/access/route-access";
 
-export async function GET() {
+async function GETHandler() {
 	const { err, data }: any = await getContexts();
 	if (err) {
 		return Response.json(err, { status: 400 });
@@ -13,7 +15,7 @@ export async function GET() {
 	return Response.json(data);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 
@@ -41,3 +43,6 @@ export async function POST(request: Request) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withRouteAccess("context.read", GETHandler);
+export const POST = withAudit(withRouteAccess("context.create", POSTHandler));

--- a/src/client/src/app/api/controller/catalog/[id]/instrument/route.ts
+++ b/src/client/src/app/api/controller/catalog/[id]/instrument/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getFeatureHandler } from "@/lib/platform/controller/features";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -8,3 +10,5 @@ export async function POST(
 	const handler = getFeatureHandler("instrumentation")!;
 	return handler.applyOperation(id, "enable", {});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("controller:operate", POSTHandler));

--- a/src/client/src/app/api/controller/catalog/[id]/restart/route.ts
+++ b/src/client/src/app/api/controller/catalog/[id]/restart/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getFeatureHandler } from "@/lib/platform/controller/features";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -8,3 +10,5 @@ export async function POST(
 	const handler = getFeatureHandler("lifecycle")!;
 	return handler.applyOperation(id, "restart", {});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("controller:operate", POSTHandler));

--- a/src/client/src/app/api/controller/catalog/[id]/start/route.ts
+++ b/src/client/src/app/api/controller/catalog/[id]/start/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getFeatureHandler } from "@/lib/platform/controller/features";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -8,3 +10,5 @@ export async function POST(
 	const handler = getFeatureHandler("lifecycle")!;
 	return handler.applyOperation(id, "start", {});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("controller:operate", POSTHandler));

--- a/src/client/src/app/api/controller/catalog/[id]/stop/route.ts
+++ b/src/client/src/app/api/controller/catalog/[id]/stop/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getFeatureHandler } from "@/lib/platform/controller/features";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -8,3 +10,5 @@ export async function POST(
 	const handler = getFeatureHandler("lifecycle")!;
 	return handler.applyOperation(id, "stop", {});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("controller:operate", POSTHandler));

--- a/src/client/src/app/api/controller/catalog/[id]/uninstrument/route.ts
+++ b/src/client/src/app/api/controller/catalog/[id]/uninstrument/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getFeatureHandler } from "@/lib/platform/controller/features";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -8,3 +10,5 @@ export async function POST(
 	const handler = getFeatureHandler("instrumentation")!;
 	return handler.applyOperation(id, "disable", {});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("controller:operate", POSTHandler));

--- a/src/client/src/app/api/controller/config/route.ts
+++ b/src/client/src/app/api/controller/config/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import {
 	getControllerInstances,
 	getControllerConfig,
@@ -8,7 +10,7 @@ import {
 	ConfigValidationError,
 } from "@/lib/platform/controller/validate-config";
 
-export async function GET(request: Request) {
+async function GETHandler(request: Request) {
 	const { searchParams } = new URL(request.url);
 	const instanceId = searchParams.get("instance_id");
 
@@ -37,7 +39,7 @@ export async function GET(request: Request) {
 	}
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	try {
 		const body = await request.json();
 		const { instance_id } = body as { instance_id?: string };
@@ -87,3 +89,6 @@ export async function POST(request: Request) {
 		);
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("controller:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("controller:configure", POSTHandler));

--- a/src/client/src/app/api/db-config/[id]/route.ts
+++ b/src/client/src/app/api/db-config/[id]/route.ts
@@ -1,7 +1,15 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { deleteDBConfig } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
+import { errorResponse } from "@/utils/api-response";
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("db_config:delete")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const { id } = context.params;
 	const [err, res] = await asaw(deleteDBConfig(id));
 	if (err)
@@ -10,3 +18,5 @@ export async function DELETE(_: Request, context: any) {
 		});
 	return Response.json(res);
 }
+
+export const DELETE = withAudit(DELETEHandler);

--- a/src/client/src/app/api/db-config/current/[id]/route.ts
+++ b/src/client/src/app/api/db-config/current/[id]/route.ts
@@ -1,7 +1,15 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { setCurrentDBConfig } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
+import { errorResponse } from "@/utils/api-response";
 
-export async function POST(_: Request, context: any) {
+async function POSTHandler(_: Request, context: any) {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("db_config:select")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const { id } = context.params;
 	const [err, res] = await asaw(setCurrentDBConfig(id));
 	if (err)
@@ -10,3 +18,5 @@ export async function POST(_: Request, context: any) {
 		});
 	return Response.json(res);
 }
+
+export const POST = withAudit(POSTHandler);

--- a/src/client/src/app/api/db-config/route.ts
+++ b/src/client/src/app/api/db-config/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getDBConfigByUser, upsertDBConfig } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
 import { DatabaseConfig } from "@prisma/client";
@@ -11,6 +13,11 @@ function stripSensitiveDbFields(config: any) {
 }
 
 export async function GET() {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("db_config:read")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const [err, res]: any = await asaw(getDBConfigByUser());
 	if (err)
 		return errorResponse(err, "Failed to fetch database configurations");
@@ -22,9 +29,15 @@ export async function GET() {
 	return Response.json(sanitized);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const id = formData.id;
+	const requiredPermission = id ? "db_config:update" : "db_config:create" as const;
+
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission(requiredPermission)
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
 
 	const dbConfig: Partial<DatabaseConfig> = {
 		name: formData.name,
@@ -44,3 +57,5 @@ export async function POST(request: Request) {
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(POSTHandler);

--- a/src/client/src/app/api/db-config/share/route.ts
+++ b/src/client/src/app/api/db-config/share/route.ts
@@ -1,7 +1,15 @@
+import { withAudit } from "@/lib/audit/route";
+import { requireCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { shareDBConfig } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
+import { errorResponse } from "@/utils/api-response";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
+	const [permissionErr] = await asaw(
+		requireCurrentOrganisationPermission("db_config:share")
+	);
+	if (permissionErr) return errorResponse(permissionErr, "Forbidden", 403);
+
 	const formData = await request.json();
 	const shareArray = formData.shareArray;
 	const id = formData.id;
@@ -12,3 +20,5 @@ export async function POST(request: Request) {
 		});
 	return Response.json(res);
 }
+
+export const POST = withAudit(POSTHandler);

--- a/src/client/src/app/api/evaluation/[spanId]/feedback/route.ts
+++ b/src/client/src/app/api/evaluation/[spanId]/feedback/route.ts
@@ -1,8 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { storeManualFeedback } from "@/lib/platform/evaluation";
 import { SERVER_EVENTS } from "@/constants/events";
 import PostHogServer from "@/lib/posthog";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: { spanId: string } }
 ) {
@@ -40,3 +42,5 @@ export async function POST(
 	});
 	return Response.json({ success: true });
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("evaluation:feedback", POSTHandler));

--- a/src/client/src/app/api/evaluation/[spanId]/route.ts
+++ b/src/client/src/app/api/evaluation/[spanId]/route.ts
@@ -1,9 +1,11 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getEvaluationsForSpanId, setEvaluationsForSpanId } from "@/lib/platform/evaluation";
 import { SERVER_EVENTS } from "@/constants/events";
 import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 
-export async function GET(
+async function GETHandler(
 	_: NextRequest,
 	{ params }: { params: { spanId: string } }
 ) {
@@ -13,7 +15,7 @@ export async function GET(
 	return Response.json(res);
 }
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: { spanId: string } }
 ) {
@@ -28,3 +30,6 @@ export async function POST(
 	});
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("evaluation:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("evaluation:run", POSTHandler));

--- a/src/client/src/app/api/evaluation/auto/route.ts
+++ b/src/client/src/app/api/evaluation/auto/route.ts
@@ -1,9 +1,11 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { autoEvaluate } from "@/lib/platform/evaluation";
 import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 	const result = await autoEvaluate(formData);
@@ -15,3 +17,5 @@ export async function POST(request: NextRequest) {
 	});
 	return Response.json(result);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("evaluation:run", POSTHandler));

--- a/src/client/src/app/api/evaluation/config/route.ts
+++ b/src/client/src/app/api/evaluation/config/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import {
 	getEvaluationConfig,
 	setEvaluationConfig,
@@ -8,12 +10,12 @@ import { EvaluationConfigInput } from "@/types/evaluation";
 import { NextRequest } from "next/server";
 import asaw from "@/utils/asaw";
 
-export async function GET(_: NextRequest) {
+async function GETHandler(_: NextRequest) {
 	const res: any = await getEvaluationConfig(undefined, true, false);
 	return Response.json(res);
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 	const evaluationConfig: EvaluationConfigInput = {
@@ -46,3 +48,6 @@ export async function POST(request: NextRequest) {
 	});
 	return Response.json(data);
 }
+
+export const GET = withCurrentOrganisationPermission("evaluation:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("evaluation:configure", POSTHandler));

--- a/src/client/src/app/api/evaluation/types/[id]/route.ts
+++ b/src/client/src/app/api/evaluation/types/[id]/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getEvaluationConfig } from "@/lib/platform/evaluation/config";
 import { syncRuleEntitiesFromConfig } from "@/lib/platform/evaluation/sync-rule-entities";
 import { SERVER_EVENTS } from "@/constants/events";
@@ -32,7 +34,7 @@ function normalizeRules(rules: any[]): RuleWithPriority[] {
 		}));
 }
 
-export async function GET(
+async function GETHandler(
 	_: NextRequest,
 	{ params }: { params: { id: string } }
 ) {
@@ -55,7 +57,7 @@ export async function GET(
 	return Response.json({ data: typeConfig });
 }
 
-export async function PATCH(
+async function PATCHHandler(
 	request: NextRequest,
 	{ params }: { params: { id: string } }
 ) {
@@ -109,7 +111,7 @@ export async function PATCH(
 	return Response.json({ data: updated });
 }
 
-export async function DELETE(
+async function DELETEHandler(
 	_: NextRequest,
 	{ params }: { params: { id: string } }
 ) {
@@ -155,3 +157,7 @@ export async function DELETE(
 	});
 	return Response.json({ data: { deleted: typeId } });
 }
+
+export const GET = withCurrentOrganisationPermission("evaluation:read", GETHandler);
+export const PATCH = withAudit(withCurrentOrganisationPermission("evaluation:configure", PATCHHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("evaluation:configure", DELETEHandler));

--- a/src/client/src/app/api/evaluation/types/route.ts
+++ b/src/client/src/app/api/evaluation/types/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getEvaluationConfig } from "@/lib/platform/evaluation/config";
 import { syncRuleEntitiesFromConfig } from "@/lib/platform/evaluation/sync-rule-entities";
 import { SERVER_EVENTS } from "@/constants/events";
@@ -50,7 +52,7 @@ function normalizeTypeConfig(t: any): EvaluationTypeConfig {
 	return config;
 }
 
-export async function GET(_: NextRequest) {
+async function GETHandler(_: NextRequest) {
 	const [err, config] = await asaw(getEvaluationConfig(undefined, true, false));
 	if (err || !config?.id) {
 		return Response.json(
@@ -63,7 +65,7 @@ export async function GET(_: NextRequest) {
 	return Response.json({ data: types });
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const body = await request.json();
 	const types = body.types as any[] | undefined;
@@ -103,3 +105,6 @@ export async function POST(request: NextRequest) {
 	});
 	return Response.json({ data: normalizedTypes });
 }
+
+export const GET = withCurrentOrganisationPermission("evaluation:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("evaluation:configure", POSTHandler));

--- a/src/client/src/app/api/fleet-hub/[id]/config/route.ts
+++ b/src/client/src/app/api/fleet-hub/[id]/config/route.ts
@@ -1,8 +1,11 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { updateAgentConfig } from "@/lib/platform/fleet-hub";
+import { emitManagementAlertSignalSafe } from "@/lib/platform/alerts/signals";
 import PostHogServer from "@/lib/posthog";
 
-export async function POST(request: Request, context: any) {
+async function POSTHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const { config } = await request.json();
@@ -23,5 +26,21 @@ export async function POST(request: Request, context: any) {
 		event: SERVER_EVENTS.FLEET_HUB_CONFIG_UPDATE_SUCCESS,
 		startTimestamp,
 	});
+	emitManagementAlertSignalSafe({
+		triggerType: "fleet_hub_config_update",
+		event: "fleet_hub_config_updated",
+		message: `Fleet Hub configuration for ${id} was updated.`,
+		sourceId: id,
+		fields: {
+			agent_id: id,
+			config_key: config && typeof config === "object" ? Object.keys(config)[0] || "" : "",
+		},
+		payloadSummary: {
+			agentId: id,
+			configKeys: config && typeof config === "object" ? Object.keys(config) : [],
+		},
+	});
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("fleet_hub:configure", POSTHandler));

--- a/src/client/src/app/api/fleet-hub/[id]/route.ts
+++ b/src/client/src/app/api/fleet-hub/[id]/route.ts
@@ -1,7 +1,10 @@
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getAgentByInstanceId } from "@/lib/platform/fleet-hub";
 
-export async function GET(_: Request, context: any) {
+async function GETHandler(_: Request, context: any) {
 	const { id } = context.params;
 	const res = await getAgentByInstanceId(id);
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("fleet_hub:read", GETHandler);

--- a/src/client/src/app/api/fleet-hub/[id]/tls-connection/route.ts
+++ b/src/client/src/app/api/fleet-hub/[id]/tls-connection/route.ts
@@ -1,8 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { updateTlsConnection } from "@/lib/platform/fleet-hub";
 import PostHogServer from "@/lib/posthog";
 
-export async function POST(request: Request, context: any) {
+async function POSTHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const { tlsMin } = await request.json();
@@ -13,3 +15,5 @@ export async function POST(request: Request, context: any) {
 	});
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("fleet_hub:configure", POSTHandler));

--- a/src/client/src/app/api/fleet-hub/route.ts
+++ b/src/client/src/app/api/fleet-hub/route.ts
@@ -1,6 +1,9 @@
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getAllAgents } from "@/lib/platform/fleet-hub";
 
-export async function GET() {
+async function GETHandler() {
 	const res: any = await getAllAgents();
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("fleet_hub:read", GETHandler);

--- a/src/client/src/app/api/manage-dashboard/board/[id]/route.ts
+++ b/src/client/src/app/api/manage-dashboard/board/[id]/route.ts
@@ -1,9 +1,11 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { deleteBoard, getBoardById, setMainDashboard, updatePinnedBoard } from "@/lib/platform/manage-dashboard/board";
 import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 
-export async function DELETE(
+async function DELETEHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -16,7 +18,7 @@ export async function DELETE(
 	return Response.json(res);
 }
 
-export async function GET(
+async function GETHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -24,7 +26,7 @@ export async function GET(
 	return Response.json(res);
 }
 
-export async function PATCH(
+async function PATCHHandler(
 	request: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -54,3 +56,7 @@ export async function PATCH(
 	});
 	return Response.json({ err: "Invalid PATCH request" }, { status: 400 });
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const PATCH = withAudit(withCurrentOrganisationPermission("dashboard:update", PATCHHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("dashboard:delete", DELETEHandler));

--- a/src/client/src/app/api/manage-dashboard/board/route.ts
+++ b/src/client/src/app/api/manage-dashboard/board/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import {
 	createBoard,
@@ -8,7 +10,7 @@ import PostHogServer from "@/lib/posthog";
 import { Board } from "@/types/manage-dashboard";
 import { NextRequest } from "next/server";
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const board: Board = await request.json();
 
@@ -20,7 +22,7 @@ export async function POST(request: NextRequest) {
 	return Response.json(res);
 }
 
-export async function PUT(request: NextRequest) {
+async function PUTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const board: Board & { updateParent?: boolean } = await request.json();
 	const res = await updateBoard(board);
@@ -31,8 +33,12 @@ export async function PUT(request: NextRequest) {
 	return Response.json(res);
 }
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
 	const isHome = request.nextUrl.searchParams.get("home") === "true";
 	const res = await getBoards(isHome);
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("dashboard:create", POSTHandler));
+export const PUT = withAudit(withCurrentOrganisationPermission("dashboard:update", PUTHandler));

--- a/src/client/src/app/api/manage-dashboard/folder/[id]/route.ts
+++ b/src/client/src/app/api/manage-dashboard/folder/[id]/route.ts
@@ -1,9 +1,11 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { deleteFolder, getFolderById } from "@/lib/platform/manage-dashboard/folder";
 import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 
-export async function DELETE(
+async function DELETEHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -16,10 +18,13 @@ export async function DELETE(
 	return Response.json(res);
 }
 
-export async function GET(
+async function GETHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
 	const res = await getFolderById(id);
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const DELETE = withAudit(withCurrentOrganisationPermission("dashboard:delete", DELETEHandler));

--- a/src/client/src/app/api/manage-dashboard/folder/route.ts
+++ b/src/client/src/app/api/manage-dashboard/folder/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import {
 	createFolder,
@@ -8,7 +10,7 @@ import PostHogServer from "@/lib/posthog";
 import { Folder } from "@/types/manage-dashboard";
 import { NextRequest } from "next/server";
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const folder: Folder = await request.json();
 
@@ -20,7 +22,7 @@ export async function POST(request: NextRequest) {
 	return Response.json(res);
 }
 
-export async function PUT(request: NextRequest) {
+async function PUTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const folder: Folder = await request.json();
 
@@ -32,7 +34,11 @@ export async function PUT(request: NextRequest) {
 	return Response.json(res);
 }
 
-export async function GET() {
+async function GETHandler() {
 	const res = await getFolders();
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("dashboard:create", POSTHandler));
+export const PUT = withAudit(withCurrentOrganisationPermission("dashboard:update", PUTHandler));

--- a/src/client/src/app/api/manage-dashboard/query/run/route.ts
+++ b/src/client/src/app/api/manage-dashboard/query/run/route.ts
@@ -1,7 +1,16 @@
+import { requireRouteAccess } from "@/lib/access/route-access";
 import { runWidgetQuery } from "@/lib/platform/manage-dashboard/widget";
+import asaw from "@/utils/asaw";
 import { NextRequest } from "next/server";
 
 export async function POST(request: NextRequest) {
+	const [permissionErr] = await asaw(
+		requireRouteAccess("dashboard.read")
+	);
+	if (permissionErr) {
+		return Response.json({ err: String(permissionErr) }, { status: 403 });
+	}
+
 	const {
 		widgetId,
 		userQuery,

--- a/src/client/src/app/api/manage-dashboard/widget/[id]/route.ts
+++ b/src/client/src/app/api/manage-dashboard/widget/[id]/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import {
 	deleteWidget,
@@ -9,7 +11,7 @@ import { Widget } from "@/types/manage-dashboard";
 import { NextRequest } from "next/server";
 
 // Delete widget
-export async function DELETE(
+async function DELETEHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -23,7 +25,7 @@ export async function DELETE(
 }
 
 // Get widget by id
-export async function GET(
+async function GETHandler(
 	_: NextRequest,
 	{ params: { id } }: { params: { id: string } }
 ) {
@@ -32,7 +34,7 @@ export async function GET(
 }
 
 // Update widget
-export async function PUT(request: NextRequest) {
+async function PUTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const widget: Widget = await request.json();
 
@@ -43,3 +45,7 @@ export async function PUT(request: NextRequest) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const PUT = withAudit(withCurrentOrganisationPermission("dashboard:update", PUTHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("dashboard:delete", DELETEHandler));

--- a/src/client/src/app/api/manage-dashboard/widget/route.ts
+++ b/src/client/src/app/api/manage-dashboard/widget/route.ts
@@ -1,10 +1,12 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { createWidget, getWidgets } from "@/lib/platform/manage-dashboard/widget";
 import PostHogServer from "@/lib/posthog";
 import { Widget } from "@/types/manage-dashboard";
 import { NextRequest } from "next/server";
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const widget: Widget = await request.json();
 	const startTimestamp = Date.now();
 	const res = await createWidget(widget);
@@ -15,7 +17,10 @@ export async function POST(request: NextRequest) {
 	return Response.json(res);
 }
 
-export async function GET() {
+async function GETHandler() {
 	const res = await getWidgets();
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("dashboard:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("dashboard:create", POSTHandler));

--- a/src/client/src/app/api/metrics/exception/grouped/route.ts
+++ b/src/client/src/app/api/metrics/exception/grouped/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getGroupedRequests } from "@/lib/platform/request";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const selectedConfig = formData.selectedConfig || {};
@@ -32,3 +33,5 @@ export async function POST(request: Request) {
 	const res = await getGroupedRequests(params, groupBy);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/fanspeed/time/route.ts
+++ b/src/client/src/app/api/metrics/gpu/fanspeed/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getFanspeedParamsPerTime } from "@/lib/platform/gpu/fanspeed";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getFanspeedParamsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/memory/average/route.ts
+++ b/src/client/src/app/api/metrics/gpu/memory/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getAverageMemoryUsage } from "@/lib/platform/gpu/memory";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageMemoryUsage(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/memory/time/route.ts
+++ b/src/client/src/app/api/metrics/gpu/memory/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getMemoryParamsPerTime } from "@/lib/platform/gpu/memory";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getMemoryParamsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/power/average/route.ts
+++ b/src/client/src/app/api/metrics/gpu/power/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getAveragePowerDraw } from "@/lib/platform/gpu/power";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getAveragePowerDraw(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/power/time/route.ts
+++ b/src/client/src/app/api/metrics/gpu/power/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getPowerParamsPerTime } from "@/lib/platform/gpu/power";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getPowerParamsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/temperature/average/route.ts
+++ b/src/client/src/app/api/metrics/gpu/temperature/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getAverageTemperature } from "@/lib/platform/gpu/temperature";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageTemperature(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/temperature/time/route.ts
+++ b/src/client/src/app/api/metrics/gpu/temperature/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getAverageTemperatureParamsPerTime } from "@/lib/platform/gpu/temperature";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageTemperatureParamsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/utilization/average/route.ts
+++ b/src/client/src/app/api/metrics/gpu/utilization/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getAverageUtilization } from "@/lib/platform/gpu/utilization";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageUtilization(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/gpu/utilization/time/route.ts
+++ b/src/client/src/app/api/metrics/gpu/utilization/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { GPUMetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getUtilizationParamsPerTime } from "@/lib/platform/gpu/utilization";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -26,3 +27,5 @@ export async function POST(request: Request) {
 	const res: any = await getUtilizationParamsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/category/route.ts
+++ b/src/client/src/app/api/metrics/llm/category/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getResultGenerationByCategories } from "@/lib/platform/llm/category";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationByCategories(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/cost/application/route.ts
+++ b/src/client/src/app/api/metrics/llm/cost/application/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getCostByApplication } from "@/lib/platform/llm/cost";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getCostByApplication(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/cost/environment/route.ts
+++ b/src/client/src/app/api/metrics/llm/cost/environment/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getCostByEnvironment } from "@/lib/platform/llm/cost";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getCostByEnvironment(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/cost/request/average/route.ts
+++ b/src/client/src/app/api/metrics/llm/cost/request/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getAverageCost } from "@/lib/platform/llm/cost";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageCost(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/cost/total/route.ts
+++ b/src/client/src/app/api/metrics/llm/cost/total/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getTotalCost } from "@/lib/platform/llm/cost";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getTotalCost(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/endpoint/route.ts
+++ b/src/client/src/app/api/metrics/llm/endpoint/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -6,7 +7,7 @@ import {
 import { getResultGenerationByEndpoint } from "@/lib/platform/llm/endpoint";
 import { OPERATION_TYPE } from "@/types/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const operationType = formData.operationType as OPERATION_TYPE;
@@ -30,3 +31,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationByEndpoint(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/model/time/route.ts
+++ b/src/client/src/app/api/metrics/llm/model/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getModelsPerTime } from "@/lib/platform/llm/model";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getModelsPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/model/top/route.ts
+++ b/src/client/src/app/api/metrics/llm/model/top/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { ModelMetricParams, getTopModels } from "@/lib/platform/llm/model";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { TimeLimit } from "@/lib/platform/common";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -28,3 +29,5 @@ export async function POST(request: Request) {
 	const res: any = await getTopModels(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/token/request/average/route.ts
+++ b/src/client/src/app/api/metrics/llm/token/request/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import {
 	type TokenParams,
 	getAverageTokensPerRequest,
@@ -8,7 +9,7 @@ import {
 } from "@/helpers/server/platform";
 import { TimeLimit } from "@/lib/platform/common";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -31,3 +32,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageTokensPerRequest(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/llm/token/time/route.ts
+++ b/src/client/src/app/api/metrics/llm/token/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getTokensPerTime } from "@/lib/platform/llm/token";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getTokensPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/attribute-keys/route.ts
+++ b/src/client/src/app/api/metrics/request/attribute-keys/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getAttributeKeys } from "@/lib/platform/request";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res = await getAttributeKeys(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/config/route.ts
+++ b/src/client/src/app/api/metrics/request/config/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getRequestsConfig } from "@/lib/platform/request";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const limit = formData.limit || 10;
@@ -31,3 +32,5 @@ export async function POST(request: Request) {
 	const res: any = await getRequestsConfig(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/duration/average/route.ts
+++ b/src/client/src/app/api/metrics/request/duration/average/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getAverageRequestDuration } from "@/lib/platform/request";
 import {
@@ -6,7 +7,7 @@ import {
 } from "@/helpers/server/platform";
 import { OPERATION_TYPE } from "@/types/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const operationType = formData.operationType as OPERATION_TYPE;
@@ -30,3 +31,5 @@ export async function POST(request: Request) {
 	const res: any = await getAverageRequestDuration(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/exist/route.ts
+++ b/src/client/src/app/api/metrics/request/exist/route.ts
@@ -1,6 +1,7 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { getRequestExist } from "@/lib/platform/request";
 
-export async function POST() {
+async function POSTHandler() {
 	const res = await getRequestExist();
 	const { data } = res;
 	if ((data as any[])?.[0]?.total_requests > 0) {
@@ -9,3 +10,5 @@ export async function POST() {
 
 	return Response.json(false);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/grouped/route.ts
+++ b/src/client/src/app/api/metrics/request/grouped/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getGroupedRequests } from "@/lib/platform/request";
 import {
@@ -6,7 +7,7 @@ import {
 } from "@/helpers/server/platform";
 import { GroupByKey } from "@/types/store/filter";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const selectedConfig = formData.selectedConfig || {};
@@ -32,3 +33,5 @@ export async function POST(request: Request) {
 	const res = await getGroupedRequests(params, groupBy);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/time/route.ts
+++ b/src/client/src/app/api/metrics/request/time/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getRequestPerTime } from "@/lib/platform/request";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getRequestPerTime(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/request/total/route.ts
+++ b/src/client/src/app/api/metrics/request/total/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getTotalRequests } from "@/lib/platform/request";
 import {
@@ -6,7 +7,7 @@ import {
 } from "@/helpers/server/platform";
 import { OPERATION_TYPE } from "@/types/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 	const operationType = formData.operationType as OPERATION_TYPE;
@@ -30,3 +31,5 @@ export async function POST(request: Request) {
 	const res: any = await getTotalRequests(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/vector/application/route.ts
+++ b/src/client/src/app/api/metrics/vector/application/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getResultGenerationByApplication } from "@/lib/platform/vector/application";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationByApplication(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/vector/environment/route.ts
+++ b/src/client/src/app/api/metrics/vector/environment/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getResultGenerationByEnvironment } from "@/lib/platform/vector/environment";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationByEnvironment(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/vector/operation/route.ts
+++ b/src/client/src/app/api/metrics/vector/operation/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getResultGenerationByOperation } from "@/lib/platform/vector/operation";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationByOperation(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/metrics/vector/system/route.ts
+++ b/src/client/src/app/api/metrics/vector/system/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import {
 	validateMetricsRequest,
@@ -5,7 +6,7 @@ import {
 } from "@/helpers/server/platform";
 import { getResultGenerationBySystem } from "@/lib/platform/vector/system";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const timeLimit = formData.timeLimit as TimeLimit;
 
@@ -27,3 +28,5 @@ export async function POST(request: Request) {
 	const res: any = await getResultGenerationBySystem(params);
 	return Response.json(res);
 }
+
+export const POST = withRouteAccess("metrics.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/observability/metrics/[name]/route.ts
+++ b/src/client/src/app/api/observability/metrics/[name]/route.ts
@@ -1,7 +1,8 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getMetricDetail } from "@/lib/platform/observability";
 
-export async function POST(
+async function POSTHandler(
 	request: Request,
 	{ params }: { params: { name: string } }
 ) {
@@ -18,3 +19,5 @@ export async function POST(
 		await getMetricDetail(metricName, metricType, serviceName, metricParams)
 	);
 }
+
+export const POST = withRouteAccess("observability.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/observability/metrics/attribute-keys/route.ts
+++ b/src/client/src/app/api/observability/metrics/attribute-keys/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getMetricAttributeKeys } from "@/lib/platform/observability";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const params: MetricParams = {
 		timeLimit: formData.timeLimit as TimeLimit,
@@ -18,3 +19,5 @@ export async function POST(request: Request) {
 
 	return Response.json(await getMetricAttributeKeys(params));
 }
+
+export const POST = withRouteAccess("observability.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/observability/metrics/config/route.ts
+++ b/src/client/src/app/api/observability/metrics/config/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getMetricsConfig } from "@/lib/platform/observability";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const params: MetricParams = {
 		timeLimit: formData.timeLimit as TimeLimit,
@@ -18,3 +19,5 @@ export async function POST(request: Request) {
 
 	return Response.json(await getMetricsConfig(params));
 }
+
+export const POST = withRouteAccess("observability.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/observability/metrics/route.ts
+++ b/src/client/src/app/api/observability/metrics/route.ts
@@ -1,3 +1,4 @@
+import { withRouteAccess } from "@/lib/access/route-access";
 import { MetricParams, TimeLimit } from "@/lib/platform/common";
 import { getMetrics } from "@/lib/platform/observability";
 import {
@@ -5,7 +6,7 @@ import {
 	validateMetricsRequestType,
 } from "@/helpers/server/platform";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 	const params: MetricParams = {
 		timeLimit: formData.timeLimit as TimeLimit,
@@ -22,3 +23,5 @@ export async function POST(request: Request) {
 
 	return Response.json(await getMetrics(params));
 }
+
+export const POST = withRouteAccess("observability.read", POSTHandler, { requireDbConfig: true });

--- a/src/client/src/app/api/openground/[id]/route.ts
+++ b/src/client/src/app/api/openground/[id]/route.ts
@@ -1,10 +1,11 @@
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getOpengroundEvaluationById } from "@/lib/platform/openground-clickhouse";
 import { getCurrentUser } from "@/lib/session";
 import { getDBConfigByUser } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
 import getMessage from "@/constants/messages";
 
-export async function GET(_: Request, { params }: { params: { id: string } }) {
+async function GETHandler(_: Request, { params }: { params: { id: string } }) {
 	const user = await getCurrentUser();
 	if (!user) {
 		return Response.json({ error: getMessage().UNAUTHORIZED_USER }, { status: 401 });
@@ -26,3 +27,5 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
 
 	return Response.json(data);
 }
+
+export const GET = withCurrentOrganisationPermission("openground:read", GETHandler);

--- a/src/client/src/app/api/openground/config/route.ts
+++ b/src/client/src/app/api/openground/config/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { NextRequest, NextResponse } from "next/server";
 import { SERVER_EVENTS } from "@/constants/events";
 import { getCurrentUser } from "@/lib/session";
@@ -16,7 +18,7 @@ import * as messages from "@/constants/messages/en";
  * GET /api/openground/config
  * Get all provider configurations for the current user
  */
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
 	try {
 		const user = await getCurrentUser();
 		if (!user) {
@@ -54,7 +56,7 @@ export async function GET(request: NextRequest) {
  * POST /api/openground/config
  * Create or update a provider configuration
  */
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	try {
 		const user = await getCurrentUser();
@@ -122,7 +124,7 @@ export async function POST(request: NextRequest) {
  * DELETE /api/openground/config
  * Delete a provider configuration
  */
-export async function DELETE(request: NextRequest) {
+async function DELETEHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	try {
 		const user = await getCurrentUser();
@@ -183,7 +185,7 @@ export async function DELETE(request: NextRequest) {
  * PATCH /api/openground/config
  * Toggle active status of a configuration
  */
-export async function PATCH(request: NextRequest) {
+async function PATCHHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	try {
 		const user = await getCurrentUser();
@@ -244,3 +246,8 @@ export async function PATCH(request: NextRequest) {
 		);
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("openground:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));
+export const PATCH = withAudit(withCurrentOrganisationPermission("openground:configure", PATCHHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("openground:configure", DELETEHandler));

--- a/src/client/src/app/api/openground/models/cleanup/route.ts
+++ b/src/client/src/app/api/openground/models/cleanup/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/auth";
@@ -19,7 +21,7 @@ interface SessionWithId {
 }
 
 // POST: Clean up models with invalid UUIDs
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const session = (await getServerSession(authOptions)) as SessionWithId;
 
 	if (!session?.user?.id) {
@@ -100,3 +102,5 @@ export async function POST(request: NextRequest) {
 		})),
 	});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));

--- a/src/client/src/app/api/openground/models/import/route.ts
+++ b/src/client/src/app/api/openground/models/import/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/app/auth";
@@ -41,7 +43,7 @@ interface SessionWithId {
  *   ...
  * }
  */
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const session = (await getServerSession(authOptions)) as SessionWithId;
 
 	if (!session?.user?.id) {
@@ -232,3 +234,5 @@ export async function POST(request: NextRequest) {
 		providersSkipped,
 	});
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));

--- a/src/client/src/app/api/openground/models/route.ts
+++ b/src/client/src/app/api/openground/models/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { SERVER_EVENTS } from "@/constants/events";
@@ -21,7 +23,7 @@ interface SessionWithId {
 }
 
 // GET: List all custom models for a provider (or all providers if no provider specified)
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
 	const session = (await getServerSession(authOptions)) as SessionWithId;
 
 	if (!session?.user?.id) {
@@ -122,7 +124,7 @@ export async function GET(request: NextRequest) {
 }
 
 // POST: Create or update a custom model
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const session = (await getServerSession(authOptions)) as SessionWithId;
 
@@ -270,7 +272,7 @@ export async function POST(request: NextRequest) {
 }
 
 // DELETE: Remove a custom model
-export async function DELETE(request: NextRequest) {
+async function DELETEHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const session = (await getServerSession(authOptions)) as SessionWithId;
 
@@ -339,3 +341,7 @@ export async function DELETE(request: NextRequest) {
 	});
 	return NextResponse.json({ success: true, deleted: true });
 }
+
+export const GET = withCurrentOrganisationPermission("openground:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("openground:configure", DELETEHandler));

--- a/src/client/src/app/api/openground/providers/route.ts
+++ b/src/client/src/app/api/openground/providers/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/session";
 import { getDBConfigByUser } from "@/lib/db-config";
@@ -19,7 +21,7 @@ import {
  * GET /api/openground/providers
  * Get all available LLM providers with custom models merged in
  */
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
 	try {
 		const user = await getCurrentUser();
 		if (!user) {
@@ -96,7 +98,7 @@ export async function GET(request: NextRequest) {
  * POST /api/openground/providers
  * Create a new provider
  */
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	try {
 		const user = await getCurrentUser();
 		if (!user) {
@@ -168,7 +170,7 @@ export async function POST(request: NextRequest) {
  * the latest updated_at. This avoids string-interpolated ALTER TABLE UPDATE
  * and the SQL injection surface that comes with it.
  */
-export async function PUT(request: NextRequest) {
+async function PUTHandler(request: NextRequest) {
 	try {
 		const user = await getCurrentUser();
 		if (!user) {
@@ -260,7 +262,7 @@ export async function PUT(request: NextRequest) {
  * DELETE /api/openground/providers
  * Delete a provider and all its models
  */
-export async function DELETE(request: NextRequest) {
+async function DELETEHandler(request: NextRequest) {
 	try {
 		const user = await getCurrentUser();
 		if (!user) {
@@ -324,3 +326,8 @@ export async function DELETE(request: NextRequest) {
 		);
 	}
 }
+
+export const GET = withCurrentOrganisationPermission("openground:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));
+export const PUT = withAudit(withCurrentOrganisationPermission("openground:configure", PUTHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("openground:configure", DELETEHandler));

--- a/src/client/src/app/api/openground/route.ts
+++ b/src/client/src/app/api/openground/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { evaluate } from "@/lib/platform/openground/evaluate";
 import { getOpengroundEvaluations } from "@/lib/platform/openground-clickhouse";
@@ -7,7 +9,7 @@ import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
 import getMessage from "@/constants/messages";
 
-export async function GET() {
+async function GETHandler() {
 	const user = await getCurrentUser();
 	if (!user) {
 		return Response.json({ error: getMessage().UNAUTHORIZED_USER }, { status: 401 });
@@ -33,7 +35,7 @@ export async function GET() {
 	return Response.json(data);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const startTimestamp = Date.now();
 	const user = await getCurrentUser();
 	if (!user) {
@@ -79,3 +81,6 @@ export async function POST(request: Request) {
 	});
 	return Response.json(data);
 }
+
+export const GET = withCurrentOrganisationPermission("openground:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("openground:configure", POSTHandler));

--- a/src/client/src/app/api/organisation/[id]/members/route.ts
+++ b/src/client/src/app/api/organisation/[id]/members/route.ts
@@ -2,9 +2,10 @@ import {
 	getOrganisationMembers,
 	getOrganisationPendingInvites,
 } from "@/lib/organisation";
+import { withPermission } from "@/lib/rbac/route";
 import asaw from "@/utils/asaw";
 
-export async function GET(
+async function GETHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -29,3 +30,5 @@ export async function GET(
 		pendingInvites,
 	});
 }
+
+export const GET = withPermission("members:read", GETHandler);

--- a/src/client/src/app/api/organisation/[id]/projects/current/[projectId]/route.ts
+++ b/src/client/src/app/api/organisation/[id]/projects/current/[projectId]/route.ts
@@ -1,7 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withPermission } from "@/lib/rbac/route";
 import { setCurrentProject } from "@/lib/organisation";
 import asaw from "@/utils/asaw";
+import getMessage from "@/constants/messages";
 
-export async function POST(
+async function POSTHandler(
 	_request: Request,
 	{ params }: { params: { id: string; projectId: string } }
 ) {
@@ -9,7 +12,13 @@ export async function POST(
 		setCurrentProject(params.id, params.projectId)
 	);
 
-	if (err) return Response.json(err, { status: 400 });
+	if (err) {
+		const status =
+			String(err).includes(getMessage().PROJECT_ACCESS_REQUIRED) ? 403 : 400;
+		return Response.json(err, { status });
+	}
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(withPermission("projects:read", POSTHandler));

--- a/src/client/src/app/api/organisation/[id]/route.ts
+++ b/src/client/src/app/api/organisation/[id]/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withPermission } from "@/lib/rbac/route";
 import {
 	getOrganisationById,
 	updateOrganisation,
@@ -5,7 +7,7 @@ import {
 } from "@/lib/organisation";
 import asaw from "@/utils/asaw";
 
-export async function GET(
+async function GETHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -20,7 +22,7 @@ export async function GET(
 	return Response.json(res);
 }
 
-export async function PUT(
+async function PUTHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -39,7 +41,7 @@ export async function PUT(
 	return Response.json(res);
 }
 
-export async function DELETE(
+async function DELETEHandler(
 	request: Request,
 	{ params }: { params: Promise<{ id: string }> }
 ) {
@@ -54,3 +56,7 @@ export async function DELETE(
 
 	return Response.json(res);
 }
+
+export const GET = withPermission("organisation:read", GETHandler);
+export const PUT = withAudit(withPermission("organisation:update", PUTHandler));
+export const DELETE = withAudit(withPermission("organisation:delete", DELETEHandler));

--- a/src/client/src/app/api/pricing/auto/route.ts
+++ b/src/client/src/app/api/pricing/auto/route.ts
@@ -1,9 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
 import { SERVER_EVENTS } from "@/constants/events";
 import { autoUpdatePricing } from "@/lib/platform/pricing";
 import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 	const result = await autoUpdatePricing(formData);
@@ -15,3 +16,5 @@ export async function POST(request: NextRequest) {
 	});
 	return Response.json(result);
 }
+
+export const POST = withAudit(POSTHandler);

--- a/src/client/src/app/api/pricing/config/route.ts
+++ b/src/client/src/app/api/pricing/config/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import {
 	getPricingConfig,
 	setPricingConfig,
@@ -8,12 +10,12 @@ import PostHogServer from "@/lib/posthog";
 import { NextRequest } from "next/server";
 import asaw from "@/utils/asaw";
 
-export async function GET(_: NextRequest) {
+async function GETHandler(_: NextRequest) {
 	const config = await getPricingConfig();
 	return Response.json({ data: config });
 }
 
-export async function POST(request: NextRequest) {
+async function POSTHandler(request: NextRequest) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 	const pricingConfig: PricingConfigInput = {
@@ -41,3 +43,6 @@ export async function POST(request: NextRequest) {
 
 	return Response.json({ data });
 }
+
+export const GET = withCurrentOrganisationPermission("pricing:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("pricing:configure", POSTHandler));

--- a/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
+++ b/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { dataCollector } from "@/lib/platform/common";
-import { getDBConfigById } from "@/lib/db-config";
+import { getDBConfigByIdInternal } from "@/lib/db-config";
 import { OPENLIT_PROVIDER_MODELS_TABLE_NAME } from "@/lib/platform/providers/table-details";
 import asaw from "@/utils/asaw";
 
@@ -27,7 +27,7 @@ export async function GET(
 	}
 
 	// Validate the dbConfigId exists
-	const [err, dbConfig] = await asaw(getDBConfigById({ id: dbConfigId }));
+	const [err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: dbConfigId }));
 
 	if (err || !dbConfig?.id) {
 		return NextResponse.json(

--- a/src/client/src/app/api/prompt/[id]/route.ts
+++ b/src/client/src/app/api/prompt/[id]/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { deletePrompt } from "@/lib/platform/prompt";
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
 	const { id } = context.params;
 	const [err, res] = await deletePrompt(id);
 	if (err) {
@@ -11,3 +13,5 @@ export async function DELETE(_: Request, context: any) {
 
 	return Response.json(res);
 }
+
+export const DELETE = withAudit(withCurrentOrganisationPermission("prompt:delete", DELETEHandler));

--- a/src/client/src/app/api/prompt/route.ts
+++ b/src/client/src/app/api/prompt/route.ts
@@ -1,8 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { PromptInput } from "@/constants/prompts";
 import { createPrompt } from "@/lib/platform/prompt";
 import asaw from "@/utils/asaw";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 
 	const promptInput: PromptInput = {
@@ -24,3 +26,5 @@ export async function POST(request: Request) {
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("prompt:create", POSTHandler));

--- a/src/client/src/app/api/prompt/version/route.ts
+++ b/src/client/src/app/api/prompt/version/route.ts
@@ -1,8 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { PromptUpdate } from "@/constants/prompts";
 import { upsertPromptVersion } from "@/lib/platform/prompt/version";
 import asaw from "@/utils/asaw";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 
 	const promptInput: PromptUpdate = {
@@ -25,3 +27,5 @@ export async function POST(request: Request) {
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("prompt:update", POSTHandler));

--- a/src/client/src/app/api/rule-engine/entities/route.ts
+++ b/src/client/src/app/api/rule-engine/entities/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { RuleEntityInput } from "@/types/rule-engine";
 import { getRuleEntities, addRuleEntity, deleteRuleEntity } from "@/lib/platform/rule-engine";
@@ -8,7 +10,7 @@ import {
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
 
-export async function GET(request: Request) {
+async function GETHandler(request: Request) {
 	const { searchParams } = new URL(request.url);
 	const filters = {
 		rule_id: searchParams.get("rule_id") || undefined,
@@ -24,7 +26,7 @@ export async function GET(request: Request) {
 	return Response.json(data);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 
@@ -60,7 +62,7 @@ export async function POST(request: Request) {
 	return Response.json(res);
 }
 
-export async function DELETE(request: Request) {
+async function DELETEHandler(request: Request) {
 	const startTimestamp = Date.now();
 	const { searchParams } = new URL(request.url);
 	let id = searchParams.get("id");
@@ -99,3 +101,7 @@ export async function DELETE(request: Request) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("rule_engine:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("rule_engine:configure", POSTHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("rule_engine:configure", DELETEHandler));

--- a/src/client/src/app/api/rule-engine/field-values/route.ts
+++ b/src/client/src/app/api/rule-engine/field-values/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getCurrentUser } from "@/lib/session";
 import { dataCollector, OTEL_TRACES_TABLE_NAME } from "@/lib/platform/common";
 
@@ -14,7 +15,7 @@ const FIELD_COLUMN_MAP: Record<string, string> = {
 	"gen_ai.request.model": "SpanAttributes['gen_ai.request.model']",
 };
 
-export async function GET(request: NextRequest) {
+async function GETHandler(request: NextRequest) {
 	const user = await getCurrentUser();
 	if (!user) {
 		return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -45,3 +46,5 @@ export async function GET(request: NextRequest) {
 		.filter(Boolean);
 	return NextResponse.json({ values });
 }
+
+export const GET = withCurrentOrganisationPermission("rule_engine:read", GETHandler);

--- a/src/client/src/app/api/rule-engine/rules/[id]/conditions/route.ts
+++ b/src/client/src/app/api/rule-engine/rules/[id]/conditions/route.ts
@@ -1,10 +1,12 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { RuleConditionGroupInput } from "@/types/rule-engine";
 import { addConditionGroupsToRule } from "@/lib/platform/rule-engine";
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
 
-export async function POST(request: Request, context: any) {
+async function POSTHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const formData = await request.json();
@@ -26,3 +28,5 @@ export async function POST(request: Request, context: any) {
 	});
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("rule_engine:configure", POSTHandler));

--- a/src/client/src/app/api/rule-engine/rules/[id]/preview/route.ts
+++ b/src/client/src/app/api/rule-engine/rules/[id]/preview/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getCurrentUser } from "@/lib/session";
 import { getRuleById } from "@/lib/platform/rule-engine";
 import { dataCollector, OTEL_TRACES_TABLE_NAME } from "@/lib/platform/common";
@@ -94,7 +95,7 @@ function evaluateRule(
 		: groupResults.some(Boolean);
 }
 
-export async function POST(
+async function POSTHandler(
 	_req: NextRequest,
 	{ params }: { params: { id: string } }
 ) {
@@ -177,3 +178,5 @@ export async function POST(
 		return NextResponse.json({ error: message }, { status: 500 });
 	}
 }
+
+export const POST = withCurrentOrganisationPermission("rule_engine:evaluate", POSTHandler);

--- a/src/client/src/app/api/rule-engine/rules/[id]/route.ts
+++ b/src/client/src/app/api/rule-engine/rules/[id]/route.ts
@@ -1,10 +1,12 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { RuleInput } from "@/types/rule-engine";
 import { getRuleById, updateRule, deleteRule } from "@/lib/platform/rule-engine";
 import PostHogServer from "@/lib/posthog";
 import asaw from "@/utils/asaw";
 
-export async function GET(_: Request, context: any) {
+async function GETHandler(_: Request, context: any) {
 	const { id } = context.params;
 	const { err, data }: any = await getRuleById(id);
 	if (err) {
@@ -14,7 +16,7 @@ export async function GET(_: Request, context: any) {
 	return Response.json(data);
 }
 
-export async function PUT(request: Request, context: any) {
+async function PUTHandler(request: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const formData = await request.json();
@@ -42,7 +44,7 @@ export async function PUT(request: Request, context: any) {
 	return Response.json(res);
 }
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
 	const startTimestamp = Date.now();
 	const { id } = context.params;
 	const [err, res] = await deleteRule(id);
@@ -60,3 +62,7 @@ export async function DELETE(_: Request, context: any) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("rule_engine:read", GETHandler);
+export const PUT = withAudit(withCurrentOrganisationPermission("rule_engine:configure", PUTHandler));
+export const DELETE = withAudit(withCurrentOrganisationPermission("rule_engine:configure", DELETEHandler));

--- a/src/client/src/app/api/rule-engine/rules/route.ts
+++ b/src/client/src/app/api/rule-engine/rules/route.ts
@@ -1,3 +1,5 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SERVER_EVENTS } from "@/constants/events";
 import { RuleInput } from "@/types/rule-engine";
 import { getRules, createRule } from "@/lib/platform/rule-engine";
@@ -6,7 +8,7 @@ import asaw from "@/utils/asaw";
 
 import { resolveDbConfigId } from "@/helpers/server/auth";
 
-export async function GET(request: Request) {
+async function GETHandler(request: Request) {
 	const [authErr, databaseConfigId] = await resolveDbConfigId(request);
 	if (authErr) {
 		return Response.json({ err: authErr }, { status: 401 });
@@ -20,7 +22,7 @@ export async function GET(request: Request) {
 	return Response.json(data);
 }
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const startTimestamp = Date.now();
 	const formData = await request.json();
 
@@ -46,3 +48,6 @@ export async function POST(request: Request) {
 	});
 	return Response.json(res);
 }
+
+export const GET = withCurrentOrganisationPermission("rule_engine:read", GETHandler);
+export const POST = withAudit(withCurrentOrganisationPermission("rule_engine:configure", POSTHandler));

--- a/src/client/src/app/api/vault/[id]/route.ts
+++ b/src/client/src/app/api/vault/[id]/route.ts
@@ -1,6 +1,8 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { deleteSecret } from "@/lib/platform/vault";
 
-export async function DELETE(_: Request, context: any) {
+async function DELETEHandler(_: Request, context: any) {
 	const { id } = context.params;
 	const [err, res] = await deleteSecret(id);
 	if (err) {
@@ -11,3 +13,5 @@ export async function DELETE(_: Request, context: any) {
 
 	return Response.json(res);
 }
+
+export const DELETE = withAudit(withCurrentOrganisationPermission("vault:delete", DELETEHandler));

--- a/src/client/src/app/api/vault/route.ts
+++ b/src/client/src/app/api/vault/route.ts
@@ -1,8 +1,10 @@
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { SecretInput } from "@/types/vault";
 import { upsertSecret } from "@/lib/platform/vault";
 import asaw from "@/utils/asaw";
 
-export async function POST(request: Request) {
+async function POSTHandler(request: Request) {
 	const formData = await request.json();
 
 	const promptInput: Partial<SecretInput> = {
@@ -22,7 +24,7 @@ export async function POST(request: Request) {
 	return Response.json(res);
 }
 
-export async function PUT(request: Request) {
+async function PUTHandler(request: Request) {
 	const formData = await request.json();
 
 	const secretInput: Partial<SecretInput> = {
@@ -42,3 +44,6 @@ export async function PUT(request: Request) {
 
 	return Response.json(res);
 }
+
+export const POST = withAudit(withCurrentOrganisationPermission("vault:write", POSTHandler));
+export const PUT = withAudit(withCurrentOrganisationPermission("vault:write", PUTHandler));

--- a/src/client/src/clickhouse/migrations/create-openground-migration.ts
+++ b/src/client/src/clickhouse/migrations/create-openground-migration.ts
@@ -2,7 +2,7 @@ import { dataCollector } from "@/lib/platform/common";
 import getMessage from "@/constants/messages";
 import prisma from "@/lib/prisma";
 import asaw from "@/utils/asaw";
-import { getDBConfigByUser, getDBConfigById } from "@/lib/db-config";
+import { getDBConfigByIdInternal, getDBConfigByUser } from "@/lib/db-config";
 import {
 	OPENLIT_OPENGROUND_TABLE_NAME,
 	OPENLIT_OPENGROUND_PROVIDERS_TABLE_NAME,
@@ -12,7 +12,7 @@ import {
 export default async function CreateOpengroundMigration(databaseConfigId?: string) {
 	const [, dbConfig] = await asaw(
 		databaseConfigId
-			? getDBConfigById({ id: databaseConfigId })
+			? getDBConfigByIdInternal({ id: databaseConfigId })
 			: getDBConfigByUser(true)
 	);
 

--- a/src/client/src/clickhouse/migrations/create-providers-migration.ts
+++ b/src/client/src/clickhouse/migrations/create-providers-migration.ts
@@ -2,7 +2,7 @@ import { dataCollector } from "@/lib/platform/common";
 import getMessage from "@/constants/messages";
 import prisma from "@/lib/prisma";
 import asaw from "@/utils/asaw";
-import { getDBConfigById, getDBConfigByUser } from "@/lib/db-config";
+import { getDBConfigByIdInternal, getDBConfigByUser } from "@/lib/db-config";
 import {
 	OPENLIT_PROVIDERS_TABLE_NAME,
 	OPENLIT_PROVIDER_MODELS_TABLE_NAME,
@@ -31,7 +31,7 @@ const MIGRATION_ID = "create-providers-and-provider-models-tables";
 export default async function CreateProvidersMigration(databaseConfigId?: string) {
 	const [, dbConfig] = await asaw(
 		databaseConfigId
-			? getDBConfigById({ id: databaseConfigId })
+			? getDBConfigByIdInternal({ id: databaseConfigId })
 			: getDBConfigByUser(true)
 	);
 

--- a/src/client/src/clickhouse/migrations/encrypt-vault-values-migration.ts
+++ b/src/client/src/clickhouse/migrations/encrypt-vault-values-migration.ts
@@ -1,7 +1,7 @@
 import { OPENLIT_VAULT_TABLE_NAME } from "@/lib/platform/vault/table-details";
 import { dataCollector } from "@/lib/platform/common";
 import { encryptValue, isEncrypted } from "@/utils/crypto";
-import { getDBConfigById, getDBConfigByUser } from "@/lib/db-config";
+import { getDBConfigByIdInternal, getDBConfigByUser } from "@/lib/db-config";
 import asaw from "@/utils/asaw";
 import prisma from "@/lib/prisma";
 import { consoleLog } from "@/utils/log";
@@ -17,7 +17,7 @@ export default async function EncryptVaultValuesMigration(
 ) {
 	let err, dbConfig;
 	if (databaseConfigId) {
-		[err, dbConfig] = await asaw(getDBConfigById({ id: databaseConfigId }));
+		[err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: databaseConfigId }));
 	} else {
 		[err, dbConfig] = await asaw(getDBConfigByUser(true));
 	}

--- a/src/client/src/clickhouse/migrations/migration-helper.ts
+++ b/src/client/src/clickhouse/migrations/migration-helper.ts
@@ -1,5 +1,5 @@
 import getMessage from "@/constants/messages";
-import { getDBConfigById, getDBConfigByUser } from "@/lib/db-config";
+import { getDBConfigByIdInternal, getDBConfigByUser } from "@/lib/db-config";
 import { dataCollector } from "@/lib/platform/common";
 import prisma from "@/lib/prisma";
 import asaw from "@/utils/asaw";
@@ -20,7 +20,7 @@ export default async function migrationHelper({
 }) {
 	let err, dbConfig;
 	if (databaseConfigId) {
-		[err, dbConfig] = await asaw(getDBConfigById({ id: databaseConfigId }));
+		[err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: databaseConfigId }));
 	} else {
 		[err, dbConfig] = await asaw(getDBConfigByUser(true));
 	}

--- a/src/client/src/components/(playground)/api-keys/api-reference.tsx
+++ b/src/client/src/components/(playground)/api-keys/api-reference.tsx
@@ -492,7 +492,7 @@ export default function ApiReference({ userApiKey }: ApiReferenceProps) {
 				</span>
 			</div>
 
-			<div className="flex flex-col lg:flex-row divide-y lg:divide-y-0 lg:divide-x divide-stone-200 dark:divide-stone-800 min-h-[450px] h-full overflow-hidden">
+			<div className="flex flex-col lg:flex-row divide-y lg:divide-y-0 lg:divide-x divide-stone-200 dark:divide-stone-800 h-full overflow-hidden">
 				{/* Sidebar list */}
 				<div className="w-full lg:w-80 shrink-0 bg-stone-50/50 dark:bg-stone-950/20 py-2 overflow-y-auto h-full">
 					<div className="space-y-2 px-2">

--- a/src/client/src/components/paid-feature-lock-overlay.tsx
+++ b/src/client/src/components/paid-feature-lock-overlay.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from "react";
+
+type PaidFeatureLockOverlayProps = {
+	children: ReactNode;
+	isLocked: boolean;
+	featureName: string;
+	planLabel: string;
+	title: string;
+	message: string;
+	primaryActionLabel?: string;
+	onPrimaryAction?: () => void;
+	className?: string;
+};
+
+export default function PaidFeatureLockOverlay({
+	children,
+}: PaidFeatureLockOverlayProps) {
+	return <>{children}</>;
+}

--- a/src/client/src/constants/messages/en.ts
+++ b/src/client/src/constants/messages/en.ts
@@ -1090,6 +1090,8 @@ export const CURRENT = "Current";
 export const LOADING_PROJECT = "Loading project";
 export const NO_PROJECT = "No project";
 export const PROJECT_NOT_FOUND = "Project not found";
+export const PROJECT_ACCESS_REQUIRED =
+	"Your admin has not given you access to this project";
 export const PROJECT_SWITCH_FAILED = "Failed to switch project";
 export const DB_CONFIG_NOT_IN_CURRENT_PROJECT =
 	"Database config doesn't exist in current project";

--- a/src/client/src/lib/access/route-access.ts
+++ b/src/client/src/lib/access/route-access.ts
@@ -1,3 +1,5 @@
+import { withDbConfigAccess } from "@/lib/rbac/route";
+
 type RouteHandler = (
 	request: any,
 	context: any
@@ -12,7 +14,10 @@ export async function requireRouteAccess(_access: RouteAccessKey) {
 export function withRouteAccess<THandler extends RouteHandler>(
 	_access: RouteAccessKey,
 	handler: THandler,
-	_options: { requireDbConfig?: boolean } = {}
+	options: { requireDbConfig?: boolean } = {}
 ): THandler {
+	if (options.requireDbConfig) {
+		return withDbConfigAccess(handler);
+	}
 	return handler;
 }

--- a/src/client/src/lib/audit/route.ts
+++ b/src/client/src/lib/audit/route.ts
@@ -1,0 +1,10 @@
+type RouteHandler = (
+	request: any,
+	context: any
+) => Promise<Response> | Response;
+
+export function withAudit<THandler extends RouteHandler>(
+	handler: THandler
+): THandler {
+	return handler;
+}

--- a/src/client/src/lib/db-config.ts
+++ b/src/client/src/lib/db-config.ts
@@ -108,12 +108,50 @@ export const getDBConfigByUser = async (currentOnly?: boolean) => {
 	}));
 };
 
-export const getDBConfigById = async ({ id }: { id: string }) => {
+export const getDBConfigByIdInternal = async ({ id }: { id: string }) => {
 	return await prisma.databaseConfig.findUnique({
 		where: {
 			id,
 		},
 	});
+};
+
+export const getDBConfigById = async ({ id }: { id: string }) => {
+	const user = await getCurrentUser();
+	if (!user) throw new Error(getMessage().UNAUTHORIZED_USER);
+
+	return getDBConfigByIdForUser({ id, userId: user.id });
+};
+
+export const getDBConfigByIdForUser = async ({
+	id,
+	userId,
+}: {
+	id: string;
+	userId: string;
+}) => {
+	const currentOrg = await getCurrentOrganisation();
+	const currentProject = currentOrg?.id
+		? await getCurrentProjectForOrganisation(currentOrg.id)
+		: null;
+	const scopedProjectId = currentOrg?.id ? currentProject?.id : null;
+
+	if (currentOrg?.id && !scopedProjectId) return null;
+
+	const dbConfigUser = await prisma.databaseConfigUser.findFirst({
+		where: {
+			userId,
+			databaseConfigId: id,
+			databaseConfig: {
+				projectId: scopedProjectId,
+			},
+		},
+		select: {
+			databaseConfig: true,
+		},
+	});
+
+	return dbConfigUser?.databaseConfig ?? null;
 };
 
 export const getFirstDBConfig = async (): Promise<DatabaseConfig | null> => {

--- a/src/client/src/lib/organisation-projects.ts
+++ b/src/client/src/lib/organisation-projects.ts
@@ -1,0 +1,1 @@
+export { createOrganisationProject } from "@/lib/organisation";

--- a/src/client/src/lib/platform/alerts/signals.ts
+++ b/src/client/src/lib/platform/alerts/signals.ts
@@ -1,54 +1,7 @@
-import { emitAlertSignal } from "@/features/alerts";
-import { getDBConfigByUser } from "@/lib/db-config";
-import { getCurrentOrganisation, getCurrentProjectForOrganisation } from "@/lib/organisation";
-import type { AlertSignalInput, AlertTriggerType } from "@/types/alerts";
+import type { ManagementAlertInput } from "@/types/alerts";
 
-type ManagementAlertInput = {
-	triggerType: AlertTriggerType;
-	event: string;
-	message: string;
-	sourceId?: string | null;
-	fields?: Record<string, string | number | boolean | undefined | null>;
-	payloadSummary?: Record<string, unknown>;
-	databaseConfigId?: string | null;
-};
-
-function cleanFields(fields: ManagementAlertInput["fields"]) {
-	return Object.fromEntries(
-		Object.entries(fields || {}).filter((entry): entry is [string, string | number | boolean] => {
-			const value = entry[1];
-			return typeof value === "string" || typeof value === "number" || typeof value === "boolean";
-		})
-	);
+export async function emitManagementAlertSignal(_input: ManagementAlertInput) {
+	return [];
 }
 
-export async function emitManagementAlertSignal(input: ManagementAlertInput) {
-	const organisation = await getCurrentOrganisation().catch(() => null);
-	if (!organisation?.id) return [];
-
-	const project = await getCurrentProjectForOrganisation(organisation.id).catch(() => null);
-	const rawDbConfig = await getDBConfigByUser(true).catch(() => null);
-	const databaseConfig = rawDbConfig && !Array.isArray(rawDbConfig) ? rawDbConfig : null;
-	const fields = {
-		event: input.event,
-		...cleanFields(input.fields),
-	};
-	const payloadSummary = {
-		message: input.message,
-		...input.payloadSummary,
-	};
-
-	return emitAlertSignal({
-		triggerType: input.triggerType,
-		organisationId: organisation.id,
-		projectId: project?.id ?? null,
-		databaseConfigId: input.databaseConfigId ?? databaseConfig?.id ?? null,
-		sourceId: input.sourceId ?? null,
-		fields,
-		payloadSummary,
-	} satisfies AlertSignalInput);
-}
-
-export function emitManagementAlertSignalSafe(input: ManagementAlertInput) {
-	emitManagementAlertSignal(input).catch(() => undefined);
-}
+export function emitManagementAlertSignalSafe(_input: ManagementAlertInput) {}

--- a/src/client/src/lib/platform/common.ts
+++ b/src/client/src/lib/platform/common.ts
@@ -1,7 +1,12 @@
 import { Pool } from "generic-pool";
-import { getDBConfigById, getDBConfigByUser } from "../db-config";
+import {
+	getDBConfigByIdInternal,
+	getDBConfigByIdForUser,
+	getDBConfigByUser,
+} from "../db-config";
 import createClickhousePool from "./clickhouse/clickhouse-client";
 import asaw from "@/utils/asaw";
+import { getCurrentUser } from "@/lib/session";
 import {
 	ClickHouseClient,
 	QueryParams,
@@ -68,12 +73,20 @@ export async function dataCollector(
 ): Promise<DataCollectorType> {
 	let err, dbConfig;
 	if (dbConfigId) {
-		[err, dbConfig] = await asaw(getDBConfigById({ id: dbConfigId }));
+		const [userErr, user] = await asaw(getCurrentUser());
+		if (!userErr && user?.id) {
+			[err, dbConfig] = await asaw(
+				getDBConfigByIdForUser({ id: dbConfigId, userId: user.id })
+			);
+		} else {
+			[err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: dbConfigId }));
+		}
 	} else {
 		[err, dbConfig] = await asaw(getDBConfigByUser(true));
 	}
 
 	if (err) return { err, data: [] };
+	if (!dbConfig) return { err: "Database config is not accessible", data: [] };
 	let clickhousePool: Pool<ClickHouseClient> | undefined;
 	let client: ClickHouseClient | undefined;
 

--- a/src/client/src/lib/platform/evaluation/index.ts
+++ b/src/client/src/lib/platform/evaluation/index.ts
@@ -24,7 +24,7 @@ import {
 } from "./rule-engine-context";
 import { TraceRow } from "@/types/trace";
 import { get } from "lodash";
-import { getDBConfigById } from "@/lib/db-config";
+import { getDBConfigByIdInternal } from "@/lib/db-config";
 import { SUPPORTED_EVALUATION_OPERATIONS } from "@/constants/traces";
 import {
 	AUTO_EVALUATION_HANDLED_SOURCES,
@@ -584,7 +584,7 @@ export async function autoEvaluate(autoEvaluationConfig: AutoEvaluationConfig) {
 	}
 
 	const [databaseConfigErr, databaseConfig] = await asaw(
-		getDBConfigById({ id: evaluationConfig.databaseConfigId })
+		getDBConfigByIdInternal({ id: evaluationConfig.databaseConfigId })
 	);
 
 	if (databaseConfigErr || !databaseConfig.id) {

--- a/src/client/src/lib/platform/pricing/index.ts
+++ b/src/client/src/lib/platform/pricing/index.ts
@@ -7,7 +7,7 @@ import {
 	getTraceMappingKeyFullPaths,
 } from "@/helpers/server/trace";
 import { SUPPORTED_EVALUATION_OPERATIONS } from "@/constants/traces";
-import { getDBConfigById } from "@/lib/db-config";
+import { getDBConfigByIdInternal } from "@/lib/db-config";
 import { getRequestViaSpanId } from "@/lib/platform/request";
 import { ProviderRegistry } from "@/lib/platform/providers/provider-registry";
 import { getPricingConfigById } from "./config";
@@ -193,7 +193,7 @@ export async function autoUpdatePricing(payload: AutoPricingPayload) {
 	}
 
 	const [dbConfigErr, dbConfig] = await asaw(
-		getDBConfigById({ id: pricingConfig.databaseConfigId })
+		getDBConfigByIdInternal({ id: pricingConfig.databaseConfigId })
 	);
 
 	if (dbConfigErr || !dbConfig?.id) {

--- a/src/client/src/lib/rbac/current.ts
+++ b/src/client/src/lib/rbac/current.ts
@@ -1,0 +1,22 @@
+type RouteHandler = (
+	request: any,
+	context: any
+) => Promise<Response> | Response;
+
+export async function requireCurrentOrganisationPermission(_permission: string) {
+	return null;
+}
+
+export async function requireCurrentOrganisationEntitledPermission(
+	_featureId: string,
+	_permission: string
+) {
+	return null;
+}
+
+export function withCurrentOrganisationPermission<THandler extends RouteHandler>(
+	_permission: string,
+	handler: THandler
+): THandler {
+	return handler;
+}

--- a/src/client/src/lib/rbac/route.ts
+++ b/src/client/src/lib/rbac/route.ts
@@ -1,0 +1,95 @@
+import { getCurrentUser } from "@/lib/session";
+import getMessage from "@/constants/messages";
+import { getDBConfigByIdForUser } from "@/lib/db-config";
+import {
+	getCurrentOrganisation,
+	getCurrentProjectForOrganisation,
+} from "@/lib/organisation";
+import { OPENLIT_CONTEXT_HEADERS } from "@/constants/openlit-context";
+
+type RouteContext = {
+	params?: Record<string, string> | Promise<Record<string, string>>;
+};
+
+type RouteHandler = (
+	request: any,
+	context: any
+) => Promise<Response> | Response;
+
+function firstString(...values: unknown[]) {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim()) return value;
+	}
+	return undefined;
+}
+
+function extractDatabaseConfigId(body: any, request: Request) {
+	const selectedConfig = body?.selectedConfig;
+	return firstString(
+		body?.databaseConfigId,
+		body?.dbConfigId,
+		typeof selectedConfig === "string" ? selectedConfig : undefined,
+		selectedConfig?.databaseConfigId,
+		selectedConfig?.dbConfigId,
+		request.headers?.get?.(OPENLIT_CONTEXT_HEADERS.databaseConfigId)
+	);
+}
+
+export function withPermission<THandler extends RouteHandler>(
+	_permission: string,
+	handler: THandler
+): THandler {
+	return handler;
+}
+
+export function withEntitledPermission<THandler extends RouteHandler>(
+	_featureId: string,
+	_permission: string,
+	handler: THandler
+): THandler {
+	return handler;
+}
+
+export function withDbConfigAccess<THandler extends RouteHandler>(
+	handler: THandler
+): THandler {
+	return (async (request: Request, context: RouteContext = {}) => {
+		const messages = getMessage();
+		const user = await getCurrentUser();
+		if (!user) return Response.json({ error: messages.UNAUTHORIZED_USER }, { status: 401 });
+
+		const body =
+			typeof request.clone === "function"
+				? await request.clone().json().catch(() => ({}))
+				: {};
+		const databaseConfigId = extractDatabaseConfigId(body, request);
+		if (!databaseConfigId) {
+			const currentOrganisation = await getCurrentOrganisation();
+			const currentProject = currentOrganisation?.id
+				? await getCurrentProjectForOrganisation(currentOrganisation.id)
+				: null;
+
+			if (currentOrganisation?.id && !currentProject?.id) {
+				return Response.json(
+					{ error: messages.PROJECT_ACCESS_REQUIRED },
+					{ status: 403 }
+				);
+			}
+
+			return handler(request, context);
+		}
+
+		const dbConfig = await getDBConfigByIdForUser({
+			id: databaseConfigId,
+			userId: user.id,
+		});
+		if (!dbConfig) {
+			return Response.json(
+				{ error: messages.PROJECT_ACCESS_REQUIRED },
+				{ status: 403 }
+			);
+		}
+
+		return handler(request, context);
+	}) as THandler;
+}

--- a/src/client/src/lib/rbac/routes/api/alerts/condition-values/route.ts
+++ b/src/client/src/lib/rbac/routes/api/alerts/condition-values/route.ts
@@ -1,0 +1,3 @@
+import { alertingUnavailable } from "../unavailable";
+
+export const GET = alertingUnavailable;

--- a/src/client/src/types/alerts.ts
+++ b/src/client/src/types/alerts.ts
@@ -75,6 +75,16 @@ export type AlertSignalInput = {
 	payloadSummary?: Record<string, unknown>;
 };
 
+export type ManagementAlertInput = {
+	triggerType: AlertTriggerType;
+	event: string;
+	message: string;
+	sourceId?: string | null;
+	fields?: Record<string, string | number | boolean | undefined | null>;
+	payloadSummary?: Record<string, unknown>;
+	databaseConfigId?: string | null;
+};
+
 export type ProviderFieldDefinition = {
 	key: string;
 	label: string;


### PR DESCRIPTION
## Summary
- Adds the missing CE-side fallback for `@/lib/rbac/route` (`withPermission`/`withEntitledPermission` pass-throughs, real `withDbConfigAccess` ownership check) and wires `withRouteAccess` to delegate to it — this alias previously had no CE sibling at all in the enterprise fork's tsconfig fallback pattern.
- Closes an accidental data-access gap: `getDBConfigById` performed an unscoped Prisma lookup; splits it into a scoped `getDBConfigByIdForUser` and an explicit unscoped `getDBConfigByIdInternal` for trusted internal/migration contexts.
- Restores real route bodies (previously replaced downstream by a one-line re-export into an enterprise-only module) for `db-config`, `api-key`, `vault`, `prompt`, `evaluation`, `manage-dashboard`, `openground`, `rule-engine`, `controller`, `fleet-hub`, `context`, `pricing`, `coding-agents`, and `organisation` — matching file layout so future syncs stop conflicting on these paths.
- Makes `emitManagementAlertSignal` a true no-op on this side rather than doing real DB work only to discard the result.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm test -- --runInBand`
- [x] `npm run lint`
- [x] `npx prisma validate --schema prisma/schema.prisma`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten CE-side RBAC, audit, and database config access seams while restoring full route implementations for various management APIs.

New Features:
- Introduce CE-safe RBAC helpers for route-level and organisation-level permission handling, plus a no-op audit wrapper and paid feature lock overlay component.
- Add route-access integration with database config ownership checks for metrics and observability endpoints, and wire chat improvement routes through Otter DB access decorators.

Bug Fixes:
- Scope database config lookups by user and project, separating trusted internal access from user-facing queries to close an unintended data-access gap.
- Make management alert emission a true no-op in the CE client to avoid unnecessary database work.

Enhancements:
- Restore concrete handler bodies for numerous API routes (db-config, api-key, vault, prompt, evaluation, manage-dashboard, openground, rule-engine, controller, fleet-hub, context, pricing, coding-agents, organisation) and wrap them with appropriate RBAC and audit decorators.
- Update data collection and migrations to use the new internal DB config accessor and enforce DB config accessibility for query execution.
- Extend route-access tests and behaviour to support optional DB config access requirements, and adjust platform tests to cover the new access patterns.

Tests:
- Expand unit tests around db-config access patterns, dataCollector behaviour with and without user sessions, and CE route-access fallbacks to validate the new RBAC and access controls.