### PR TITLE
docs: add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ We are dedicated to continuously improving OpenLIT. Here's a look at what's been
 | [Dataset Generation Based on LLM Events](https://github.com/openlit/openlit/issues/472)                                           | 🔜 Coming Soon |
 | [Search over Traces]()                                                                                                            | 🔜 Coming Soon |
 
+## ☁️ One-Click Deploy
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/openlit/)
+
 ## 🌱 Contributing
 
 Whether it's big or small, we love contributions 💚. Check out our [Contribution guide](./CONTRIBUTING.md) to get started


### PR DESCRIPTION
Added a "One-Click Deploy" section with a RepoCloud deploy button to the README, placed between the Roadmap and Contributing sections.

 - New `## ☁️ One-Click Deploy` section added after the Roadmap table
 - Button links to https://repocloud.io/details/openlit/

## Summary by Sourcery

Documentation:
- Add a README section with a RepoCloud one-click deployment button for OpenLIT.