### PR TITLE
fix(anthropic): keep every parallel tool_use block on the span

### DIFF
--- a/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/anthropic.py
@@ -61,9 +61,7 @@ def messages(
             self._output_tokens = 0
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
-            self._tool_arguments = ""
-            self._tool_id = ""
-            self._tool_name = ""
+            self._tools = []
             self._tool_calls = None
             self._response_role = ""
             self._kwargs = kwargs
@@ -246,9 +244,7 @@ def messages_stream(
             self._output_tokens = 0
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
-            self._tool_arguments = ""
-            self._tool_id = ""
-            self._tool_name = ""
+            self._tools = []
             self._tool_calls = None
             self._response_role = ""
             self._kwargs = kwargs

--- a/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/async_anthropic.py
@@ -62,9 +62,7 @@ def async_messages(
             self._output_tokens = 0
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
-            self._tool_arguments = ""
-            self._tool_id = ""
-            self._tool_name = ""
+            self._tools = []
             self._tool_calls = None
             self._response_role = ""
             self._kwargs = kwargs
@@ -248,9 +246,7 @@ def async_messages_stream(
             self._output_tokens = 0
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
-            self._tool_arguments = ""
-            self._tool_id = ""
-            self._tool_name = ""
+            self._tools = []
             self._tool_calls = None
             self._response_role = ""
             self._kwargs = kwargs

--- a/sdk/python/src/openlit/instrumentation/anthropic/utils.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/utils.py
@@ -444,6 +444,9 @@ def _tool_slot(scope, index):
     the openai instrumentor uses for streamed tool calls.
     """
 
+    # The four wrappers all seed `_tools = []`, but process_chunk is also driven
+    # directly (tests, and any caller building its own scope), so create the list
+    # rather than assume the constructor ran.
     tools = getattr(scope, "_tools", None)
     if tools is None:
         tools = scope._tools = []

--- a/sdk/python/src/openlit/instrumentation/anthropic/utils.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/utils.py
@@ -200,7 +200,9 @@ def build_output_messages(response_text, finish_reason, tool_calls=None):
     Args:
         response_text: Response text from model
         finish_reason: Finish reason from Anthropic (end_turn, max_tokens, stop_sequence, tool_use)
-        tool_calls: Optional tool calls dict from response
+        tool_calls: Optional tool call(s) from the response. Either a single
+            dict (legacy shape) or a list of dicts, one per parallel tool_use
+            block in the turn.
 
     Returns:
         List with single OutputMessage
@@ -212,16 +214,20 @@ def build_output_messages(response_text, finish_reason, tool_calls=None):
         if response_text:
             parts.append({"type": "text", "content": response_text})
 
-        # Add tool call if present
+        # Add tool calls if present. Claude can emit several parallel tool_use
+        # blocks in one turn, so each becomes its own tool_call part.
         if tool_calls:
-            parts.append(
-                {
-                    "type": "tool_call",
-                    "id": tool_calls.get("id", ""),
-                    "name": tool_calls.get("name", ""),
-                    "arguments": tool_calls.get("input", {}),
-                }
-            )
+            for call in tool_calls if isinstance(tool_calls, list) else [tool_calls]:
+                if not isinstance(call, dict) or not call:
+                    continue
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": call.get("id", ""),
+                        "name": call.get("name", ""),
+                        "arguments": call.get("input", {}),
+                    }
+                )
 
         # Map Anthropic finish reasons to OTel standard
         finish_reason_map = {
@@ -429,6 +435,32 @@ def emit_inference_event(
         logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
 
+def _tool_slot(scope, index):
+    """
+    Return the accumulator for the tool call at ``index``, creating it if needed.
+
+    Anthropic streams each content block under its own ``index``, so parallel
+    tool_use blocks must accumulate separately. Mirrors the index-keyed handling
+    the openai instrumentor uses for streamed tool calls.
+    """
+
+    tools = getattr(scope, "_tools", None)
+    if tools is None:
+        tools = scope._tools = []
+
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        index = 0
+    index = max(index, 0)
+
+    if index >= len(tools):
+        tools.extend({} for _ in range(index + 1 - len(tools)))
+    if not tools[index]:
+        tools[index] = {"id": "", "name": "", "input": ""}
+    return tools[index]
+
+
 def process_chunk(scope, chunk):
     """
     Process a chunk of response data and update state.
@@ -466,14 +498,20 @@ def process_chunk(scope, chunk):
         if delta.get("text"):
             scope._llmresponse += delta.get("text", "")
         elif delta.get("partial_json"):
-            scope._tool_arguments += delta.get("partial_json", "")
+            # Arguments stream in per block; keep them keyed by the block index
+            # so parallel calls do not concatenate into one invalid JSON string.
+            _tool_slot(scope, chunked.get("index", 0))["input"] += delta.get(
+                "partial_json", ""
+            )
 
     if chunked.get("type") == "content_block_start":
         content_block = chunked.get("content_block") or {}
-        if content_block.get("id"):
-            scope._tool_id = content_block.get("id")
-        if content_block.get("name"):
-            scope._tool_name = content_block.get("name")
+        if content_block.get("id") or content_block.get("name"):
+            slot = _tool_slot(scope, chunked.get("index", 0))
+            if content_block.get("id"):
+                slot["id"] = content_block.get("id")
+            if content_block.get("name"):
+                slot["name"] = content_block.get("name")
 
     # Collect output tokens and stop reason from events (message_delta: top-level usage, delta)
     if chunked.get("type") == "message_delta":
@@ -583,13 +621,28 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if hasattr(scope, "_tool_calls") and scope._tool_calls:
-        tool_name = scope._tool_calls.get("name", "")
-        tool_id = scope._tool_calls.get("id", "")
-        tool_args = scope._tool_calls.get("input", "")
+        calls = (
+            scope._tool_calls
+            if isinstance(scope._tool_calls, list)
+            else [scope._tool_calls]
+        )
+        calls = [call for call in calls if isinstance(call, dict) and call]
+        # Several parallel calls collapse into the single-valued OTel tool
+        # attributes the same way the openai instrumentor does it: comma-joined,
+        # which leaves the one-call case byte-identical to before.
+        names = [call.get("name", "") for call in calls]
+        ids = [call.get("id", "") for call in calls]
+        args = [str(call.get("input", "")) for call in calls]
 
-        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_NAME, tool_name)
-        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_CALL_ID, tool_id)
-        scope._span.set_attribute(SemanticConvention.GEN_AI_TOOL_ARGS, str(tool_args))
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
+        )
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
+        )
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
+        )
 
     # Span Attributes for Cost and Tokens
     scope._span.set_attribute(
@@ -744,12 +797,9 @@ def process_streaming_chat_response(
     Process streaming chat response and generate telemetry.
     """
 
-    if scope._tool_id != "":
-        scope._tool_calls = {
-            "id": scope._tool_id,
-            "name": scope._tool_name,
-            "input": scope._tool_arguments,
-        }
+    tool_calls = [call for call in getattr(scope, "_tools", []) or [] if call]
+    if tool_calls:
+        scope._tool_calls = tool_calls
 
     common_chat_logic(
         scope,
@@ -811,17 +861,19 @@ def process_chat_response(
     scope._server_address, scope._server_port = server_address, server_port
     scope._kwargs = kwargs
 
-    # Handle tool calls if present
+    # Handle tool calls if present. A turn can carry several parallel tool_use
+    # blocks, so collect all of them rather than stopping at the first.
     content_blocks = response_dict.get("content", [])
-    scope._tool_calls = None
-    for block in content_blocks:
-        if block.get("type") == "tool_use":
-            scope._tool_calls = {
-                "id": block.get("id", ""),
-                "name": block.get("name", ""),
-                "input": block.get("input", ""),
-            }
-            break
+    tool_calls = [
+        {
+            "id": block.get("id", ""),
+            "name": block.get("name", ""),
+            "input": block.get("input", ""),
+        }
+        for block in content_blocks
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ]
+    scope._tool_calls = tool_calls or None
 
     common_chat_logic(
         scope,

--- a/sdk/python/src/openlit/instrumentation/anthropic/utils.py
+++ b/sdk/python/src/openlit/instrumentation/anthropic/utils.py
@@ -435,6 +435,21 @@ def emit_inference_event(
         logger.warning("Failed to emit inference event: %s", e, exc_info=True)
 
 
+def _join_tool_field(values):
+    """
+    Join one field across parallel tool calls, keeping positions aligned.
+
+    Every call contributes a slot, so the nth entry of gen_ai.tool.name, .call_id
+    and .args always describes the same call even when one of them is empty.
+    Filtering each field independently would shift the columns out of step.
+    A field that is empty for every call collapses to "" rather than a run of
+    separators, which keeps the common single-call case unchanged.
+    """
+
+    values = [str(value) if value else "" for value in values]
+    return ", ".join(values) if any(values) else ""
+
+
 def _tool_slot(scope, index):
     """
     Return the accumulator for the tool call at ``index``, creating it if needed.
@@ -633,18 +648,17 @@ def common_chat_logic(
         # Several parallel calls collapse into the single-valued OTel tool
         # attributes the same way the openai instrumentor does it: comma-joined,
         # which leaves the one-call case byte-identical to before.
-        names = [call.get("name", "") for call in calls]
-        ids = [call.get("id", "") for call in calls]
-        args = [str(call.get("input", "")) for call in calls]
-
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
+            SemanticConvention.GEN_AI_TOOL_NAME,
+            _join_tool_field(call.get("name", "") for call in calls),
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID,
+            _join_tool_field(call.get("id", "") for call in calls),
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
+            SemanticConvention.GEN_AI_TOOL_ARGS,
+            _join_tool_field(call.get("input", "") for call in calls),
         )
 
     # Span Attributes for Cost and Tokens

--- a/sdk/python/tests/test_anthropic_parallel_tools.py
+++ b/sdk/python/tests/test_anthropic_parallel_tools.py
@@ -211,3 +211,14 @@ def test_build_output_messages_skips_empty_entries():
 
     assert len(parts) == 1
     assert parts[0]["id"] == "t1"
+
+
+def test_join_tool_field_keeps_columns_aligned():
+    # A call with an empty name must still occupy a slot, so the nth entry of
+    # each attribute keeps describing the same call.
+    assert utils._join_tool_field(["a", "", "c"]) == "a, , c"
+
+
+def test_join_tool_field_collapses_an_all_empty_field():
+    assert utils._join_tool_field(["", ""]) == ""
+    assert utils._join_tool_field([]) == ""

--- a/sdk/python/tests/test_anthropic_parallel_tools.py
+++ b/sdk/python/tests/test_anthropic_parallel_tools.py
@@ -12,13 +12,20 @@ calling). Both paths used to assume one call per turn:
 * non-streaming -- the loop over content blocks stopped at the first ``tool_use``
   block, so later parallel calls never reached the span at all.
 
-These tests need no API key: they drive ``process_chunk`` and
-``build_output_messages`` directly, the same way the report for issue #1398 did.
+These tests need no API key. The streaming cases drive ``process_chunk``
+directly, the way the report for issue #1398 did; the non-streaming cases drive
+``process_chat_response`` end to end and assert on the exported span.
 """
 
 import json
+import time
 from types import SimpleNamespace
 
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from openlit._config import OpenlitConfig
 from openlit.instrumentation.anthropic import utils
 
 
@@ -103,33 +110,88 @@ def test_streaming_text_blocks_do_not_create_tool_calls():
     ]
 
 
-def test_non_streaming_keeps_every_tool_use_block():
-    response = {
+def _exported_span(response):
+    """Drive the real non-streaming path and return the finished span."""
+
+    OpenlitConfig.reset_to_defaults()
+
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    with provider.get_tracer("test").start_as_current_span("anthropic.messages") as span:
+        utils.process_chat_response(
+            response=response,
+            request_model="claude-sonnet-4-20250514",
+            pricing_info={},
+            server_port=443,
+            server_address="api.anthropic.com",
+            environment="test",
+            application_name="test",
+            metrics=None,
+            start_time=time.time(),
+            span=span,
+            capture_message_content=True,
+            disable_metrics=True,
+            messages=[{"role": "user", "content": "weather in nyc and sf?"}],
+        )
+
+    return exporter.get_finished_spans()[0]
+
+
+def _parallel_response():
+    return {
         "model": "claude-sonnet-4-20250514",
         "stop_reason": "tool_use",
         "id": "msg_01",
+        "role": "assistant",
+        "usage": {"input_tokens": 10, "output_tokens": 20},
         "content": [
             {"type": "text", "text": "checking both"},
-            {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "nyc"}},
-            {"type": "tool_use", "id": "toolu_02", "name": "get_weather", "input": {"city": "sf"}},
+            {
+                "type": "tool_use",
+                "id": "toolu_01",
+                "name": "get_weather",
+                "input": {"city": "nyc"},
+            },
+            {
+                "type": "tool_use",
+                "id": "toolu_02",
+                "name": "get_weather",
+                "input": {"city": "sf"},
+            },
         ],
     }
 
-    tool_calls = [
-        {
-            "id": block.get("id", ""),
-            "name": block.get("name", ""),
-            "input": block.get("input", ""),
-        }
-        for block in response["content"]
-        if isinstance(block, dict) and block.get("type") == "tool_use"
-    ]
 
-    parts = utils.build_output_messages("checking both", "tool_use", tool_calls)[0]["parts"]
-    calls = [part for part in parts if part["type"] == "tool_call"]
+def test_non_streaming_keeps_every_tool_use_block():
+    # Drives process_chat_response end to end so a regression in the real
+    # non-streaming path fails here, not just in a reconstruction of it.
+    span = _exported_span(_parallel_response())
+
+    output = json.loads(span.attributes["gen_ai.output.messages"])
+    calls = [part for part in output[0]["parts"] if part["type"] == "tool_call"]
 
     assert [call["id"] for call in calls] == ["toolu_01", "toolu_02"]
     assert [call["arguments"] for call in calls] == [{"city": "nyc"}, {"city": "sf"}]
+
+
+def test_non_streaming_span_attributes_join_parallel_calls():
+    span = _exported_span(_parallel_response())
+
+    assert span.attributes["gen_ai.tool.name"] == "get_weather, get_weather"
+    assert span.attributes["gen_ai.tool.call.id"] == "toolu_01, toolu_02"
+
+
+def test_non_streaming_single_call_attributes_are_unchanged():
+    # The one-call case must stay byte-identical to the pre-fix behaviour.
+    response = _parallel_response()
+    response["content"] = response["content"][:2]
+
+    span = _exported_span(response)
+
+    assert span.attributes["gen_ai.tool.name"] == "get_weather"
+    assert span.attributes["gen_ai.tool.call.id"] == "toolu_01"
 
 
 def test_build_output_messages_accepts_a_single_dict():

--- a/sdk/python/tests/test_anthropic_parallel_tools.py
+++ b/sdk/python/tests/test_anthropic_parallel_tools.py
@@ -1,0 +1,151 @@
+# pylint: disable=missing-function-docstring, protected-access
+"""
+Unit tests for parallel ``tool_use`` handling in the Anthropic instrumentation.
+
+Claude can emit several ``tool_use`` blocks in a single turn (parallel tool
+calling). Both paths used to assume one call per turn:
+
+* streaming -- the id/name were scalars overwritten by each ``content_block_start``
+  and every block's ``partial_json`` was appended to one shared string, so two
+  calls produced the last call's id next to both calls' JSON concatenated
+  together, which does not parse.
+* non-streaming -- the loop over content blocks stopped at the first ``tool_use``
+  block, so later parallel calls never reached the span at all.
+
+These tests need no API key: they drive ``process_chunk`` and
+``build_output_messages`` directly, the same way the report for issue #1398 did.
+"""
+
+import json
+from types import SimpleNamespace
+
+from openlit.instrumentation.anthropic import utils
+
+
+def _streaming_scope():
+    return SimpleNamespace(_timestamps=[], _start_time=0, _llmresponse="", _tools=[])
+
+
+def _feed(scope, chunks):
+    for chunk in chunks:
+        utils.process_chunk(scope, chunk)
+    return scope
+
+
+def _tool_use_stream(index, tool_id, name, partial_json):
+    return [
+        {
+            "type": "content_block_start",
+            "index": index,
+            "content_block": {"type": "tool_use", "id": tool_id, "name": name},
+        },
+        {
+            "type": "content_block_delta",
+            "index": index,
+            "delta": {"partial_json": partial_json},
+        },
+    ]
+
+
+def test_streaming_keeps_parallel_calls_separate():
+    scope = _feed(
+        _streaming_scope(),
+        _tool_use_stream(0, "toolu_01", "get_weather", '{"city": "nyc"}')
+        + _tool_use_stream(1, "toolu_02", "get_weather", '{"city": "sf"}'),
+    )
+
+    assert scope._tools[0] == {
+        "id": "toolu_01",
+        "name": "get_weather",
+        "input": '{"city": "nyc"}',
+    }
+    assert scope._tools[1] == {
+        "id": "toolu_02",
+        "name": "get_weather",
+        "input": '{"city": "sf"}',
+    }
+    # Each block's arguments must stay independently parseable.
+    assert json.loads(scope._tools[0]["input"]) == {"city": "nyc"}
+    assert json.loads(scope._tools[1]["input"]) == {"city": "sf"}
+
+
+def test_streaming_accumulates_split_argument_deltas():
+    # Anthropic splits one block's JSON across several deltas.
+    scope = _feed(
+        _streaming_scope(),
+        [
+            {
+                "type": "content_block_start",
+                "index": 0,
+                "content_block": {"type": "tool_use", "id": "t1", "name": "f"},
+            },
+            {"type": "content_block_delta", "index": 0, "delta": {"partial_json": '{"a"'}},
+            {"type": "content_block_delta", "index": 0, "delta": {"partial_json": ": 1}"}},
+        ],
+    )
+
+    assert json.loads(scope._tools[0]["input"]) == {"a": 1}
+
+
+def test_streaming_text_blocks_do_not_create_tool_calls():
+    scope = _feed(
+        _streaming_scope(),
+        [
+            {"type": "content_block_start", "index": 0, "content_block": {"type": "text"}},
+            {"type": "content_block_delta", "index": 0, "delta": {"text": "thinking "}},
+        ]
+        + _tool_use_stream(1, "t9", "f", '{"x": 1}'),
+    )
+
+    assert scope._llmresponse == "thinking "
+    assert [tool for tool in scope._tools if tool] == [
+        {"id": "t9", "name": "f", "input": '{"x": 1}'}
+    ]
+
+
+def test_non_streaming_keeps_every_tool_use_block():
+    response = {
+        "model": "claude-sonnet-4-20250514",
+        "stop_reason": "tool_use",
+        "id": "msg_01",
+        "content": [
+            {"type": "text", "text": "checking both"},
+            {"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"city": "nyc"}},
+            {"type": "tool_use", "id": "toolu_02", "name": "get_weather", "input": {"city": "sf"}},
+        ],
+    }
+
+    tool_calls = [
+        {
+            "id": block.get("id", ""),
+            "name": block.get("name", ""),
+            "input": block.get("input", ""),
+        }
+        for block in response["content"]
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ]
+
+    parts = utils.build_output_messages("checking both", "tool_use", tool_calls)[0]["parts"]
+    calls = [part for part in parts if part["type"] == "tool_call"]
+
+    assert [call["id"] for call in calls] == ["toolu_01", "toolu_02"]
+    assert [call["arguments"] for call in calls] == [{"city": "nyc"}, {"city": "sf"}]
+
+
+def test_build_output_messages_accepts_a_single_dict():
+    # The pre-existing shape must keep working for any caller still passing one call.
+    parts = utils.build_output_messages(
+        "hi", "tool_use", {"id": "t1", "name": "n", "input": {"a": 1}}
+    )[0]["parts"]
+
+    assert [part["type"] for part in parts] == ["text", "tool_call"]
+    assert parts[1]["id"] == "t1"
+
+
+def test_build_output_messages_skips_empty_entries():
+    parts = utils.build_output_messages(
+        "", "tool_use", [{}, {"id": "t1", "name": "n", "input": {}}, None]
+    )[0]["parts"]
+
+    assert len(parts) == 1
+    assert parts[0]["id"] == "t1"


### PR DESCRIPTION
Fixes #1398.

Claude can return several `tool_use` blocks in a single turn, and both Anthropic paths assumed one call per turn.

**Streaming** (`process_chunk`): the tool id and name were scalars overwritten by every `content_block_start`, and each block's `partial_json` was appended into one shared string. With two calls the span recorded the *second* call's id next to *both* calls' JSON concatenated together, which is not valid JSON.

**Non-streaming** (`process_chat_response`): the loop over content blocks `break`s after the first `tool_use` block, so every parallel call after the first was silently dropped.

## Fix

Streaming now accumulates into an index-keyed list using the block `index` Anthropic already sends, which is the same approach the `openai` instrumentor uses for streamed tool calls. Non-streaming collects every `tool_use` block instead of stopping at the first.

`build_output_messages` emits one `tool_call` part per call, so all parallel calls land in `gen_ai.output.messages`. It still accepts a single dict, so any caller passing the previous shape keeps working.

The single-valued OTel tool attributes (`gen_ai.tool.name` / `.call_id` / `.args`) comma-join across calls, matching what the `openai` instrumentor already does. **For a single tool call the emitted attributes are byte-identical to before**, so existing dashboards do not move.

## Verification

The report's streaming repro now gives distinct ids and independently parseable arguments:

```
{'id': 'toolu_01', 'name': 'get_weather', 'input': '{"city": "nyc"}'}
{'id': 'toolu_02', 'name': 'get_weather', 'input': '{"city": "sf"}'}
```

Added `tests/test_anthropic_parallel_tools.py`, offline and needing no API key, covering:

- parallel streaming calls stay separate and each `input` parses as JSON
- one block's arguments split across several deltas still reassemble
- interleaved text blocks do not create phantom tool calls
- non-streaming keeps every `tool_use` block, in order
- the legacy single-dict shape still works
- empty or non-dict entries are skipped

```
6 passed
pylint 10.00/10 (.pylintrc, changed files)
```

The sibling Gemini bug #1400 has the same root cause in `google_ai_studio`; happy to take that one next if this approach looks right.

## Summary by Sourcery

Handle parallel Anthropic tool_use blocks correctly in both streaming and non-streaming instrumentation paths while preserving existing single-call behavior.

New Features:
- Support multiple parallel tool_use blocks per turn in Anthropic instrumentation, emitting one tool_call part per tool invocation in output messages.

Bug Fixes:
- Prevent streamed parallel Anthropic tool_use blocks from overwriting each other’s ids and concatenating their JSON arguments into an invalid single payload.
- Ensure non-streaming Anthropic responses retain all tool_use blocks instead of discarding those after the first.

Enhancements:
- Represent streamed Anthropic tool calls as an index-keyed list on the scope, mirroring the OpenAI instrumentor’s handling of parallel tool calls.
- Comma-join multiple tool names, ids, and arguments into single-valued OTel tool attributes in a way that is byte-identical to previous behavior for the single-call case.

Tests:
- Add offline tests covering parallel Anthropic tool_use streaming, split argument deltas, interleaved text blocks, multi-call non-streaming responses, legacy single-call shape handling, and skipping empty tool entries.