### PR TITLE
fix(python-sdk): capture streamed tool calls

### DIFF
--- a/sdk/python/src/openlit/instrumentation/ai21/utils.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/utils.py
@@ -285,14 +285,33 @@ def process_chunk(scope, chunk):
     chunked = response_as_dict(chunk)
 
     # Collect message IDs and aggregated response from events
-    if (
-        len(chunked.get("choices", [])) > 0
-        and "delta" in chunked.get("choices")[0]
-        and "content" in chunked.get("choices")[0].get("delta", {})
-    ):
-        content = chunked.get("choices")[0].get("delta").get("content")
+    choices = chunked.get("choices", [])
+    if choices and "delta" in choices[0]:
+        delta = choices[0].get("delta", {})
+        content = delta.get("content")
         if content:
             scope._llmresponse += content
+
+        delta_tools = delta.get("tool_calls")
+        if delta_tools:
+            scope._tools = scope._tools or []
+            for tool in delta_tools:
+                index = tool.get("index", 0)
+                scope._tools.extend([{}] * (index + 1 - len(scope._tools)))
+                function = tool.get("function", {})
+                if tool.get("id"):
+                    scope._tools[index] = {
+                        "id": tool["id"],
+                        "function": {
+                            "name": function.get("name", ""),
+                            "arguments": function.get("arguments", ""),
+                        },
+                        "type": tool.get("type", "function"),
+                    }
+                elif scope._tools[index] and "function" in tool:
+                    scope._tools[index]["function"]["arguments"] += function.get(
+                        "arguments", ""
+                    )
 
     # Handle token usage including reasoning tokens and cached tokens
     if chunked.get("usage"):

--- a/sdk/python/src/openlit/instrumentation/groq/utils.py
+++ b/sdk/python/src/openlit/instrumentation/groq/utils.py
@@ -287,6 +287,27 @@ def process_chunk(scope, chunk):
             scope._llmresponse += content
         append_scope_reasoning(scope, extract_reasoning_content(delta, "reasoning"))
 
+        delta_tools = delta.get("tool_calls")
+        if delta_tools:
+            scope._tools = scope._tools or []
+            for tool in delta_tools:
+                index = tool.get("index", 0)
+                scope._tools.extend([{}] * (index + 1 - len(scope._tools)))
+                function = tool.get("function", {})
+                if tool.get("id"):
+                    scope._tools[index] = {
+                        "id": tool["id"],
+                        "function": {
+                            "name": function.get("name", ""),
+                            "arguments": function.get("arguments", ""),
+                        },
+                        "type": tool.get("type", "function"),
+                    }
+                elif scope._tools[index] and "function" in tool:
+                    scope._tools[index]["function"]["arguments"] += function.get(
+                        "arguments", ""
+                    )
+
     if chunked.get("x_groq") is not None:
         if chunked.get("x_groq").get("usage") is not None:
             # Handle token usage including reasoning tokens and cached tokens

--- a/sdk/python/src/openlit/instrumentation/together/utils.py
+++ b/sdk/python/src/openlit/instrumentation/together/utils.py
@@ -66,13 +66,33 @@ def process_chunk(scope, chunk):
 
     chunked = response_as_dict(chunk)
     # Collect message IDs and aggregated response from events
-    if len(chunked.get("choices")) > 0 and (
-        "delta" in chunked.get("choices")[0]
-        and "content" in chunked.get("choices")[0].get("delta")
-    ):
-        content = chunked.get("choices")[0].get("delta").get("content")
+    choices = chunked.get("choices", [])
+    if choices and "delta" in choices[0]:
+        delta = choices[0].get("delta", {})
+        content = delta.get("content")
         if content:
             scope._llmresponse += content
+
+        delta_tools = delta.get("tool_calls")
+        if delta_tools:
+            scope._tools = scope._tools or []
+            for tool in delta_tools:
+                index = tool.get("index", 0)
+                scope._tools.extend([{}] * (index + 1 - len(scope._tools)))
+                function = tool.get("function", {})
+                if tool.get("id"):
+                    scope._tools[index] = {
+                        "id": tool["id"],
+                        "function": {
+                            "name": function.get("name", ""),
+                            "arguments": function.get("arguments", ""),
+                        },
+                        "type": tool.get("type", "function"),
+                    }
+                elif scope._tools[index] and "function" in tool:
+                    scope._tools[index]["function"]["arguments"] += function.get(
+                        "arguments", ""
+                    )
 
     if chunked.get("usage"):
         scope._response_id = chunked.get("id")

--- a/sdk/python/tests/test_streaming_tool_calls.py
+++ b/sdk/python/tests/test_streaming_tool_calls.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+import pytest
+
+from openlit.instrumentation.ai21 import utils as ai21_utils
+from openlit.instrumentation.groq import utils as groq_utils
+from openlit.instrumentation.together import utils as together_utils
+
+
+@pytest.mark.parametrize("utils", [groq_utils, ai21_utils, together_utils])
+def test_streaming_tool_calls_are_accumulated(utils):
+    scope = SimpleNamespace(
+        _timestamps=[],
+        _start_time=0,
+        _llmresponse="",
+        _tools=None,
+    )
+
+    utils.process_chunk(scope, {"choices": [{"delta": {
+        "tool_calls": [{
+            "index": 0,
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"q":"'},
+        }],
+    }}]})
+    utils.process_chunk(scope, {"choices": [{"delta": {
+        "tool_calls": [{
+            "index": 0,
+            "function": {"arguments": "weather"},
+        }],
+    }}]})
+
+    assert scope._tools == [{
+        "id": "call_1",
+        "type": "function",
+        "function": {"name": "lookup", "arguments": '{"q":"weather'},
+    }]


### PR DESCRIPTION
## Problem\nStreaming tool-call deltas from Groq, AI21, and Together were ignored because their process_chunk implementations only populated scope._tools on the non-streaming path.\n\n## Root cause\nThe streaming handlers processed text content but never accumulated delta.tool_calls, leaving common_chat_logic() with no tool data. AI21 and Together also skipped tool-only deltas because their guard required a content field.\n\n## Fix\nAccumulate indexed tool calls and argument fragments in all three streaming handlers, reusing the existing Mistral accumulation behavior.\n\n## Regression test\nAdded a provider-parameterized synthetic streaming test covering the initial tool-call chunk and a subsequent argument fragment.\n\n## Verification\n- python -m pytest sdk/python/tests/test_streaming_tool_calls.py -p no:ddtrace -p no:Faker -p no:anyio\n- Result: 3 passed\n- python -m compileall -q sdk/python/src/openlit/instrumentation/groq sdk/python/src/openlit/instrumentation/ai21 sdk/python/src/openlit/instrumentation/together\n- git diff --check\n\nCloses #1540

## Summary by Sourcery

Preserve streamed tool calls across supported Python SDK providers so downstream chat instrumentation can report them correctly.

Bug Fixes:
- Capture and accumulate streamed tool-call deltas for Groq, AI21, and Together, including fragmented arguments, tool-only chunks, null arguments, and parallel calls.

Tests:
- Add provider-parameterized regression coverage for streamed, fragmented, null, and parallel tool calls.