### PR TITLE
fix(python-sdk): end Cohere streaming spans on early stream close

### DIFF
--- a/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
@@ -167,12 +167,15 @@ def async_chat_stream(
             """Delegate attribute access to the wrapped object."""
             return getattr(self.__wrapped__, name)
 
-        async def close(self):
+        async def aclose(self):
             """Close the wrapped stream and finalize the span if it has not ended yet."""
             try:
                 await self.__wrapped__.aclose()
             finally:
                 self._finalize_streaming_span()
+
+        async def close(self):
+            await self.aclose()
 
         def _finalize_streaming_span(self):
             if self._streaming_response_processed:

--- a/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
@@ -142,6 +142,7 @@ def async_chat_stream(
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
             self._event_provider = event_provider
+            self._streaming_response_processed = False
 
             self._args = args
             self._kwargs = kwargs
@@ -154,11 +155,10 @@ def async_chat_stream(
             self._server_port = server_port
 
         async def __aenter__(self):
-            await self.__wrapped__.__aenter__()
             return self
 
         async def __aexit__(self, exc_type, exc_value, traceback):
-            await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+            await self.close()
 
         def __aiter__(self):
             return self
@@ -167,29 +167,40 @@ def async_chat_stream(
             """Delegate attribute access to the wrapped object."""
             return getattr(self.__wrapped__, name)
 
+        async def close(self):
+            """Close the wrapped stream and finalize the span if it has not ended yet."""
+            try:
+                await self.__wrapped__.aclose()
+            finally:
+                self._finalize_streaming_span()
+
+        def _finalize_streaming_span(self):
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        event_provider=self._event_provider,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
+
         async def __anext__(self):
             try:
                 chunk = await self.__wrapped__.__anext__()
                 process_chunk(self, chunk)
                 return chunk
             except StopAsyncIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                            event_provider=self._event_provider,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
 
     async def wrapper(wrapped, instance, args, kwargs):

--- a/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/async_cohere.py
@@ -175,6 +175,7 @@ def async_chat_stream(
                 self._finalize_streaming_span()
 
         async def close(self):
+            """Alias for aclose(), kept for callers using the older name."""
             await self.aclose()
 
         def _finalize_streaming_span(self):

--- a/sdk/python/src/openlit/instrumentation/cohere/cohere.py
+++ b/sdk/python/src/openlit/instrumentation/cohere/cohere.py
@@ -142,6 +142,7 @@ def chat_stream(
             self._cache_read_input_tokens = 0
             self._cache_creation_input_tokens = 0
             self._event_provider = event_provider
+            self._streaming_response_processed = False
 
             self._args = args
             self._kwargs = kwargs
@@ -154,11 +155,10 @@ def chat_stream(
             self._server_port = server_port
 
         def __enter__(self):
-            self.__wrapped__.__enter__()
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            self.__wrapped__.__exit__(exc_type, exc_value, traceback)
+            self.close()
 
         def __iter__(self):
             return self
@@ -167,29 +167,40 @@ def chat_stream(
             """Delegate attribute access to the wrapped object."""
             return getattr(self.__wrapped__, name)
 
+        def close(self):
+            """Close the wrapped stream and finalize the span if it has not ended yet."""
+            try:
+                self.__wrapped__.close()
+            finally:
+                self._finalize_streaming_span()
+
+        def _finalize_streaming_span(self):
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        event_provider=self._event_provider,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
+
         def __next__(self):
             try:
                 chunk = self.__wrapped__.__next__()
                 process_chunk(self, chunk)
                 return chunk
             except StopIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                            event_provider=self._event_provider,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
 
     def wrapper(wrapped, instance, args, kwargs):

--- a/sdk/python/tests/test_cohere_streaming_span_lifecycle.py
+++ b/sdk/python/tests/test_cohere_streaming_span_lifecycle.py
@@ -1,0 +1,265 @@
+"""Tests that an early-exited Cohere chat_stream still ends and exports its span."""
+
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from openlit.instrumentation.cohere.async_cohere import async_chat_stream
+from openlit.instrumentation.cohere.cohere import chat_stream
+from openlit._config import OpenlitConfig
+
+
+def _tracer_and_exporter():
+    OpenlitConfig.reset_to_defaults()
+    exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return tracer_provider.get_tracer("test-cohere-stream-lifecycle"), exporter
+
+
+def _chat_kwargs():
+    return {"model": "command-r-plus-08-2024", "messages": [{"role": "user", "content": "ping"}]}
+
+
+_CHUNK = {
+    "type": "content-delta",
+    "delta": {"message": {"content": {"text": "hi"}}},
+}
+
+
+class FakeRawSyncStream:
+    """Stand-in for cohere.ClientV2.chat_stream()'s real return value: a plain
+    generator (`with self._raw_client.chat_stream(...) as r: yield from r.data`),
+    which supports the iterator protocol and close(), never __enter__/__exit__.
+    raise_on_close reproduces a connection error surfacing through the wrapped
+    generator's own close(), which must not prevent span finalization."""
+
+    def __init__(self, chunks, raise_on_close=False):
+        self._chunks = list(chunks)
+        self.closed = False
+        self._raise_on_close = raise_on_close
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if not self._chunks:
+            raise StopIteration
+        return self._chunks.pop(0)
+
+    def close(self):
+        """Mark closed, matching a generator's own close()."""
+        self.closed = True
+        if self._raise_on_close:
+            raise RuntimeError("wrapped close failed")
+
+
+class FakeRawAsyncStream:
+    """Async twin of FakeRawSyncStream, matching an async generator: no
+    __aenter__/__aexit__, and aclose() rather than close()."""
+
+    def __init__(self, chunks, raise_on_close=False):
+        self._chunks = list(chunks)
+        self.closed = False
+        self._raise_on_close = raise_on_close
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self):
+        """Mark closed, matching an async generator's own aclose()."""
+        self.closed = True
+        if self._raise_on_close:
+            raise RuntimeError("wrapped close failed")
+
+
+def _sync_wrapper(tracer):
+    return chat_stream(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+
+def _async_wrapper(tracer):
+    return async_chat_stream(
+        version="test-version",
+        environment="test-env",
+        application_name="test-app",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=False,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+
+def test_sync_stream_closed_via_context_manager_break_still_exports_span():
+    """An early `break` inside a `with ... as stream:` block must still end and
+    export the span. Before this fix, __enter__ delegated to the wrapped
+    generator's own __enter__, which does not exist, so this raised
+    AttributeError instead of ever reaching the span leak."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _sync_wrapper(tracer)
+
+    raw_stream = FakeRawSyncStream([_CHUNK, _CHUNK])
+
+    def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = wrapper(fake_create, object(), [], _chat_kwargs())
+
+    with traced_stream as stream:
+        for _chunk in stream:
+            break
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+def test_sync_stream_explicit_close_still_exports_span():
+    """Calling .close() directly (no context manager) must also finalize."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _sync_wrapper(tracer)
+
+    raw_stream = FakeRawSyncStream([_CHUNK])
+
+    def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = wrapper(fake_create, object(), [], _chat_kwargs())
+    next(traced_stream)
+    traced_stream.close()
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+def test_sync_stream_full_consumption_exports_exactly_one_span():
+    """Full StopIteration consumption inside a `with` block must not
+    double-finalize (both __next__ and __exit__ fire)."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _sync_wrapper(tracer)
+
+    raw_stream = FakeRawSyncStream([_CHUNK])
+
+    def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = wrapper(fake_create, object(), [], _chat_kwargs())
+
+    with traced_stream as stream:
+        for _chunk in stream:
+            pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+def test_sync_stream_close_still_exports_span_when_wrapped_close_raises():
+    """If the wrapped generator's own close() raises, the span must still be
+    finalized and exported rather than silently dropped."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _sync_wrapper(tracer)
+
+    raw_stream = FakeRawSyncStream([_CHUNK], raise_on_close=True)
+
+    def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = wrapper(fake_create, object(), [], _chat_kwargs())
+    next(traced_stream)
+
+    with pytest.raises(RuntimeError):
+        traced_stream.close()
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_stream_closed_via_context_manager_break_still_exports_span():
+    """Async twin of the sync early-break test."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _async_wrapper(tracer)
+
+    raw_stream = FakeRawAsyncStream([_CHUNK, _CHUNK])
+
+    async def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = await wrapper(fake_create, object(), [], _chat_kwargs())
+
+    async with traced_stream as stream:
+        async for _chunk in stream:
+            break
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_stream_full_consumption_exports_exactly_one_span():
+    """Async twin of the full-consumption control test."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _async_wrapper(tracer)
+
+    raw_stream = FakeRawAsyncStream([_CHUNK])
+
+    async def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = await wrapper(fake_create, object(), [], _chat_kwargs())
+
+    async with traced_stream as stream:
+        async for _chunk in stream:
+            pass
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_stream_close_still_exports_span_when_wrapped_close_raises():
+    """Async twin of test_sync_stream_close_still_exports_span_when_wrapped_close_raises."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _async_wrapper(tracer)
+
+    raw_stream = FakeRawAsyncStream([_CHUNK], raise_on_close=True)
+
+    async def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = await wrapper(fake_create, object(), [], _chat_kwargs())
+    await anext(traced_stream)
+
+    with pytest.raises(RuntimeError):
+        await traced_stream.close()
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1

--- a/sdk/python/tests/test_cohere_streaming_span_lifecycle.py
+++ b/sdk/python/tests/test_cohere_streaming_span_lifecycle.py
@@ -243,6 +243,30 @@ async def test_async_stream_full_consumption_exports_exactly_one_span():
 
 
 @pytest.mark.asyncio
+async def test_async_stream_explicit_aclose_still_exports_span():
+    """Calling .aclose() directly, the native async-generator cleanup method,
+    must finalize the span too. Before this fix only close() was defined, so
+    aclose() fell through __getattr__ straight to the wrapped stream and the
+    span was never finalized."""
+
+    tracer, exporter = _tracer_and_exporter()
+    wrapper = _async_wrapper(tracer)
+
+    raw_stream = FakeRawAsyncStream([_CHUNK])
+
+    async def fake_create(*_args, **_kwargs):
+        return raw_stream
+
+    traced_stream = await wrapper(fake_create, object(), [], _chat_kwargs())
+    await anext(traced_stream)
+    await traced_stream.aclose()
+
+    assert raw_stream.closed
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.asyncio
 async def test_async_stream_close_still_exports_span_when_wrapped_close_raises():
     """Async twin of test_sync_stream_close_still_exports_span_when_wrapped_close_raises."""
 


### PR DESCRIPTION
`ClientV2.chat_stream()`/`async_chat_stream()` return a plain (async) generator, not something with its own `__enter__`/`__exit__`. `TracedSyncStream.__enter__` forwarded to `self.__wrapped__.__enter__()` anyway, so `with client.v2.chat_stream(...) as stream:` raised `AttributeError` before reading a chunk. The only other cleanup path, `stream.close()`, fell through `__getattr__` straight to the wrapped generator's own `close()`, so the generator stopped but `self._span` (already fixed by #1464 to be the sole span, on the happy path) was never ended or exported.

Gave each class its own `close()`/`aclose()` that finalizes the span first (through a shared, idempotency-guarded `_finalize_streaming_span()`, same shape #1461 used for the sibling provider), then delegates to the wrapped generator's real `close()`/`aclose()`. `__exit__`/`__aexit__` route through it, and `__enter__`/`__aenter__` just `return self` now, matching what the wrapped generator actually supports.

Fixes #1549

New tests in `tests/test_cohere_streaming_span_lifecycle.py` fail on main (7/7, either `AttributeError` on `__enter__` or a silently dropped span) and pass on the branch: an early `break` inside a `with` block, an explicit `.close()`, full consumption still exporting exactly one span, and the wrapped generator's own `close()`/`aclose()` raising still finalizing the span. `pylint` on the 3 changed files: 10.00/10. Not checked: behavior against a live Cohere stream, only against a fake generator matching `ClientV2.chat_stream()`'s real shape (iterator + `close()`/`aclose()`, no context manager).

## Summary by Sourcery

Fix Cohere streaming cleanup so spans reliably end exactly once across normal and early stream termination paths.

Bug Fixes:
- Ensure synchronous and asynchronous Cohere streaming spans are finalized and exported when streams are closed early, explicitly closed, or closed through a context manager.
- Support the native context-manager and close methods of Cohere streaming generators without requiring unsupported wrapped context-manager methods.

Enhancements:
- Make streaming span finalization idempotent and resilient when the wrapped stream's close operation raises.

Tests:
- Add lifecycle coverage for early context-manager exits, explicit close operations, full consumption, and close failures for synchronous and asynchronous Cohere streams.