### PR TITLE
docs: add The Grid integration page

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -318,6 +318,7 @@
                   "latest/sdk/integrations/digitalocean-gradient",
                   "latest/sdk/integrations/assemblyai",
                   "latest/sdk/integrations/featherless",
+                  "latest/sdk/integrations/thegrid",
                   "latest/sdk/integrations/reka",
                   "latest/sdk/integrations/krutrim",
                   "latest/sdk/integrations/titan-ml",

--- a/docs/latest/sdk/integrations/overview.mdx
+++ b/docs/latest/sdk/integrations/overview.mdx
@@ -734,6 +734,32 @@ Start integrating and monitoring your applications with OpenLIT in just one line
 
   </Card>
   <Card
+      title="The Grid"
+      href="/latest/sdk/integrations/thegrid"
+      icon={
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M4 3L7.76471 6.40541V8.35135H4V3Z" fill="currentColor"/>
+          <path d="M4 21L7.76471 17.5946V15.6486H4V21Z" fill="currentColor"/>
+          <path d="M20 3L16.2353 6.40541V8.35135H20V3Z" fill="currentColor"/>
+          <path d="M20 21L16.2353 17.5946V15.6486H20V21Z" fill="currentColor"/>
+          <path d="M9.17642 3L11.0588 6.40542V8.35135H9.17642V3Z" fill="currentColor"/>
+          <path d="M9.17642 21L11.0588 17.5946V15.6486H9.17642V21Z" fill="currentColor"/>
+          <path d="M14.8236 3L12.9412 6.40542V8.35135H14.8236V3Z" fill="currentColor"/>
+          <path d="M14.8236 21L12.9412 17.5946V15.6486H14.8236V21Z" fill="currentColor"/>
+          <path d="M4 8.59458L7.7647 10.5405V13.4594L4 15.4054V8.59458Z" fill="currentColor"/>
+          <path d="M9.17642 8.59457L11.0588 10.5405V13.4594L9.17642 15.4054V8.59457Z" fill="currentColor"/>
+          <path d="M14.8236 8.59457L12.9412 10.5405V13.4594L14.8236 15.4054V8.59457Z" fill="currentColor"/>
+          <path d="M20 8.59458L16.2353 10.5405V13.4594L20 15.4054V8.59458Z" fill="currentColor"/>
+        </svg>
+      }
+      iconType="duotone"
+    >
+    <div style={{position: "absolute", top: "12px", right: "12px", display: "flex", gap: "4px"}}>
+      <img src="https://cdn.simpleicons.org/python/ffa500" width="16" height="16" alt="Python SDK" title="Python SDK" />
+    </div>
+
+  </Card>
+  <Card
       title="Reka AI"
       href="/latest/sdk/integrations/reka"
       icon={

--- a/docs/latest/sdk/integrations/thegrid.mdx
+++ b/docs/latest/sdk/integrations/thegrid.mdx
@@ -1,0 +1,56 @@
+---
+title: 'Monitor The Grid using OpenTelemetry'
+description: 'OpenLIT auto-instruments The Grid instruments (via the OpenAI SDK) with OpenTelemetry, enabling AI observability with token usage and latency monitoring.'
+sidebarTitle: 'The Grid'
+---
+
+import IntegrationMethods from '/snippets/integration-methods.mdx';
+
+OpenLIT uses OpenTelemetry Auto-Instrumentation to help you monitor LLM applications built using The Grid. This includes tracking performance, token usage, costs, and how users interact with the application.
+
+Auto-instrumentation means you don't have to set up monitoring manually for different LLMs, frameworks, or databases. By simply adding OpenLIT in your application, all the necessary monitoring configurations are automatically set up.
+
+As The Grid uses the OpenAI SDK, This integration is compatible with  
+- OpenAI Python SDK client `>=1.92.0`, matching the `openai` constraint in OpenLIT's own `pyproject.toml` 
+
+## Get started 
+
+<Steps>
+  <Step title="Install OpenLIT">
+    Open your command line or terminal and run:
+    ```shell
+    pip install openlit
+    ```
+  </Step>
+  <IntegrationMethods />
+</Steps>
+
+<Note>
+The Grid addresses capability tiers rather than a specific lab's model name: `text-standard`, `code-prime` and `agent-max` each route to a current model for that tier. The span records the resolved model, so traces show which model actually served the request.
+</Note>
+
+<Warning>
+**Cost is not calculated for The Grid out of the box.** The Grid is market-priced and publishes no per-token rate, so it has no entry in OpenLIT's bundled `pricing.json`. You get spans, token counts and latency, but the cost attribute will be absent.
+
+To get cost, point `openlit.init()` at your own pricing document:
+
+```python
+openlit.init(pricing_json="https://your-host/pricing.json")
+```
+
+See [SDK pricing](/latest/openlit/costs/manage-models/sdk-pricing) for the expected shape.
+</Warning>
+
+---
+
+<CardGroup cols={3}>
+  <Card title="Quickstart: LLM Observability" href="/latest/sdk/quickstart-ai-observability" icon='bolt'>
+    Production-ready AI monitoring setup in 2 simple steps with zero code changes
+  </Card>
+  <Card title="Configuration" href="/latest/sdk/configuration" icon='bolt'>
+    Configure the OpenLIT SDK according to you requirements.
+  </Card>
+  <Card title="Destinations" href="/latest/sdk/destinations/overview" icon='link'>
+    Send telemetry to Datadog, Grafana, New Relic, and other observability stacks
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

Adds a docs page for **The Grid** to the SDK integrations list, following the Featherless / Krutrim / NVIDIA NIM template for OpenAI-SDK-compatible providers.

Three registration points, no SDK changes:
- `docs/latest/sdk/integrations/thegrid.mdx` (new)
- one nav string in `docs/docs.json`
- a `<Card>` in `docs/latest/sdk/integrations/overview.mdx`

## Why no code

The Grid is an OpenAI-compatible inference marketplace, so `openlit.init()` already traces it through the existing OpenAI instrumentor — `SERVER_ADDRESS` comes out as `api.thegrid.ai` and token usage is recorded normally. There's nothing to add under `sdk/python/src/openlit/instrumentation/`.

## Verified

Checked against the live API with `openai-python 2.48.0`: sync and streaming chat completions both work, and `usage` is populated (prompt/completion tokens) so cost and token metrics have real input.

## On pricing

I deliberately did **not** add entries to `assets/pricing.json`. The Grid's instruments are market-priced and move intraday, so a static per-token float would be wrong shortly after merge. The right home for this is the `pricing_json` URL hook in `openlit.init()` — we'll host an OpenLIT-shaped pricing endpoint on our side rather than ask you to carry numbers that go stale.

Disclosure: I work on The Grid. Happy to trim the framing if it reads too vendor-ish.

## Summary by Sourcery

Add The Grid to the SDK integrations documentation and explain how to monitor it with OpenLIT.

New Features:
- Add documentation for monitoring The Grid through its OpenAI-compatible SDK integration, including setup guidance and pricing configuration details.

Enhancements:
- Register The Grid in the SDK integrations navigation and overview page.

Documentation:
- Document The Grid integration capabilities, supported OpenAI SDK usage, token and latency monitoring, and custom pricing configuration.