### PR TITLE
fix(python-sdk): support mistralai 2.x instrumentation paths

### DIFF
--- a/sdk/python/src/openlit/guard/_integration.py
+++ b/sdk/python/src/openlit/guard/_integration.py
@@ -249,6 +249,18 @@ GUARDED_METHODS: List[Tuple[str, str, Extractor, Extractor]] = [
         _extract_generic_input,
         _extract_generic_output,
     ),
+    (
+        "mistralai.client.chat",
+        "Chat.complete",
+        _extract_generic_input,
+        _extract_generic_output,
+    ),
+    (
+        "mistralai.client.chat",
+        "Chat.complete_async",
+        _extract_generic_input,
+        _extract_generic_output,
+    ),
     # Cohere
     (
         "cohere.client_v2",

--- a/sdk/python/src/openlit/instrumentation/mistral/__init__.py
+++ b/sdk/python/src/openlit/instrumentation/mistral/__init__.py
@@ -1,11 +1,13 @@
 """Initializer of Auto Instrumentation of Mistral Functions"""
 
+import logging
 from typing import Collection
 import importlib.metadata
 from opentelemetry import _logs
 from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from wrapt import wrap_function_wrapper
+from wrapt.exceptions import TargetModuleNotFoundError
 
 from openlit._config import OpenlitConfig
 from openlit.instrumentation.mistral.mistral import complete, stream, embed
@@ -16,6 +18,23 @@ from openlit.instrumentation.mistral.async_mistral import (
 )
 
 _instruments = ("mistralai >= 1.0.0",)
+
+logger = logging.getLogger(__name__)
+
+_CHAT_MODULES = ("mistralai.chat", "mistralai.client.chat")
+_EMBEDDINGS_MODULES = ("mistralai.embeddings", "mistralai.client.embeddings")
+
+
+def _safe_wrap(module, class_method, wrapper):
+    """Wrap a function, skipping SDK module layouts that are not installed."""
+    try:
+        wrap_function_wrapper(module, class_method, wrapper)
+    except (ModuleNotFoundError, TargetModuleNotFoundError, AttributeError):
+        logger.debug(
+            "Skipping %s.%s — not available in this mistralai version",
+            module,
+            class_method,
+        )
 
 
 class MistralInstrumentor(BaseInstrumentor):
@@ -37,105 +56,107 @@ class MistralInstrumentor(BaseInstrumentor):
         event_provider = _logs.get_logger_provider().get_logger(__name__)
         version = importlib.metadata.version("mistralai")
 
-        # sync chat completions
-        wrap_function_wrapper(
-            "mistralai.chat",
-            "Chat.complete",
-            complete(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-                event_provider,
-            ),
-        )
+        for chat_module in _CHAT_MODULES:
+            # sync chat completions
+            _safe_wrap(
+                chat_module,
+                "Chat.complete",
+                complete(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    event_provider,
+                ),
+            )
 
-        # sync chat streaming
-        wrap_function_wrapper(
-            "mistralai.chat",
-            "Chat.stream",
-            stream(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-                event_provider,
-            ),
-        )
+            # sync chat streaming
+            _safe_wrap(
+                chat_module,
+                "Chat.stream",
+                stream(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    event_provider,
+                ),
+            )
 
-        # sync embeddings
-        wrap_function_wrapper(
-            "mistralai.embeddings",
-            "Embeddings.create",
-            embed(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-            ),
-        )
+            # async chat completions
+            _safe_wrap(
+                chat_module,
+                "Chat.complete_async",
+                async_complete(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    event_provider,
+                ),
+            )
 
-        # async chat completions
-        wrap_function_wrapper(
-            "mistralai.chat",
-            "Chat.complete_async",
-            async_complete(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-                event_provider,
-            ),
-        )
+            # async chat streaming
+            _safe_wrap(
+                chat_module,
+                "Chat.stream_async",
+                async_stream(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                    event_provider,
+                ),
+            )
 
-        # async chat streaming
-        wrap_function_wrapper(
-            "mistralai.chat",
-            "Chat.stream_async",
-            async_stream(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-                event_provider,
-            ),
-        )
+        for embeddings_module in _EMBEDDINGS_MODULES:
+            # sync embeddings
+            _safe_wrap(
+                embeddings_module,
+                "Embeddings.create",
+                embed(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                ),
+            )
 
-        # async embeddings
-        wrap_function_wrapper(
-            "mistralai.embeddings",
-            "Embeddings.create_async",
-            async_embed(
-                version,
-                environment,
-                application_name,
-                tracer,
-                pricing_info,
-                capture_message_content,
-                metrics,
-                disable_metrics,
-            ),
-        )
+            # async embeddings
+            _safe_wrap(
+                embeddings_module,
+                "Embeddings.create_async",
+                async_embed(
+                    version,
+                    environment,
+                    application_name,
+                    tracer,
+                    pricing_info,
+                    capture_message_content,
+                    metrics,
+                    disable_metrics,
+                ),
+            )
 
     def _uninstrument(self, **kwargs):
         pass

--- a/sdk/python/tests/test_guard_integration.py
+++ b/sdk/python/tests/test_guard_integration.py
@@ -4,6 +4,7 @@ import pytest
 
 from openlit.guard._base import GuardDeniedError
 from openlit.guard._integration import (
+    GUARDED_METHODS,
     _extract_openai_input,
     _extract_anthropic_input,
     _extract_generic_input,
@@ -77,6 +78,20 @@ class TestExtractors:
         kwargs = {"prompt": "Generate something"}
         text = _extract_generic_input(kwargs)
         assert text == "Generate something"
+
+
+def test_guarded_methods_include_mistral_v1_and_v2_sdk_layouts():
+    """Mistral SDK 1.x and 2.x expose chat under different modules."""
+    def has_guarded_method(module_path, class_method):
+        return any(
+            method[0] == module_path and method[1] == class_method
+            for method in GUARDED_METHODS
+        )
+
+    assert has_guarded_method("mistralai.chat", "Chat.complete")
+    assert has_guarded_method("mistralai.chat", "Chat.complete_async")
+    assert has_guarded_method("mistralai.client.chat", "Chat.complete")
+    assert has_guarded_method("mistralai.client.chat", "Chat.complete_async")
 
 
 class TestPreflightIntegration:

--- a/sdk/python/tests/test_mistral_instrumentation.py
+++ b/sdk/python/tests/test_mistral_instrumentation.py
@@ -1,0 +1,46 @@
+"""Tests for Mistral instrumentation setup."""
+
+import openlit.instrumentation.mistral as mistral_instrumentation
+from openlit._config import OpenlitConfig
+from openlit.instrumentation.mistral import MistralInstrumentor
+
+
+def test_mistral_instrumentor_registers_v1_and_v2_sdk_layouts(monkeypatch):
+    """Mistral SDK 1.x and 2.x expose chat and embeddings under different modules."""
+    OpenlitConfig.reset_to_defaults()
+    wrapped_targets = []
+
+    monkeypatch.setattr(
+        mistral_instrumentation.importlib.metadata,
+        "version",
+        lambda package_name: "2.9.4",
+    )
+    monkeypatch.setattr(
+        mistral_instrumentation,
+        "wrap_function_wrapper",
+        lambda module, class_method, wrapper: wrapped_targets.append(
+            (module, class_method)
+        ),
+    )
+
+    MistralInstrumentor()._instrument(
+        environment="test",
+        application_name="test",
+        pricing_info={},
+        disable_metrics=True,
+    )
+
+    assert set(wrapped_targets) == {
+        ("mistralai.chat", "Chat.complete"),
+        ("mistralai.chat", "Chat.stream"),
+        ("mistralai.chat", "Chat.complete_async"),
+        ("mistralai.chat", "Chat.stream_async"),
+        ("mistralai.embeddings", "Embeddings.create"),
+        ("mistralai.embeddings", "Embeddings.create_async"),
+        ("mistralai.client.chat", "Chat.complete"),
+        ("mistralai.client.chat", "Chat.stream"),
+        ("mistralai.client.chat", "Chat.complete_async"),
+        ("mistralai.client.chat", "Chat.stream_async"),
+        ("mistralai.client.embeddings", "Embeddings.create"),
+        ("mistralai.client.embeddings", "Embeddings.create_async"),
+    }


### PR DESCRIPTION
**Issue number**:
Fixes #1536

### Change description:

This updates Mistral instrumentation and auto-guard registration to support both Mistral SDK layouts:

- 1.x: mistralai.chat / mistralai.embeddings
- 2.x: mistralai.client.chat / mistralai.client.embeddings

The change keeps backwards compatibility with Mistral 1.x while allowing Mistral 2.x chat and embedding calls to be wrapped correctly.

Tests added:

- Regression coverage for Mistral 1.x and 2.x instrumentation targets
- Regression coverage for Mistral 1.x and 2.x auto-guard targets

Validation:

```bash
pytest tests/test_guard_integration.py tests/test_mistral_instrumentation.py -q
pytest tests/test_guard_integration.py tests/test_guard_pipeline.py tests/test_guard_pii.py tests/test_guard_prompt_injection.py tests/test_mistral_instrumentation.py -q
pylint src/openlit/instrumentation/mistral/__init__.py src/openlit/guard/_integration.py tests/test_guard_integration.py tests/test_mistral_instrumentation.py
poetry check
poetry build
```

### Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] PR title follows Conventional Commit format.
- [x] I have reviewed the contributing guidelines
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

## Summary by Sourcery

Support both Mistral SDK 1.x and 2.x module layouts for instrumentation and guarded chat operations.

Bug Fixes:
- Support Mistral SDK 2.x chat and embedding instrumentation and guard integration while preserving compatibility with 1.x layouts.

Enhancements:
- Make instrumentation resilient to unavailable SDK module layouts so supported targets continue to be registered.

Tests:
- Add regression coverage for Mistral 1.x and 2.x instrumentation and guard targets.