### PR TITLE
fix(go): include Anthropic prompt cache tokens in streaming cost

### DIFF
--- a/sdk/go/config.go
+++ b/sdk/go/config.go
@@ -97,8 +97,10 @@ type Config struct {
 
 // ModelPricing represents pricing information for a model
 type ModelPricing struct {
-	InputCostPerToken  float64
-	OutputCostPerToken float64
+	InputCostPerToken         float64
+	OutputCostPerToken        float64
+	CacheReadCostPerToken     float64
+	CacheCreationCostPerToken float64
 }
 
 // setDefaults sets default values for the configuration

--- a/sdk/go/helpers/pricing.go
+++ b/sdk/go/helpers/pricing.go
@@ -12,27 +12,37 @@ import (
 
 // PricingInfo holds pricing information for a model
 type PricingInfo struct {
-	InputCostPerToken  float64 `json:"input_cost_per_token"`
-	OutputCostPerToken float64 `json:"output_cost_per_token"`
+	InputCostPerToken         float64 `json:"input_cost_per_token"`
+	OutputCostPerToken        float64 `json:"output_cost_per_token"`
+	CacheReadCostPerToken     float64 `json:"cache_read_cost_per_token"`
+	CacheCreationCostPerToken float64 `json:"cache_creation_cost_per_token"`
 }
 
 // PricingCache manages pricing information with automatic fetching
 type PricingCache struct {
-	mu                sync.RWMutex
-	prices            map[string]PricingInfo
-	endpoint          string
-	disableFetch      bool
-	lastFetch         time.Time
-	fetchInterval     time.Duration
-	client            *http.Client
+	mu            sync.RWMutex
+	prices        map[string]PricingInfo
+	endpoint      string
+	disableFetch  bool
+	lastFetch     time.Time
+	fetchInterval time.Duration
+	client        *http.Client
 }
 
 // pricingResponse represents the structure from the pricing JSON
 type pricingResponse struct {
 	Data map[string]struct {
-		Input  float64 `json:"input"`
-		Output float64 `json:"output"`
+		Input         float64 `json:"input"`
+		Output        float64 `json:"output"`
+		CacheRead     float64 `json:"cache_read"`
+		CacheCreation float64 `json:"cache_creation"`
 	} `json:"data"`
+	Chat map[string]struct {
+		PromptPrice        float64 `json:"promptPrice"`
+		CompletionPrice    float64 `json:"completionPrice"`
+		CacheReadPrice     float64 `json:"cacheReadPrice"`
+		CacheCreationPrice float64 `json:"cacheCreationPrice"`
+	} `json:"chat"`
 }
 
 var (
@@ -109,6 +119,12 @@ func (pc *PricingCache) SetPricing(model string, pricing PricingInfo) {
 
 // CalculateCost calculates the cost for input and output tokens
 func (pc *PricingCache) CalculateCost(model string, inputTokens, outputTokens int) float64 {
+	return pc.CalculateCostWithCache(model, inputTokens, outputTokens, 0, 0)
+}
+
+// CalculateCostWithCache calculates cost including Anthropic cache tokens.
+// Cache prices are optional so existing custom pricing remains compatible.
+func (pc *PricingCache) CalculateCostWithCache(model string, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) float64 {
 	pricing, ok := pc.GetPricing(model)
 	if !ok {
 		return 0.0
@@ -116,8 +132,10 @@ func (pc *PricingCache) CalculateCost(model string, inputTokens, outputTokens in
 
 	inputCost := float64(inputTokens) * pricing.InputCostPerToken
 	outputCost := float64(outputTokens) * pricing.OutputCostPerToken
+	cacheReadCost := float64(cacheReadTokens) * pricing.CacheReadCostPerToken
+	cacheCreationCost := float64(cacheCreationTokens) * pricing.CacheCreationCostPerToken
 
-	return inputCost + outputCost
+	return inputCost + outputCost + cacheReadCost + cacheCreationCost
 }
 
 // fetchPricing fetches pricing information from the endpoint
@@ -159,8 +177,23 @@ func (pc *PricingCache) fetchPricing(ctx context.Context) {
 		// Don't override custom pricing
 		if _, exists := pc.prices[normalizedModel]; !exists {
 			pc.prices[normalizedModel] = PricingInfo{
-				InputCostPerToken:  prices.Input,
-				OutputCostPerToken: prices.Output,
+				InputCostPerToken:         prices.Input,
+				OutputCostPerToken:        prices.Output,
+				CacheReadCostPerToken:     prices.CacheRead,
+				CacheCreationCostPerToken: prices.CacheCreation,
+			}
+		}
+	}
+
+	// The repository pricing file stores chat prices per 1,000 tokens.
+	for model, prices := range pricingData.Chat {
+		normalizedModel := normalizeModelName(model)
+		if _, exists := pc.prices[normalizedModel]; !exists {
+			pc.prices[normalizedModel] = PricingInfo{
+				InputCostPerToken:         prices.PromptPrice / 1000,
+				OutputCostPerToken:        prices.CompletionPrice / 1000,
+				CacheReadCostPerToken:     prices.CacheReadPrice / 1000,
+				CacheCreationCostPerToken: prices.CacheCreationPrice / 1000,
 			}
 		}
 	}
@@ -188,6 +221,11 @@ func normalizeModelName(model string) string {
 
 // CalculateGlobalCost is a convenience function using the global cache
 func CalculateGlobalCost(model string, inputTokens, outputTokens int) float64 {
+	return CalculateGlobalCostWithCache(model, inputTokens, outputTokens, 0, 0)
+}
+
+// CalculateGlobalCostWithCache calculates cost including cache token pricing.
+func CalculateGlobalCostWithCache(model string, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens int) float64 {
 	cache := GetGlobalPricingCache()
-	return cache.CalculateCost(model, inputTokens, outputTokens)
+	return cache.CalculateCostWithCache(model, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens)
 }

--- a/sdk/go/helpers/pricing_test.go
+++ b/sdk/go/helpers/pricing_test.go
@@ -1,0 +1,53 @@
+package helpers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCalculateCostWithCache(t *testing.T) {
+	cache := NewPricingCache("", true, map[string]PricingInfo{
+		"claude-test": {
+			InputCostPerToken:         0.001,
+			OutputCostPerToken:        0.002,
+			CacheReadCostPerToken:     0.0001,
+			CacheCreationCostPerToken: 0.003,
+		},
+	})
+
+	got := cache.CalculateCostWithCache("claude-test", 10, 5, 100, 20)
+	want := 10*0.001 + 5*0.002 + 100*0.0001 + 20*0.003
+	if got != want {
+		t.Fatalf("CalculateCostWithCache() = %v, want %v", got, want)
+	}
+
+	if legacy := cache.CalculateCost("claude-test", 10, 5); legacy != 0.02 {
+		t.Fatalf("CalculateCost() = %v, want 0.02", legacy)
+	}
+}
+
+func TestFetchPricingReadsChatCacheRates(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"chat":{"claude-test":{"promptPrice":1,"completionPrice":2,"cacheReadPrice":0.1,"cacheCreationPrice":3}}}`))
+	}))
+	defer server.Close()
+
+	cache := NewPricingCache(server.URL, false, nil)
+	if err := cache.RefreshPricing(context.Background()); err != nil {
+		t.Fatalf("RefreshPricing() error = %v", err)
+	}
+
+	pricing, ok := cache.GetPricing("claude-test")
+	if !ok {
+		t.Fatal("expected fetched pricing")
+	}
+	if pricing.InputCostPerToken != 0.001 || pricing.OutputCostPerToken != 0.002 {
+		t.Fatalf("unexpected regular rates: %+v", pricing)
+	}
+	if pricing.CacheReadCostPerToken != 0.0001 || pricing.CacheCreationCostPerToken != 0.003 {
+		t.Fatalf("unexpected cache rates: %+v", pricing)
+	}
+}

--- a/sdk/go/helpers/pricing_test.go
+++ b/sdk/go/helpers/pricing_test.go
@@ -19,19 +19,24 @@ func TestCalculateCostWithCache(t *testing.T) {
 
 	got := cache.CalculateCostWithCache("claude-test", 10, 5, 100, 20)
 	want := 10*0.001 + 5*0.002 + 100*0.0001 + 20*0.003
-	if got != want {
+	if diff := got - want; diff < -1e-12 || diff > 1e-12 {
 		t.Fatalf("CalculateCostWithCache() = %v, want %v", got, want)
 	}
 
-	if legacy := cache.CalculateCost("claude-test", 10, 5); legacy != 0.02 {
+	legacy := cache.CalculateCost("claude-test", 10, 5)
+	if diff := legacy - 0.02; diff < -1e-12 || diff > 1e-12 {
 		t.Fatalf("CalculateCost() = %v, want 0.02", legacy)
+	}
+
+	if unknown := cache.CalculateCostWithCache("unknown-model", 1, 1, 1, 1); unknown != 0 {
+		t.Fatalf("unknown model cost = %v, want 0", unknown)
 	}
 }
 
 func TestFetchPricingReadsChatCacheRates(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"chat":{"claude-test":{"promptPrice":1,"completionPrice":2,"cacheReadPrice":0.1,"cacheCreationPrice":3}}}`))
+		_, _ = w.Write([]byte(`{"data":{"legacy-model":{"input":0.001,"output":0.002,"cache_read":0.0001,"cache_creation":0.003}},"chat":{"claude-test":{"promptPrice":1,"completionPrice":2,"cacheReadPrice":0.1,"cacheCreationPrice":3}}}`))
 	}))
 	defer server.Close()
 
@@ -47,7 +52,23 @@ func TestFetchPricingReadsChatCacheRates(t *testing.T) {
 	if pricing.InputCostPerToken != 0.001 || pricing.OutputCostPerToken != 0.002 {
 		t.Fatalf("unexpected regular rates: %+v", pricing)
 	}
-	if pricing.CacheReadCostPerToken != 0.0001 || pricing.CacheCreationCostPerToken != 0.003 {
-		t.Fatalf("unexpected cache rates: %+v", pricing)
+	got := pricing.CacheReadCostPerToken
+	if diff := got - 0.0001; diff < -1e-12 || diff > 1e-12 {
+		t.Fatalf("cache read rate = %v, want 0.0001", got)
+	}
+	got = pricing.CacheCreationCostPerToken
+	if diff := got - 0.003; diff < -1e-12 || diff > 1e-12 {
+		t.Fatalf("cache creation rate = %v, want 0.003", got)
+	}
+
+	legacy, ok := cache.GetPricing("legacy-model")
+	if !ok {
+		t.Fatal("expected legacy data pricing")
+	}
+	if diff := legacy.CacheReadCostPerToken - 0.0001; diff < -1e-12 || diff > 1e-12 {
+		t.Fatalf("legacy cache read rate = %v, want 0.0001", legacy.CacheReadCostPerToken)
+	}
+	if diff := legacy.CacheCreationCostPerToken - 0.003; diff < -1e-12 || diff > 1e-12 {
+		t.Fatalf("legacy cache creation rate = %v, want 0.003", legacy.CacheCreationCostPerToken)
 	}
 }

--- a/sdk/go/instrumentation/anthropic/anthropic_test.go
+++ b/sdk/go/instrumentation/anthropic/anthropic_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -577,7 +578,7 @@ func TestCreateMessage_Streaming_CacheUsage(t *testing.T) {
 	if got := attributes[semconv.GenAIUsagePromptTokensDetailsCacheWrite].AsInt64(); got != 20 {
 		t.Errorf("cache creation tokens = %d, want 20", got)
 	}
-	if got := attributes[semconv.GenAIUsageCost].AsFloat64(); got != 0.084 {
+	if got := attributes[semconv.GenAIUsageCost].AsFloat64(); math.Abs(got-0.084) > 1e-12 {
 		t.Errorf("cost = %v, want 0.084", got)
 	}
 }

--- a/sdk/go/instrumentation/anthropic/anthropic_test.go
+++ b/sdk/go/instrumentation/anthropic/anthropic_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 
 	openlit "github.com/openlit/openlit/sdk/go"
+	"github.com/openlit/openlit/sdk/go/helpers"
+	"github.com/openlit/openlit/sdk/go/semconv"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // initSDK initialises OpenLIT with all exporters disabled and registers cleanup.
@@ -498,5 +504,80 @@ func TestCreateMessage_Streaming_Error(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "401") {
 		t.Errorf("expected 401 in streaming error, got: %v", err)
+	}
+}
+
+func TestCreateMessage_Streaming_CacheUsage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		events := []struct{ event, data string }{
+			{"message_start", `{"type":"message_start","message":{"id":"msg-cache","type":"message","role":"assistant","content":[],"model":"claude-cache-test","usage":{"input_tokens":10,"cache_read_input_tokens":100,"cache_creation_input_tokens":20}}}`},
+			{"content_block_delta", `{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cached"}}`},
+			{"message_delta", `{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}`},
+			{"message_stop", `{"type":"message_stop"}`},
+		}
+		for _, event := range events {
+			fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event.event, event.data)
+			w.(http.Flusher).Flush()
+		}
+	}))
+	defer srv.Close()
+
+	helpers.InitGlobalPricingCache("", true, map[string]helpers.PricingInfo{
+		"claude-cache-test": {
+			InputCostPerToken:         0.001,
+			OutputCostPerToken:        0.002,
+			CacheReadCostPerToken:     0.0001,
+			CacheCreationCostPerToken: 0.003,
+		},
+	})
+
+	exporter := tracetest.NewInMemoryExporter()
+	tracerProvider := sdktrace.NewTracerProvider(
+		sdktrace.WithSpanProcessor(sdktrace.NewSimpleSpanProcessor(exporter)),
+	)
+	otel.SetTracerProvider(tracerProvider)
+	t.Cleanup(func() { _ = tracerProvider.Shutdown(context.Background()) })
+
+	client := NewClient("sk-ant-test", WithBaseURL(srv.URL))
+	stream, err := client.CreateMessageStream(context.Background(), MessageRequest{
+		Model:     "claude-cache-test",
+		MaxTokens: 40,
+		Messages:  []Message{{Role: "user", Content: "Hi"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateMessageStream: %v", err)
+	}
+	for {
+		_, err = stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("stream.Recv: %v", err)
+		}
+	}
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(spans))
+	}
+	attributes := make(map[attribute.Key]attribute.Value)
+	for _, kv := range spans[0].Attributes {
+		attributes[kv.Key] = kv.Value
+	}
+
+	if got := attributes[semconv.GenAIUsageTotalTokens].AsInt64(); got != 132 {
+		t.Errorf("total tokens = %d, want 132", got)
+	}
+	if got := attributes[semconv.GenAIUsagePromptTokensDetailsCacheRead].AsInt64(); got != 100 {
+		t.Errorf("cache read tokens = %d, want 100", got)
+	}
+	if got := attributes[semconv.GenAIUsagePromptTokensDetailsCacheWrite].AsInt64(); got != 20 {
+		t.Errorf("cache creation tokens = %d, want 20", got)
+	}
+	if got := attributes[semconv.GenAIUsageCost].AsFloat64(); got != 0.084 {
+		t.Errorf("cost = %v, want 0.084", got)
 	}
 }

--- a/sdk/go/instrumentation/anthropic/instrumentor.go
+++ b/sdk/go/instrumentation/anthropic/instrumentor.go
@@ -99,7 +99,13 @@ func (c *InstrumentedClient) createMessage(ctx context.Context, req MessageReque
 	setResponseAttributes(span, &resp, req.Model, duration)
 
 	if resp.Usage != nil {
-		cost := helpers.CalculateGlobalCost(resp.Model, resp.Usage.InputTokens, resp.Usage.OutputTokens)
+		cost := helpers.CalculateGlobalCostWithCache(
+			resp.Model,
+			resp.Usage.InputTokens,
+			resp.Usage.OutputTokens,
+			resp.Usage.CacheReadInputTokens,
+			resp.Usage.CacheCreationInputTokens,
+		)
 		semconv.SetFloat64Attribute(span, semconv.GenAIUsageCost, cost)
 
 		// Record OTel metrics
@@ -196,15 +202,7 @@ func setResponseAttributes(span trace.Span, resp *MessageResponse, requestModel 
 	}
 
 	if resp.Usage != nil {
-		semconv.SetIntAttribute(span, semconv.GenAIUsageInputTokens, resp.Usage.InputTokens)
-		semconv.SetIntAttribute(span, semconv.GenAIUsageOutputTokens, resp.Usage.OutputTokens)
-		semconv.SetIntAttribute(span, semconv.GenAIUsageTotalTokens, resp.Usage.InputTokens+resp.Usage.OutputTokens)
-		if resp.Usage.CacheCreationInputTokens > 0 {
-			semconv.SetIntAttribute(span, semconv.GenAIUsagePromptTokensDetailsCacheWrite, resp.Usage.CacheCreationInputTokens)
-		}
-		if resp.Usage.CacheReadInputTokens > 0 {
-			semconv.SetIntAttribute(span, semconv.GenAIUsagePromptTokensDetailsCacheRead, resp.Usage.CacheReadInputTokens)
-		}
+		setUsageAttributes(span, resp.Usage)
 	}
 
 	// Extract tool_use blocks from the model's response
@@ -246,6 +244,21 @@ func setResponseAttributes(span trace.Span, resp *MessageResponse, requestModel 
 			{Role: resp.Role, Content: completionText},
 		}
 		semconv.SetMessagesAttribute(span, semconv.GenAIOutputMessages, outputMessages) //nolint:errcheck
+	}
+}
+
+func setUsageAttributes(span trace.Span, usage *Usage) {
+	semconv.SetIntAttribute(span, semconv.GenAIUsageInputTokens, usage.InputTokens)
+	semconv.SetIntAttribute(span, semconv.GenAIUsageOutputTokens, usage.OutputTokens)
+	totalTokens := usage.InputTokens + usage.OutputTokens + usage.CacheReadInputTokens + usage.CacheCreationInputTokens
+	semconv.SetIntAttribute(span, semconv.GenAIUsageTotalTokens, totalTokens)
+	if usage.CacheCreationInputTokens > 0 {
+		semconv.SetIntAttribute(span, semconv.GenAIUsagePromptTokensDetailsCacheWrite, usage.CacheCreationInputTokens)
+		semconv.SetIntAttribute(span, semconv.GenAIUsageCacheCreationInputTokens, usage.CacheCreationInputTokens)
+	}
+	if usage.CacheReadInputTokens > 0 {
+		semconv.SetIntAttribute(span, semconv.GenAIUsagePromptTokensDetailsCacheRead, usage.CacheReadInputTokens)
+		semconv.SetIntAttribute(span, semconv.GenAIUsageCacheReadInputTokens, usage.CacheReadInputTokens)
 	}
 }
 

--- a/sdk/go/instrumentation/anthropic/streaming.go
+++ b/sdk/go/instrumentation/anthropic/streaming.go
@@ -117,6 +117,7 @@ func (c *InstrumentedClient) readStream(ctx context.Context, span trace.Span, bo
 	var messageModel string
 	var stopReason string
 	var inputTokens, outputTokens int
+	var cacheReadInputTokens, cacheCreationInputTokens int
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -161,6 +162,8 @@ func (c *InstrumentedClient) readStream(ctx context.Context, span trace.Span, bo
 				messageModel = event.Message.Model
 				if event.Message.Usage != nil {
 					inputTokens = event.Message.Usage.InputTokens
+					cacheReadInputTokens = event.Message.Usage.CacheReadInputTokens
+					cacheCreationInputTokens = event.Message.Usage.CacheCreationInputTokens
 				}
 			}
 
@@ -180,6 +183,12 @@ func (c *InstrumentedClient) readStream(ctx context.Context, span trace.Span, bo
 			}
 			if event.Usage != nil {
 				outputTokens = event.Usage.OutputTokens
+				if event.Usage.CacheReadInputTokens > 0 {
+					cacheReadInputTokens = event.Usage.CacheReadInputTokens
+				}
+				if event.Usage.CacheCreationInputTokens > 0 {
+					cacheCreationInputTokens = event.Usage.CacheCreationInputTokens
+				}
 			}
 		}
 
@@ -212,12 +221,22 @@ func (c *InstrumentedClient) readStream(ctx context.Context, span trace.Span, bo
 		semconv.SetStringSliceAttribute(span, semconv.GenAIResponseFinishReasons, []string{stopReason})
 	}
 
-	if inputTokens > 0 || outputTokens > 0 {
-		semconv.SetIntAttribute(span, semconv.GenAIUsageInputTokens, inputTokens)
-		semconv.SetIntAttribute(span, semconv.GenAIUsageOutputTokens, outputTokens)
-		semconv.SetIntAttribute(span, semconv.GenAIUsageTotalTokens, inputTokens+outputTokens)
+	if inputTokens > 0 || outputTokens > 0 || cacheReadInputTokens > 0 || cacheCreationInputTokens > 0 {
+		usage := &Usage{
+			InputTokens:              inputTokens,
+			OutputTokens:             outputTokens,
+			CacheReadInputTokens:     cacheReadInputTokens,
+			CacheCreationInputTokens: cacheCreationInputTokens,
+		}
+		setUsageAttributes(span, usage)
 
-		cost := helpers.CalculateGlobalCost(messageModel, inputTokens, outputTokens)
+		cost := helpers.CalculateGlobalCostWithCache(
+			messageModel,
+			inputTokens,
+			outputTokens,
+			cacheReadInputTokens,
+			cacheCreationInputTokens,
+		)
 		semconv.SetFloat64Attribute(span, semconv.GenAIUsageCost, cost)
 
 		// Record OTel metrics

--- a/sdk/go/openlit.go
+++ b/sdk/go/openlit.go
@@ -59,8 +59,10 @@ func Init(cfg Config) error {
 	customPricing := make(map[string]helpers.PricingInfo)
 	for model, p := range cfg.PricingInfo {
 		customPricing[model] = helpers.PricingInfo{
-			InputCostPerToken:  p.InputCostPerToken,
-			OutputCostPerToken: p.OutputCostPerToken,
+			InputCostPerToken:         p.InputCostPerToken,
+			OutputCostPerToken:        p.OutputCostPerToken,
+			CacheReadCostPerToken:     p.CacheReadCostPerToken,
+			CacheCreationCostPerToken: p.CacheCreationCostPerToken,
 		}
 	}
 	helpers.InitGlobalPricingCache(cfg.PricingEndpoint, cfg.DisablePricingFetch, customPricing)


### PR DESCRIPTION
## Summary

Anthropic streaming responses expose `cache_read_input_tokens` and `cache_creation_input_tokens` in the `message_start` usage block. The Go SDK was parsing the fields but dropping them from the final span usage and cost calculation.

That caused Anthropic prompt-cache usage to be under-reported and costs to be too low for streaming requests.

## Changes

- Preserve cache-read and cache-creation token counts through the streaming path.
- Include both cache token classes in `gen_ai.usage.total_tokens` and the existing cache detail attributes.
- Include cache pricing in streaming cost calculation.
- Extend custom and fetched pricing data with cache rates.
- Preserve the existing `CalculateCost` API for callers that do not provide cache counts.
- Add pricing and end-to-end streaming regression tests.

## Verification

- `go test ./...`
- `go vet ./...`
- `git diff --check`

Fixes #1440

## Summary by Sourcery

Include Anthropic prompt cache usage in Go SDK streaming telemetry and cost calculation.

Bug Fixes:
- Ensure Anthropic streaming spans include cache read and cache creation token counts in usage and cost attributes.

Enhancements:
- Extend pricing models, configuration, and helpers to support cache read and cache creation token pricing, including chat pricing sources.
- Unify usage attribute handling so total token counts and cache-related attributes are consistently recorded for both standard and streaming Anthropic responses.

Tests:
- Add unit tests for pricing helpers to cover cache-aware cost calculation and fetched chat cache rates.
- Add an Anthropic streaming regression test to validate prompt cache token usage and cost reporting.