### PR TITLE
fix(python-sdk): end bedrock streaming span on early break/close

### DIFF
--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -191,9 +191,12 @@ def converse_stream(
                     self.__wrapped_stream.__exit__(exc_type, exc_value, traceback)
             finally:
                 # Finalize on every exit: a break before exhaustion never
-                # hits StopIteration, so the span would leak otherwise.
-                if not exc_type:
-                    self._finalize_streaming_span()
+                # hits StopIteration, so the span would leak otherwise. Also
+                # finalize on exception exits (exc_type set) — the flag in
+                # _finalize_streaming_span keeps a double call a no-op, so the
+                # span is still exported even when the caller aborts the
+                # with-block with an error that never reaches StopIteration.
+                self._finalize_streaming_span()
 
         def __iter__(self):
             return self

--- a/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
+++ b/sdk/python/src/openlit/instrumentation/bedrock/bedrock.py
@@ -178,6 +178,7 @@ def converse_stream(
             self._server_address = server_address
             self._server_port = server_port
             self._event_provider = event_provider
+            self._streaming_response_processed = False
 
         def __enter__(self):
             if hasattr(self.__wrapped_stream, "__enter__"):
@@ -185,8 +186,14 @@ def converse_stream(
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            if hasattr(self.__wrapped_stream, "__exit__"):
-                self.__wrapped_stream.__exit__(exc_type, exc_value, traceback)
+            try:
+                if hasattr(self.__wrapped_stream, "__exit__"):
+                    self.__wrapped_stream.__exit__(exc_type, exc_value, traceback)
+            finally:
+                # Finalize on every exit: a break before exhaustion never
+                # hits StopIteration, so the span would leak otherwise.
+                if not exc_type:
+                    self._finalize_streaming_span()
 
         def __iter__(self):
             return self
@@ -213,24 +220,42 @@ def converse_stream(
                 process_chunk(self, chunk)
                 return chunk
             except StopIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                            event_provider=self._event_provider,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
+
+        def _finalize_streaming_span(self):
+            """Complete and end the span exactly once.
+
+            Called on stream exhaustion and again from close()/manager exit;
+            the flag keeps the double call a no-op so early exits that never
+            see StopIteration still export the span instead of leaking it.
+            """
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        event_provider=self._event_provider,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
+
+        def close(self):
+            """Close the wrapped stream and finalize the span if not ended."""
+            try:
+                if hasattr(self.__wrapped_stream, "close"):
+                    self.__wrapped_stream.close()
+            finally:
+                self._finalize_streaming_span()
 
     def wrapper(wrapped, instance, args, kwargs):
         """

--- a/sdk/python/tests/test_bedrock_stream_span_lifecycle.py
+++ b/sdk/python/tests/test_bedrock_stream_span_lifecycle.py
@@ -1,0 +1,139 @@
+# pylint: disable=protected-access, missing-function-docstring
+"""Regression tests: the Bedrock streaming wrapper must end its span on
+every exit path.
+
+`TracedSyncStream.__next__` ended the span only on `StopIteration`; leaving
+the stream early (a `break` before exhaustion inside a `with` block, or a
+bare `stream.close()`) left the span recording forever, so it was never
+exported and its telemetry was lost. These tests drive the real
+`converse_stream` wrapper factory with a fake client returning Bedrock
+`converse_stream`-shaped chunk dicts, and assert the span ends exactly once
+on each exit path.
+"""
+
+import time
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from openlit._config import OpenlitConfig
+from openlit.instrumentation.bedrock import bedrock as bedrock_mod
+
+CHUNKS = [
+    {"messageStart": {"role": "assistant"}},
+    {"contentBlockDelta": {"delta": {"text": "partial answer"}}},
+    {"contentBlockDelta": {"delta": {"text": " and more"}}},
+    {"messageStop": {"stopReason": "end_turn"}},
+    {"metadata": {"usage": {"inputTokens": 10, "outputTokens": 5}}},
+]
+
+
+def _tracer_with_exporter():
+    OpenlitConfig.reset_to_defaults()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer(__name__), exporter
+
+
+def _factory(tracer):
+    return bedrock_mod.converse_stream(
+        version="test",
+        environment="test",
+        application_name="test",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=True,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+
+class FakeStream:
+    """Iterable of Bedrock chunk dicts shaped like a botocore event stream."""
+
+    def __init__(self):
+        self._it = iter(CHUNKS)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._it)
+
+    def close(self):
+        """Record that the caller closed the stream without draining it."""
+        self.closed = True
+
+
+class FakeClient:
+    """Client shaped like a botocore bedrock-runtime client."""
+
+    def __init__(self):
+        self.stream = FakeStream()
+
+    def converse_stream(self, **kwargs):
+        return {"stream": self.stream}
+
+
+def _make_stream(factory):
+    fake_client_holder = {}
+
+    def fake_create_client(*args, **kwargs):
+        client = FakeClient()
+        fake_client_holder["client"] = client
+        return client
+
+    client = factory(
+        fake_create_client, None, (), {"service_name": "bedrock-runtime"}
+    )
+    stream = client.converse_stream(modelId="amazon.titan-text-express-v1")
+    return stream, fake_client_holder["client"]
+
+
+def test_sync_early_break_inside_with_ends_span():
+    """Leaving the with-block after one chunk must still end the span."""
+    tracer, exporter = _tracer_with_exporter()
+    factory = _factory(tracer)
+
+    stream, _ = _make_stream(factory)
+    with stream:
+        next(stream)  # consume one chunk, then leave the block early
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "early exit must still end and export the span"
+
+
+def test_sync_full_consumption_exports_exactly_one_span():
+    """Draining the stream must export exactly one finished span."""
+    tracer, exporter = _tracer_with_exporter()
+    factory = _factory(tracer)
+
+    stream, _ = _make_stream(factory)
+    with stream:
+        for _ in stream:
+            pass
+
+    time.sleep(0.1)
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_sync_close_finalizes_span():
+    """Calling close() inside the with-block must finalize the span once."""
+    tracer, exporter = _tracer_with_exporter()
+    factory = _factory(tracer)
+
+    stream, fake_client = _make_stream(factory)
+    with stream:
+        next(stream)
+        stream.close()
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "close() must finalize the span exactly once"
+    assert fake_client.stream.closed is True

--- a/sdk/python/tests/test_bedrock_stream_span_lifecycle.py
+++ b/sdk/python/tests/test_bedrock_stream_span_lifecycle.py
@@ -13,6 +13,8 @@ on each exit path.
 
 import time
 
+import pytest
+
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -137,3 +139,26 @@ def test_sync_close_finalizes_span():
     spans = exporter.get_finished_spans()
     assert len(spans) == 1, "close() must finalize the span exactly once"
     assert fake_client.stream.closed is True
+
+
+def test_sync_exception_exit_ends_span():
+    """An exception escaping the with-block must still export the span.
+
+    When the caller's code inside the with-block raises before the stream is
+    exhausted, ``__exit__`` receives a non-None ``exc_type``. The span must
+    still be finalized (and the original exception preserved) instead of
+    leaking -- ``_finalize_streaming_span`` is idempotent, so its explicit
+    flag keeps the double call a no-op.
+    """
+    tracer, exporter = _tracer_with_exporter()
+    factory = _factory(tracer)
+
+    stream, _ = _make_stream(factory)
+    with pytest.raises(RuntimeError, match="boom"):
+        with stream:
+            next(stream)
+            raise RuntimeError("boom")
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "exception exit must still end and export the span"


### PR DESCRIPTION
**Issue number**: #1545

### Change description:

`TracedSyncStream` in the Bedrock `converse_stream` instrumentation ended its span only inside the `StopIteration` branch of `__next__`. `__exit__` merely forwarded to the wrapped botocore stream and there was no `close()`, so any caller that stopped consuming the stream before exhaustion — a `with ... as stream:` block that `break`s out of the loop, or a bare `stream.close()` — left the span recording forever and it was never exported. The whole call (tokens, cost, response) was invisible to the observability backend. This is the normal shape of an agentic tool-calling loop that stops reading a stream once it has what it needs, and it is the Bedrock instance of the same defect already fixed for Anthropic (#1461) and reported for OpenAI (#1454) / Groq-Mistral (#1514/#1515).

The fix mirrors the merged Anthropic implementation (#1461):

- Added an idempotency flag `_streaming_response_processed` (init `False`).
- Extracted the existing `StopIteration` finalization into `_finalize_streaming_span()`, guarded by the flag so the span is completed and exported exactly once.
- `__exit__` now finalizes on clean exit (when no exception escaped the `with` block), so an early `break` still exports the span.
- Added `close()` which closes the wrapped stream (when it has one) and finalizes the span in a `finally`.

### Verification

- Added `sdk/python/tests/test_bedrock_stream_span_lifecycle.py` driving the real `converse_stream` wrapper factory with a synthetic Bedrock event stream and an `InMemorySpanExporter`. Three exit paths each export exactly one finished span:
  - early `break`/leave of the `with` block,
  - full consumption to `StopIteration` (still exactly one span — idempotency),
  - explicit `stream.close()` inside the block.
- `pytest sdk/python/tests/test_bedrock_stream_span_lifecycle.py -q` → `3 passed`.
- Mutation check: reverting only the exit-time finalize makes `test_sync_early_break_inside_with_ends_span` fail with `len == 0` (span leaked); restoring it passes again.
- Existing `test_anthropic_stream_span_lifecycle.py` sync tests still pass (the 2 async cases require `pytest-asyncio`, which is absent in this environment and untouched).

### Checklist

* [x] PR title follows Conventional Commit format.
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

### AI-generated code disclosure

Implemented with AI assistance (OpenCode + muse-spark 1.3) from a self-contained task specification, then reviewed and verified locally for correctness, test coverage, and scope (only `bedrock.py` and the new test file changed; no new dependencies).

Fixes #1545

## Summary by Sourcery

Ensure Bedrock streaming telemetry is completed on every stream lifecycle exit path.

Bug Fixes:
- Ensure Bedrock streaming spans are finalized and exported when streams are exited early, explicitly closed, fully consumed, or terminated by an exception.

Enhancements:
- Make streaming span finalization idempotent so each response produces exactly one completed span.

Tests:
- Add lifecycle regression tests covering early exit, full consumption, explicit close, and exception exit paths.