### PR TITLE
fix(instrumentation): handle tool_calls list in groq/ai21/together/reka span attrs (#1438)

### DIFF
--- a/sdk/python/src/openlit/instrumentation/ai21/utils.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/utils.py
@@ -414,16 +414,32 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if scope._tools:
+        tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
+
+        names, ids, args = (
+            zip(
+                *[
+                    (
+                        t.get("function", {}).get("name", ""),
+                        str(t.get("id", "")),
+                        str(t.get("function", {}).get("arguments", "")),
+                    )
+                    for t in tools
+                    if isinstance(t, dict) and t
+                ]
+            )
+            if tools
+            else ([], [], [])
+        )
+
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME,
-            scope._tools.get("function", {}).get("name", ""),
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, str(scope._tools.get("id", ""))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS,
-            str(scope._tools.get("function", {}).get("arguments", "")),
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
         )
 
     # Span Attributes for Cost and Tokens

--- a/sdk/python/src/openlit/instrumentation/ai21/utils.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/utils.py
@@ -416,21 +416,16 @@ def common_chat_logic(
     if scope._tools:
         tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
 
-        names, ids, args = (
-            zip(
-                *[
-                    (
-                        t.get("function", {}).get("name", ""),
-                        str(t.get("id", "")),
-                        str(t.get("function", {}).get("arguments", "")),
-                    )
-                    for t in tools
-                    if isinstance(t, dict) and t
-                ]
+        tool_rows = [
+            (
+                t.get("function", {}).get("name", ""),
+                str(t.get("id", "")),
+                str(t.get("function", {}).get("arguments", "")),
             )
-            if tools
-            else ([], [], [])
-        )
+            for t in tools
+            if isinstance(t, dict) and t
+        ]
+        names, ids, args = zip(*tool_rows) if tool_rows else ([], [], [])
 
         scope._span.set_attribute(
             SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))

--- a/sdk/python/src/openlit/instrumentation/groq/utils.py
+++ b/sdk/python/src/openlit/instrumentation/groq/utils.py
@@ -425,21 +425,16 @@ def common_chat_logic(
     if scope._tools:
         tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
 
-        names, ids, args = (
-            zip(
-                *[
-                    (
-                        t.get("function", {}).get("name", ""),
-                        str(t.get("id", "")),
-                        str(t.get("function", {}).get("arguments", "")),
-                    )
-                    for t in tools
-                    if isinstance(t, dict) and t
-                ]
+        tool_rows = [
+            (
+                t.get("function", {}).get("name", ""),
+                str(t.get("id", "")),
+                str(t.get("function", {}).get("arguments", "")),
             )
-            if tools
-            else ([], [], [])
-        )
+            for t in tools
+            if isinstance(t, dict) and t
+        ]
+        names, ids, args = zip(*tool_rows) if tool_rows else ([], [], [])
 
         scope._span.set_attribute(
             SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))

--- a/sdk/python/src/openlit/instrumentation/groq/utils.py
+++ b/sdk/python/src/openlit/instrumentation/groq/utils.py
@@ -423,16 +423,32 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if scope._tools:
+        tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
+
+        names, ids, args = (
+            zip(
+                *[
+                    (
+                        t.get("function", {}).get("name", ""),
+                        str(t.get("id", "")),
+                        str(t.get("function", {}).get("arguments", "")),
+                    )
+                    for t in tools
+                    if isinstance(t, dict) and t
+                ]
+            )
+            if tools
+            else ([], [], [])
+        )
+
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME,
-            scope._tools.get("function", {}).get("name", ""),
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, str(scope._tools.get("id", ""))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS,
-            str(scope._tools.get("function", {}).get("arguments", "")),
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
         )
 
     # Span Attributes for Cost and Tokens

--- a/sdk/python/src/openlit/instrumentation/reka/utils.py
+++ b/sdk/python/src/openlit/instrumentation/reka/utils.py
@@ -366,15 +366,32 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if scope._tools:
+        tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
+
+        names, ids, args = (
+            zip(
+                *[
+                    (
+                        t.get("name", ""),
+                        str(t.get("id", "")),
+                        str(t.get("parameters", "")),
+                    )
+                    for t in tools
+                    if isinstance(t, dict) and t
+                ]
+            )
+            if tools
+            else ([], [], [])
+        )
+
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME, scope._tools.get("name", "")
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, str(scope._tools.get("id", ""))
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS,
-            str(scope._tools.get("parameters", "")),
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
         )
 
     # Span Attributes for Cost and Tokens

--- a/sdk/python/src/openlit/instrumentation/reka/utils.py
+++ b/sdk/python/src/openlit/instrumentation/reka/utils.py
@@ -368,21 +368,16 @@ def common_chat_logic(
     if scope._tools:
         tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
 
-        names, ids, args = (
-            zip(
-                *[
-                    (
-                        t.get("name", ""),
-                        str(t.get("id", "")),
-                        str(t.get("parameters", "")),
-                    )
-                    for t in tools
-                    if isinstance(t, dict) and t
-                ]
+        tool_rows = [
+            (
+                t.get("name", ""),
+                str(t.get("id", "")),
+                str(t.get("parameters", "")),
             )
-            if tools
-            else ([], [], [])
-        )
+            for t in tools
+            if isinstance(t, dict) and t
+        ]
+        names, ids, args = zip(*tool_rows) if tool_rows else ([], [], [])
 
         scope._span.set_attribute(
             SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -258,15 +258,32 @@ def common_chat_logic(
 
     # Span Attributes for Tools
     if scope._tools:
+        tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
+
+        names, ids, args = (
+            zip(
+                *[
+                    (
+                        t.get("function", {}).get("name", ""),
+                        str(t.get("id", "")),
+                        str(t.get("function", {}).get("arguments", "")),
+                    )
+                    for t in tools
+                    if isinstance(t, dict) and t
+                ]
+            )
+            if tools
+            else ([], [], [])
+        )
+
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_NAME, scope._tools.get("function", "")
-        ).get("name", "")
-        scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_CALL_ID, str(scope._tools.get("id", ""))
+            SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))
         )
         scope._span.set_attribute(
-            SemanticConvention.GEN_AI_TOOL_ARGS,
-            str(scope._tools.get("function", "").get("arguments", "")),
+            SemanticConvention.GEN_AI_TOOL_CALL_ID, ", ".join(filter(None, ids))
+        )
+        scope._span.set_attribute(
+            SemanticConvention.GEN_AI_TOOL_ARGS, ", ".join(filter(None, args))
         )
 
     # Compute system instructions + tool definitions unconditionally so the

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -260,21 +260,16 @@ def common_chat_logic(
     if scope._tools:
         tools = scope._tools if isinstance(scope._tools, list) else [scope._tools]
 
-        names, ids, args = (
-            zip(
-                *[
-                    (
-                        t.get("function", {}).get("name", ""),
-                        str(t.get("id", "")),
-                        str(t.get("function", {}).get("arguments", "")),
-                    )
-                    for t in tools
-                    if isinstance(t, dict) and t
-                ]
+        tool_rows = [
+            (
+                t.get("function", {}).get("name", ""),
+                str(t.get("id", "")),
+                str(t.get("function", {}).get("arguments", "")),
             )
-            if tools
-            else ([], [], [])
-        )
+            for t in tools
+            if isinstance(t, dict) and t
+        ]
+        names, ids, args = zip(*tool_rows) if tool_rows else ([], [], [])
 
         scope._span.set_attribute(
             SemanticConvention.GEN_AI_TOOL_NAME, ", ".join(filter(None, names))


### PR DESCRIPTION
## What

`process_chat_response` in the **groq**, **ai21**, **together** and **reka** instrumentors sets `scope._tools` to the *list* of tool_calls the provider returns, then calls `.get()` on it as if it were a single dict:

```python
scope._tools = response_dict["choices"][0]["message"]["tool_calls"]   # a list
...
scope._tools.get("function", {}).get("name", "")                       # AttributeError
```

Any response containing a tool call raises `AttributeError: 'list' object has no attribute 'get'` inside `process_chat_response`. Each wrapper's `except Exception as e: handle_exception(span, e)` catches it, so the outer LLM call still returns fine — but **the span is silently marked ERROR and every remaining attribute (tokens, cost, response id, tool name/args/id) is dropped.**

`together/utils.py` had an extra defect on top: one line chained `.get("name", "")` onto the return value of `set_attribute()`, which is `None`.

This is the same bug class already fixed for Ollama (#870 / #853) and generalised to most providers by #1002's semconv refactor. #1002 touched groq/ai21/reka's `utils.py` for unrelated renames but never touched this block, and never touched `together/utils.py` at all, so the fix never reached these four providers.

Fixes #1438.

## Fix

Adopt the exact safe list-handling pattern #1002 introduced for `openai/utils.py` — normalise `scope._tools` to a list and join `name`/`id`/`arguments` across all tool calls (reka keeps its top-level `name`/`parameters` shape). A single dict, if one ever slips through, is still handled.

## Verification

Reproduced the crash from the issue with a schema-accurate synthetic response and confirmed the fix, old vs new, for the shared block logic:

```
OLD raises: AttributeError - 'list' object has no attribute 'get'
NEW: {'tool.name': 'get_weather, get_time', 'tool.id': 'call_1, call_2', 'tool.args': '{"city":"SF"}, {}'}
NEW reka: {'tool.name': 'lookup', 'tool.id': 'c1', 'tool.args': '{"q":"x"}'}
NEW single-dict: {'tool.name': 'get_weather', 'tool.id': 'call_1', 'tool.args': '{"city":"SF"}'}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize tool call handling in Groq, AI21, Together, and Reka Python instrumentations so spans correctly record tool metadata from list-based tool_calls responses.

Bug Fixes:
- Prevent AttributeError when processing list-based tool_calls in Groq, AI21, Together, and Reka chat instrumentation, ensuring spans are not erroneously marked as errors and tool-related attributes are preserved.

Enhancements:
- Aggregate tool names, ids, and arguments across multiple tool calls into span attributes for Groq, AI21, Together, and Reka providers, aligning their behavior with the OpenAI instrumentation.