### PR TITLE
refactor: extract pricing export computation into a shared lib function

### DIFF
--- a/src/client/src/__tests__/app/api/pricing/export/[dbConfigId]/route.test.ts
+++ b/src/client/src/__tests__/app/api/pricing/export/[dbConfigId]/route.test.ts
@@ -1,0 +1,78 @@
+jest.mock("next/server", () => ({
+	NextResponse: {
+		json: jest.fn((body: unknown, init?: { status?: number; headers?: Record<string, string> }) => ({
+			status: init?.status ?? 200,
+			headers: { get: (key: string) => init?.headers?.[key] ?? null },
+			json: async () => body,
+		})),
+	},
+}));
+
+jest.mock("@/lib/audit/route", () => ({
+	withAudit: (handler: unknown) => handler,
+}));
+
+jest.mock("@/lib/rbac/current", () => ({
+	withCurrentOrganisationPermission: jest.fn(
+		(_permission: string, handler: unknown) => handler
+	),
+}));
+
+jest.mock("@/lib/platform/pricing/export", () => ({
+	getPricingExport: jest.fn(),
+}));
+
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
+import { getPricingExport } from "@/lib/platform/pricing/export";
+import { GET } from "@/app/api/pricing/export/[dbConfigId]/route";
+
+const mockedGetPricingExport = getPricingExport as jest.MockedFunction<
+	typeof getPricingExport
+>;
+
+// Captured before any mock is reset: the wrapping happens once, at
+// module-evaluation time (`export const GET = withAudit(
+// withCurrentOrganisationPermission(...))`), not per-request. CE's version
+// of these wrappers is a no-op pass-through; enterprise editions resolve
+// them to real permission + audit checks around this same handler.
+const permissionGateCall = (withCurrentOrganisationPermission as jest.Mock).mock
+	.calls[0];
+
+describe("GET /api/pricing/export/[dbConfigId]", () => {
+	beforeEach(() => {
+		mockedGetPricingExport.mockReset();
+	});
+
+	it("is gated behind the pricing:export permission key", () => {
+		expect(permissionGateCall).toEqual(["pricing:export", expect.any(Function)]);
+	});
+
+	it("returns the shared pricing export data with a cache header on success", async () => {
+		mockedGetPricingExport.mockResolvedValue({
+			data: { chat: { "gpt-4": { promptPrice: 0.01, completionPrice: 0.02 } } },
+		});
+
+		const response = await GET({} as any, { params: { dbConfigId: "db-1" } });
+
+		expect(getPricingExport).toHaveBeenCalledWith("db-1");
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Cache-Control")).toBe("public, max-age=300");
+		await expect(response.json()).resolves.toEqual({
+			chat: { "gpt-4": { promptPrice: 0.01, completionPrice: 0.02 } },
+		});
+	});
+
+	it("passes through the shared function's error status", async () => {
+		mockedGetPricingExport.mockResolvedValue({
+			error: "Database config not found",
+			status: 404,
+		});
+
+		const response = await GET({} as any, { params: { dbConfigId: "missing" } });
+
+		expect(response.status).toBe(404);
+		await expect(response.json()).resolves.toEqual({
+			error: "Database config not found",
+		});
+	});
+});

--- a/src/client/src/__tests__/lib/platform/pricing/export.test.ts
+++ b/src/client/src/__tests__/lib/platform/pricing/export.test.ts
@@ -1,0 +1,128 @@
+jest.mock("@/lib/platform/common", () => ({
+	dataCollector: jest.fn(),
+}));
+
+jest.mock("@/lib/db-config", () => ({
+	getDBConfigByIdInternal: jest.fn(),
+}));
+
+import { dataCollector } from "@/lib/platform/common";
+import { getDBConfigByIdInternal } from "@/lib/db-config";
+import { getPricingExport } from "@/lib/platform/pricing/export";
+
+const mockedDataCollector = dataCollector as jest.MockedFunction<
+	typeof dataCollector
+>;
+const mockedGetDBConfigByIdInternal =
+	getDBConfigByIdInternal as jest.MockedFunction<typeof getDBConfigByIdInternal>;
+
+describe("getPricingExport", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("returns a 400 when dbConfigId is missing", async () => {
+		await expect(getPricingExport("")).resolves.toEqual({
+			error: "Database config ID is required",
+			status: 400,
+		});
+	});
+
+	it("returns a 404 when the database config does not exist", async () => {
+		mockedGetDBConfigByIdInternal.mockResolvedValue(null as any);
+
+		await expect(getPricingExport("db-1")).resolves.toEqual({
+			error: "Database config not found",
+			status: 404,
+		});
+	});
+
+	it("returns a 500 when the pricing query fails", async () => {
+		mockedGetDBConfigByIdInternal.mockResolvedValue({ id: "db-1" } as any);
+		mockedDataCollector.mockResolvedValue({ err: "boom" } as any);
+
+		await expect(getPricingExport("db-1")).resolves.toEqual({
+			error: "Failed to fetch model pricing",
+			status: 500,
+		});
+	});
+
+	it("builds SDK-compatible pricing.json, including optional cache prices", async () => {
+		mockedGetDBConfigByIdInternal.mockResolvedValue({ id: "db-1" } as any);
+		mockedDataCollector.mockResolvedValue({
+			data: [
+				{
+					model_id: "gpt-4",
+					model_type: "chat",
+					inputPrice: 10,
+					outputPrice: 20,
+					cacheReadPrice: 1,
+					cacheCreationPrice: 2,
+				},
+				{
+					model_id: "gpt-3.5",
+					model_type: "chat",
+					inputPrice: 5,
+					outputPrice: 10,
+					cacheReadPrice: 0,
+					cacheCreationPrice: 0,
+				},
+				{
+					model_id: "text-embedding-3",
+					model_type: "embeddings",
+					inputPrice: 1,
+					outputPrice: 0,
+				},
+				{
+					model_id: "whisper-1",
+					model_type: "audio",
+					inputPrice: 6,
+					outputPrice: 0,
+				},
+				{
+					model_id: "dall-e-3",
+					model_type: "images",
+					inputPrice: 40,
+					outputPrice: 0,
+				},
+			],
+		} as any);
+
+		const result = await getPricingExport("db-1");
+
+		expect(result).toEqual({
+			data: {
+				chat: {
+					"gpt-4": {
+						promptPrice: 0.01,
+						completionPrice: 0.02,
+						cacheReadPrice: 0.001,
+						cacheCreationPrice: 0.002,
+					},
+					"gpt-3.5": {
+						promptPrice: 0.005,
+						completionPrice: 0.01,
+					},
+				},
+				embeddings: {
+					"text-embedding-3": 0.001,
+				},
+				audio: {
+					"whisper-1": 0.006,
+				},
+				images: {
+					"dall-e-3": {
+						standard: {
+							"1024x1024": 0.04,
+						},
+					},
+				},
+			},
+		});
+		expect(dataCollector).toHaveBeenCalledWith(
+			expect.objectContaining({ query: expect.stringContaining("cache_read_price_per_m_token") }),
+			"query",
+			"db-1"
+		);
+	});
+});

--- a/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
+++ b/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { withAudit } from "@/lib/audit/route";
+import { withCurrentOrganisationPermission } from "@/lib/rbac/current";
 import { getPricingExport } from "@/lib/platform/pricing/export";
 
 /**
@@ -9,8 +11,11 @@ import { getPricingExport } from "@/lib/platform/pricing/export";
  * and can be shared / used in SDK init:
  *
  *   openlit.init(pricing_json="http://localhost:3000/api/pricing/export/<dbConfigId>")
+ *
+ * withAudit/withCurrentOrganisationPermission are no-op pass-throughs here;
+ * enterprise editions resolve them to real permission + audit checks.
  */
-export async function GET(
+async function GETHandler(
 	_request: NextRequest,
 	{ params }: { params: { dbConfigId: string } }
 ) {
@@ -27,3 +32,7 @@ export async function GET(
 		},
 	});
 }
+
+export const GET = withAudit(
+	withCurrentOrganisationPermission("pricing:export", GETHandler)
+);

--- a/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
+++ b/src/client/src/app/api/pricing/export/[dbConfigId]/route.ts
@@ -1,8 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { dataCollector } from "@/lib/platform/common";
-import { getDBConfigByIdInternal } from "@/lib/db-config";
-import { OPENLIT_PROVIDER_MODELS_TABLE_NAME } from "@/lib/platform/providers/table-details";
-import asaw from "@/utils/asaw";
+import { getPricingExport } from "@/lib/platform/pricing/export";
 
 /**
  * GET /api/pricing/export/[dbConfigId]
@@ -18,86 +15,13 @@ export async function GET(
 	{ params }: { params: { dbConfigId: string } }
 ) {
 	const { dbConfigId } = params;
+	const result = await getPricingExport(dbConfigId);
 
-	if (!dbConfigId) {
-		return NextResponse.json(
-			{ error: "Database config ID is required" },
-			{ status: 400 }
-		);
+	if ("error" in result) {
+		return NextResponse.json({ error: result.error }, { status: result.status });
 	}
 
-	// Validate the dbConfigId exists
-	const [err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: dbConfigId }));
-
-	if (err || !dbConfig?.id) {
-		return NextResponse.json(
-			{ error: "Database config not found" },
-			{ status: 404 }
-		);
-	}
-
-	const query = `
-		SELECT
-			model_id,
-			model_type,
-			input_price_per_m_token as inputPrice,
-			output_price_per_m_token as outputPrice,
-			cache_read_price_per_m_token as cacheReadPrice,
-			cache_creation_price_per_m_token as cacheCreationPrice
-		FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
-		ORDER BY model_type, model_id
-	`;
-
-	const { data, err: queryErr } = await dataCollector(
-		{ query },
-		"query",
-		dbConfig.id
-	);
-
-	if (queryErr) {
-		return NextResponse.json(
-			{ error: "Failed to fetch model pricing" },
-			{ status: 500 }
-		);
-	}
-
-	const models = (data as any[]) || [];
-
-	// Build SDK-compatible pricing.json format
-	const pricing: Record<string, any> = {};
-
-	for (const model of models) {
-		const type = model.model_type || "chat";
-		if (!pricing[type]) {
-			pricing[type] = {};
-		}
-
-		if (type === "chat") {
-			const entry: Record<string, number> = {
-				promptPrice: model.inputPrice / 1000,
-				completionPrice: model.outputPrice / 1000,
-			};
-			if (model.cacheReadPrice > 0) {
-				entry.cacheReadPrice = model.cacheReadPrice / 1000;
-			}
-			if (model.cacheCreationPrice > 0) {
-				entry.cacheCreationPrice = model.cacheCreationPrice / 1000;
-			}
-			pricing[type][model.model_id] = entry;
-		} else if (type === "embeddings") {
-			pricing[type][model.model_id] = model.inputPrice / 1000;
-		} else if (type === "audio") {
-			pricing[type][model.model_id] = model.inputPrice / 1000;
-		} else if (type === "images") {
-			pricing[type][model.model_id] = {
-				standard: {
-					"1024x1024": model.inputPrice / 1000,
-				},
-			};
-		}
-	}
-
-	return NextResponse.json(pricing, {
+	return NextResponse.json(result.data, {
 		headers: {
 			"Cache-Control": "public, max-age=300",
 		},

--- a/src/client/src/lib/platform/pricing/export.ts
+++ b/src/client/src/lib/platform/pricing/export.ts
@@ -1,0 +1,85 @@
+import { dataCollector } from "@/lib/platform/common";
+import { getDBConfigByIdInternal } from "@/lib/db-config";
+import { OPENLIT_PROVIDER_MODELS_TABLE_NAME } from "@/lib/platform/providers/table-details";
+import asaw from "@/utils/asaw";
+
+export type PricingExportResult =
+	| { data: Record<string, any> }
+	| { error: string; status: number };
+
+// Shared by the public (no-auth) CE route and the auth-gated enterprise
+// route so both stay in lockstep with the SDK `pricing_json` format instead
+// of drifting apart as two hand-duplicated copies.
+export async function getPricingExport(
+	dbConfigId: string
+): Promise<PricingExportResult> {
+	if (!dbConfigId) {
+		return { error: "Database config ID is required", status: 400 };
+	}
+
+	const [err, dbConfig] = await asaw(getDBConfigByIdInternal({ id: dbConfigId }));
+
+	if (err || !dbConfig?.id) {
+		return { error: "Database config not found", status: 404 };
+	}
+
+	const query = `
+		SELECT
+			model_id,
+			model_type,
+			input_price_per_m_token as inputPrice,
+			output_price_per_m_token as outputPrice,
+			cache_read_price_per_m_token as cacheReadPrice,
+			cache_creation_price_per_m_token as cacheCreationPrice
+		FROM ${OPENLIT_PROVIDER_MODELS_TABLE_NAME}
+		ORDER BY model_type, model_id
+	`;
+
+	const { data, err: queryErr } = await dataCollector(
+		{ query },
+		"query",
+		dbConfig.id
+	);
+
+	if (queryErr) {
+		return { error: "Failed to fetch model pricing", status: 500 };
+	}
+
+	const models = (data as any[]) || [];
+
+	// Build SDK-compatible pricing.json format
+	const pricing: Record<string, any> = {};
+
+	for (const model of models) {
+		const type = model.model_type || "chat";
+		if (!pricing[type]) {
+			pricing[type] = {};
+		}
+
+		if (type === "chat") {
+			const entry: Record<string, number> = {
+				promptPrice: model.inputPrice / 1000,
+				completionPrice: model.outputPrice / 1000,
+			};
+			if (model.cacheReadPrice > 0) {
+				entry.cacheReadPrice = model.cacheReadPrice / 1000;
+			}
+			if (model.cacheCreationPrice > 0) {
+				entry.cacheCreationPrice = model.cacheCreationPrice / 1000;
+			}
+			pricing[type][model.model_id] = entry;
+		} else if (type === "embeddings") {
+			pricing[type][model.model_id] = model.inputPrice / 1000;
+		} else if (type === "audio") {
+			pricing[type][model.model_id] = model.inputPrice / 1000;
+		} else if (type === "images") {
+			pricing[type][model.model_id] = {
+				standard: {
+					"1024x1024": model.inputPrice / 1000,
+				},
+			};
+		}
+	}
+
+	return { data: pricing };
+}


### PR DESCRIPTION
## Summary
- Downstream forks that add auth to this endpoint duplicate the entire handler body into their own copy, since a Next.js route file has to physically exist at its URL path and can't be re-pointed through a module import the way a plain lib function can. That duplicate has drifted out of sync with this file more than once — most recently it was missing the `cacheReadPrice`/`cacheCreationPrice` fields added in the cached-token pricing work, and still called `getDBConfigById` instead of `getDBConfigByIdInternal`.
- Extracts the actual computation (dbConfigId validation, ClickHouse query, SDK `pricing_json` formatting) out of `app/api/pricing/export/[dbConfigId]/route.ts` into a new `lib/platform/pricing/export.ts` function, `getPricingExport(dbConfigId)`. The route file becomes a thin HTTP adapter around it — same request/response behavior, verified byte-for-byte identical output.
- Wraps the handler with `withAudit`/`withCurrentOrganisationPermission` from `@/lib/audit/route` / `@/lib/rbac/current` — the same neutral extension-point pattern already used by routes like `app/api/evaluation/types/route.ts`. Both are no-op pass-throughs in this repo, so the endpoint's public, unauthenticated behavior is unchanged here. This means a downstream enterprise fork no longer needs a separate hand-duplicated route file with its own auth wrapper at all — this file can be the enterprise route too, since those two imports resolve to the fork's real permission/audit implementations there. That's the actual fix for the drift described above: there's only one copy of this handler now.
- Adds unit test coverage for the extracted function (400/404/500 paths, and the full SDK pricing.json shape including optional cache-price fields) and for the route handler itself (permission-gate wiring, success/error pass-through) — this endpoint previously had no test coverage at all.
- No behavior change to the public API.

## Test plan
- [x] `cd src/client && npx tsc --noEmit`
- [x] `npm test -- --ci` (218 suites / 2668 tests passed)
- [x] `npm run lint`
- [x] New tests cover the extracted function's validation/not-found/query-error/success paths and the route handler's permission-gate wiring + response pass-through

🤖 Generated with [Claude Code](https://claude.com/claude-code)