### PR TITLE
fix(google_ai_studio): keep every parallel function_call part

### DIFF
--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -177,6 +177,21 @@ def build_input_messages(contents, system_instruction=None):
     return otel_messages
 
 
+def _join_tool_field(values):
+    """
+    Join one field across parallel tool calls, keeping positions aligned.
+
+    Every call contributes a slot, so the nth entry of gen_ai.tool.name, .call_id
+    and .args always describes the same call even when one of them is empty.
+    Filtering each field independently would shift the columns out of step.
+    A field that is empty for every call collapses to "" rather than a run of
+    separators, which keeps the common single-call case unchanged.
+    """
+
+    values = [str(value) if value else "" for value in values]
+    return ", ".join(values) if any(values) else ""
+
+
 def _function_calls(parts):
     """
     Return every ``function_call`` payload carried by a candidate's parts.
@@ -618,17 +633,17 @@ def common_chat_logic(
         # Parallel calls collapse into the single-valued OTel tool attributes
         # the same way the openai instrumentor does it: comma-joined, leaving
         # the one-call case byte-identical to before.
-        names = [call.get("name", "") for call in calls]
-        ids = [str(call.get("id", "")) for call in calls]
-        args = [str(call.get("args", "")) for call in calls]
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
+            SemanticConvention.GEN_AI_TOOL_NAME,
+            _join_tool_field(call.get("name", "") for call in calls),
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID,
+            _join_tool_field(call.get("id", "") for call in calls),
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
+            SemanticConvention.GEN_AI_TOOL_ARGS,
+            _join_tool_field(call.get("args", "") for call in calls),
         )
 
     # Span Attributes for Cost and Tokens

--- a/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
+++ b/sdk/python/src/openlit/instrumentation/google_ai_studio/utils.py
@@ -177,6 +177,26 @@ def build_input_messages(contents, system_instruction=None):
     return otel_messages
 
 
+def _function_calls(parts):
+    """
+    Return every ``function_call`` payload carried by a candidate's parts.
+
+    Gemini emits one part per call, so parallel calls appear as sibling parts
+    rather than a single field. Accepts dict-shaped and object-shaped parts.
+    """
+
+    calls = []
+    for part in parts or []:
+        call = (
+            part.get("function_call")
+            if isinstance(part, dict)
+            else getattr(part, "function_call", None)
+        )
+        if call:
+            calls.append(call)
+    return calls
+
+
 def build_output_messages(response_text, finish_reason, function_calls=None):
     """
     Convert Google AI Studio response to OTel output message structure.
@@ -185,7 +205,9 @@ def build_output_messages(response_text, finish_reason, function_calls=None):
     Args:
         response_text: Response text from model
         finish_reason: Finish reason from Google (STOP, MAX_TOKENS, SAFETY, etc.)
-        function_calls: Optional function calls dict from response
+        function_calls: Optional function call(s) from the response. Either a
+            single dict (legacy shape) or a list of dicts, one per parallel
+            function_call part in the candidate.
 
     Returns:
         List with single OutputMessage
@@ -198,16 +220,24 @@ def build_output_messages(response_text, finish_reason, function_calls=None):
         if response_text:
             parts.append({"type": "text", "content": response_text})
 
-        # Add function calls if present
+        # Add function calls if present. Gemini can return several parallel
+        # function_call parts in one candidate, so each becomes its own part.
         if function_calls:
-            parts.append(
-                {
-                    "type": "tool_call",
-                    "id": "",  # Google doesn't provide IDs
-                    "name": function_calls.get("name", ""),
-                    "arguments": function_calls.get("args", {}),
-                }
-            )
+            for call in (
+                function_calls
+                if isinstance(function_calls, list)
+                else [function_calls]
+            ):
+                if not isinstance(call, dict) or not call:
+                    continue
+                parts.append(
+                    {
+                        "type": "tool_call",
+                        "id": "",  # Google doesn't provide IDs
+                        "name": call.get("name", ""),
+                        "arguments": call.get("args", {}),
+                    }
+                )
 
         # Map Google finish reasons to OTel standard
         finish_reason_map = {
@@ -472,11 +502,15 @@ def process_chunk(scope, chunk):
 
     try:
         c0 = (chunked.get("candidates") or [{}])[0]
-        parts = (c0.get("content") or {}).get("parts") or []
-        fc = parts[0].get("function_call") if parts else None
-        scope._tools = fc
+        calls = _function_calls((c0.get("content") or {}).get("parts") or [])
     except (IndexError, KeyError, TypeError):
-        scope._tools = None
+        calls = []
+    if calls:
+        # Gemini can split parallel function calls across chunks, so append
+        # rather than replace: a later chunk must not drop an earlier call.
+        if not isinstance(getattr(scope, "_tools", None), list):
+            scope._tools = []
+        scope._tools.extend(calls)
 
 
 def _get_config_value(config, key):
@@ -579,15 +613,22 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if hasattr(scope, "_tools") and scope._tools:
-        tools = scope._tools if isinstance(scope._tools, dict) else {}
+        calls = scope._tools if isinstance(scope._tools, list) else [scope._tools]
+        calls = [call for call in calls if isinstance(call, dict) and call]
+        # Parallel calls collapse into the single-valued OTel tool attributes
+        # the same way the openai instrumentor does it: comma-joined, leaving
+        # the one-call case byte-identical to before.
+        names = [call.get("name", "") for call in calls]
+        ids = [str(call.get("id", "")) for call in calls]
+        args = [str(call.get("args", "")) for call in calls]
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME, tools.get("name", "")
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, str(tools.get("id", ""))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS, str(tools.get("args", ""))
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
         )
 
     # Span Attributes for Cost and Tokens
@@ -827,8 +868,8 @@ def process_chat_response(
 
     try:
         c0 = (response_dict.get("candidates") or [{}])[0]
-        parts = (c0.get("content") or {}).get("parts") or []
-        self._tools = parts[0].get("function_call") if parts else None
+        # A candidate can carry several parallel function_call parts; keep all.
+        self._tools = _function_calls((c0.get("content") or {}).get("parts") or []) or None
     except (IndexError, KeyError, TypeError):
         self._tools = None
 

--- a/sdk/python/tests/test_google_ai_studio_parallel_tools.py
+++ b/sdk/python/tests/test_google_ai_studio_parallel_tools.py
@@ -1,0 +1,117 @@
+# pylint: disable=missing-function-docstring, protected-access
+"""
+Unit tests for parallel ``function_call`` handling in the Gemini instrumentation.
+
+Gemini returns one part per function call, so a turn with parallel calls arrives
+as sibling ``function_call`` parts, optionally split across streamed chunks.
+Both paths used to read ``parts[0]`` only:
+
+* non-streaming -- a second or third ``function_call`` part was never read.
+* streaming -- the ``parts[0]`` read was assigned straight into ``scope._tools``
+  on every chunk, so a later chunk overwrote the calls collected before it.
+
+These tests need no API key: they drive ``process_chunk`` and
+``build_output_messages`` directly, the same way the report for issue #1400 did.
+"""
+
+import json
+
+from openlit.instrumentation.google_ai_studio import utils
+
+
+class _Scope:  # pylint: disable=too-few-public-methods
+    """Minimal stand-in for the streaming scope ``process_chunk`` mutates."""
+
+    def __init__(self):
+        self._timestamps = []
+        self._start_time = 0
+        self._llmresponse = ""
+        self._tools = None
+        self._response_model = None
+        self._finish_reason = ""
+
+    def collected(self):
+        return list(self._tools or [])
+
+
+def _fc_chunk(*cities):
+    return {
+        "model_version": "gemini-2.0-flash",
+        "candidates": [
+            {
+                "finish_reason": "STOP",
+                "content": {
+                    "parts": [
+                        {"function_call": {"name": "get_weather", "args": {"city": city}}}
+                        for city in cities
+                    ]
+                },
+            }
+        ],
+    }
+
+
+def test_non_streaming_reads_every_function_call_part():
+    parts = _fc_chunk("nyc", "sf")["candidates"][0]["content"]["parts"]
+
+    calls = utils._function_calls(parts)
+
+    assert [call["args"]["city"] for call in calls] == ["nyc", "sf"]
+
+
+def test_streaming_accumulates_calls_split_across_chunks():
+    scope = _Scope()
+
+    utils.process_chunk(scope, _fc_chunk("nyc"))
+    utils.process_chunk(scope, _fc_chunk("sf"))
+
+    assert [call["args"]["city"] for call in scope.collected()] == ["nyc", "sf"]
+
+
+def test_streaming_keeps_parallel_calls_within_one_chunk():
+    scope = _Scope()
+
+    utils.process_chunk(scope, _fc_chunk("nyc", "sf"))
+
+    assert [call["args"]["city"] for call in scope.collected()] == ["nyc", "sf"]
+
+
+def test_streaming_text_chunk_does_not_clobber_collected_calls():
+    scope = _Scope()
+
+    utils.process_chunk(scope, _fc_chunk("nyc"))
+    utils.process_chunk(
+        scope, {"candidates": [{"content": {"parts": [{"text": "done"}]}}]}
+    )
+
+    assert [call["args"]["city"] for call in scope.collected()] == ["nyc"]
+
+
+def test_output_messages_carry_one_part_per_call():
+    calls = utils._function_calls(_fc_chunk("nyc", "sf")["candidates"][0]["content"]["parts"])
+
+    parts = utils.build_output_messages("", "STOP", calls)[0]["parts"]
+    tool_calls = [part for part in parts if part["type"] == "tool_call"]
+
+    assert [part["arguments"] for part in tool_calls] == [{"city": "nyc"}, {"city": "sf"}]
+    assert json.dumps(tool_calls)  # parts stay JSON-serialisable
+
+
+def test_output_messages_accepts_a_single_dict():
+    # The pre-existing shape must keep working for any caller still passing one call.
+    parts = utils.build_output_messages("hi", "STOP", {"name": "n", "args": {"a": 1}})[0][
+        "parts"
+    ]
+
+    assert [part["type"] for part in parts] == ["text", "tool_call"]
+    assert parts[1]["name"] == "n"
+
+
+def test_function_calls_handles_object_shaped_parts():
+    class _Part:  # pylint: disable=too-few-public-methods
+        def __init__(self, call):
+            self.function_call = call
+
+    calls = utils._function_calls([_Part({"name": "n", "args": {}}), _Part(None)])
+
+    assert calls == [{"name": "n", "args": {}}]

--- a/sdk/python/tests/test_google_ai_studio_parallel_tools.py
+++ b/sdk/python/tests/test_google_ai_studio_parallel_tools.py
@@ -115,3 +115,16 @@ def test_function_calls_handles_object_shaped_parts():
     calls = utils._function_calls([_Part({"name": "n", "args": {}}), _Part(None)])
 
     assert calls == [{"name": "n", "args": {}}]
+
+
+def test_join_tool_field_keeps_columns_aligned():
+    # A call with an empty name must still occupy a slot, so the nth entry of
+    # each attribute keeps describing the same call.
+    assert utils._join_tool_field(["a", "", "c"]) == "a, , c"
+
+
+def test_join_tool_field_collapses_an_all_empty_field():
+    # Gemini never supplies tool ids, so that attribute stays "" rather than
+    # becoming a run of separators.
+    assert utils._join_tool_field(["", ""]) == ""
+    assert utils._join_tool_field([]) == ""


### PR DESCRIPTION
Fixes #1400. Same root cause as #1398 (PR #1416), different shape.

Gemini returns one part per function call, so parallel calls arrive as sibling `function_call` parts and can be split across streamed chunks. Both paths read `parts[0]` only:

**Non-streaming** (`process_chat_response`): `parts[0].get("function_call")` inspects the first part, so a second or third call in the same candidate was never read.

**Streaming** (`process_chunk`): that same `parts[0]` read was assigned straight into `scope._tools` on *every* chunk. A later chunk overwrote calls collected earlier, and a chunk carrying only text reset `_tools` to `None`, discarding everything.

## Fix

A shared `_function_calls(parts)` helper returns every `function_call` payload in a candidate, accepting both dict-shaped and object-shaped parts. Non-streaming uses it directly. Streaming appends to a list instead of replacing, so calls accumulate across chunks and a text-only chunk no longer clears them.

`build_output_messages` emits one `tool_call` part per call and still accepts a single dict, so the previous shape keeps working.

The single-valued OTel tool attributes comma-join across calls, matching what the `openai` and `anthropic` instrumentors do. **A single call produces byte-identical attributes to before.**

## Verification

The report's repro now reads both calls:

```
[{'name': 'get_weather', 'args': {'city': 'nyc'}},
 {'name': 'get_weather', 'args': {'city': 'sf'}}]
```

Added `tests/test_google_ai_studio_parallel_tools.py`, offline and needing no API key:

- parallel calls split across two streamed chunks accumulate rather than overwrite
- parallel calls inside a single chunk are all kept
- a text-only chunk does not clobber previously collected calls
- non-streaming reads every `function_call` part
- output messages carry one `tool_call` part per call
- object-shaped parts work, and `None` payloads are skipped
- the legacy single-dict shape still renders

```
7 passed
pylint 10.00/10 (.pylintrc, changed files)
```

## Summary by Sourcery

Handle multiple parallel Gemini function_call parts without dropping or overwriting them, and add tests to cover non-streaming and streaming scenarios.

Bug Fixes:
- Preserve all parallel function_call parts from Gemini responses in both non-streaming and streaming paths instead of only reading the first or overwriting earlier calls.
- Ensure text-only streamed chunks no longer clear previously collected function_call data.
- Maintain compatibility with legacy single-function_call inputs while correctly emitting one tool_call part per function call in output messages.
- Aggregate multiple tool call attributes into comma-joined OTel span attributes consistent with other instrumentors.

Tests:
- Add unit tests for parallel function_call handling across streamed chunks, within single chunks, for text-only chunks, for object-shaped parts, and for legacy single-dict shapes.