### PR TITLE
fix(python-sdk): relax langchain dependency constraint to >=0.3.15

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -45,6 +45,7 @@ opentelemetry-instrumentation-urllib3 = ">=0.52b0,<1.0.0"
 opentelemetry-instrumentation-system-metrics = {version = ">=0.52b0,<1.0.0", optional = true}
 openai = ">=1.92.0,<3.0.0"
 anthropic = ">=0.42.0,<1.0.0"
+langchain = ">=0.3.15"
 
 [tool.poetry.scripts]
 openlit-instrument = "openlit.cli.main:run"


### PR DESCRIPTION
### Summary

Fixes #949

In sdk/python/pyproject.toml, the langchain dependency was constrained to ^0.3.15 (>=0.3.15, <0.4.0), causing installation and resolution conflicts for projects using newer versions of langchain.

This PR relaxes the dependency constraint to langchain = 