### PR TITLE
fix(cli): report user-facing command errors

### DIFF
--- a/cli/cmd/openlit/main.go
+++ b/cli/cmd/openlit/main.go
@@ -11,6 +11,8 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/openlit/openlit/cli/internal/coding"
@@ -21,15 +23,21 @@ import (
 )
 
 func main() {
-	root := newRootCmd()
-	if err := root.Execute(); err != nil {
-		// cobra already prints to stderr; just set the exit code.
-		// We never use os.Exit on telemetry-path errors; those swallow
-		// inside the command handlers themselves so the agent never
-		// sees a non-zero exit. Errors here are misuse (bad flags,
-		// unknown subcommands) where exiting non-zero is correct.
+	if execute(os.Args[1:], os.Stdout, os.Stderr) != 0 {
 		os.Exit(1)
 	}
+}
+
+func execute(args []string, stdout, stderr io.Writer) int {
+	root := newRootCmd()
+	root.SetArgs(args)
+	root.SetOut(stdout)
+	root.SetErr(stderr)
+	if err := root.Execute(); err != nil {
+		fmt.Fprintf(stderr, "openlit: %v\n", err)
+		return 1
+	}
+	return 0
 }
 
 func newRootCmd() *cobra.Command {
@@ -55,13 +63,12 @@ Configure the OTLP endpoint and (optional) API key via:
   - or std: OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_HEADERS
   - or file: ~/.config/openlit/config.env (allow-listed keys)
 `,
-		// Suppress cobra's default usage spam on errors that bubble up
-		// from subcommands; the subcommands handle their own messaging.
+		// Suppress cobra's default usage spam on errors that bubble up;
+		// execute reports the concise error instead.
 		SilenceUsage: true,
-		// Errors are printed by cobra by default. We keep that for misuse
-		// errors (bad flags) but swallow telemetry-path errors inside the
-		// subcommand handlers so they never leak to stdout/stderr at all.
-		SilenceErrors: false,
+		// execute prints returned command errors exactly once. Telemetry-path
+		// failures are swallowed inside their handlers and never reach it.
+		SilenceErrors: true,
 	}
 
 	registerSubcommands(root)

--- a/cli/cmd/openlit/main_test.go
+++ b/cli/cmd/openlit/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestExecuteReportsUserFacingErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantText string
+	}{
+		{
+			name:     "unknown doctor flag",
+			args:     []string{"doctor", "--definitely-invalid"},
+			wantText: "unknown flag: --definitely-invalid",
+		},
+		{
+			name:     "invalid configure value",
+			args:     []string{"configure", "--content-capture", "oops"},
+			wantText: `invalid --content-capture "oops"`,
+		},
+		{
+			name:     "missing install vendor",
+			args:     []string{"coding", "install"},
+			wantText: `required flag(s) "vendor" not set`,
+		},
+		{
+			name:     "unknown root command",
+			args:     []string{"definitely-invalid"},
+			wantText: `unknown command "definitely-invalid" for "openlit"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			exitCode := execute(tt.args, &stdout, &stderr)
+
+			if exitCode != 1 {
+				t.Fatalf("execute() exit code = %d, want 1", exitCode)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("execute() stdout = %q, want empty", stdout.String())
+			}
+			if !strings.Contains(stderr.String(), tt.wantText) {
+				t.Errorf("execute() stderr = %q, want it to contain %q", stderr.String(), tt.wantText)
+			}
+			if count := strings.Count(stderr.String(), tt.wantText); count != 1 {
+				t.Errorf("execute() stderr contains error %d times, want once: %q", count, stderr.String())
+			}
+			if strings.Contains(stderr.String(), "Usage:") {
+				t.Errorf("execute() stderr contains usage output: %q", stderr.String())
+			}
+		})
+	}
+}

--- a/cli/cmd/openlit/main_test.go
+++ b/cli/cmd/openlit/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 )
 
@@ -20,7 +19,7 @@ func TestExecuteReportsUserFacingErrors(t *testing.T) {
 		{
 			name:     "invalid configure value",
 			args:     []string{"configure", "--content-capture", "oops"},
-			wantText: `invalid --content-capture "oops"`,
+			wantText: `invalid --content-capture "oops" (allowed: minimal, metadata_only, full)`,
 		},
 		{
 			name:     "missing install vendor",
@@ -47,14 +46,9 @@ func TestExecuteReportsUserFacingErrors(t *testing.T) {
 			if stdout.Len() != 0 {
 				t.Errorf("execute() stdout = %q, want empty", stdout.String())
 			}
-			if !strings.Contains(stderr.String(), tt.wantText) {
-				t.Errorf("execute() stderr = %q, want it to contain %q", stderr.String(), tt.wantText)
-			}
-			if count := strings.Count(stderr.String(), tt.wantText); count != 1 {
-				t.Errorf("execute() stderr contains error %d times, want once: %q", count, stderr.String())
-			}
-			if strings.Contains(stderr.String(), "Usage:") {
-				t.Errorf("execute() stderr contains usage output: %q", stderr.String())
+			wantStderr := "openlit: " + tt.wantText + "\n"
+			if got := stderr.String(); got != wantStderr {
+				t.Errorf("execute() stderr = %q, want %q", got, wantStderr)
 			}
 		})
 	}


### PR DESCRIPTION
> [!IMPORTANT]
> This pull request follows the issue-first workflow and closes #1551.

**Issue number**: Closes #1551

### Change description:

User-facing CLI validation errors currently return exit code 1 without any stdout or stderr output because child commands silence Cobra errors while `main` assumes Cobra has printed them.

This change:

* centralizes command execution and prints returned errors exactly once to stderr with an `openlit:` prefix;
* keeps Cobra usage output suppressed;
* preserves telemetry-hook failure isolation because operational hook errors remain swallowed inside their handlers;
* adds command-level regression coverage for invalid flags, invalid values, missing required flags, and unknown commands.

Verification:

* `go test -race -count=1 ./...`
* `go build -trimpath ./...`
* `go vet ./...`
* Manual check: an invalid `doctor` flag exits 1, writes nothing to stdout, and prints `openlit: unknown flag: --definitely-invalid` to stderr.

### Checklist

* [x] PR title follows Conventional Commit format.
* [x] I have reviewed the [contributing guidelines](https://github.com/openlit/openlit/blob/main/CONTRIBUTING.md)
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/openlit/openlit/pulls) for the same update/change?
* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

No documentation update is needed because this restores normal CLI error reporting and the behavior is covered by command-level tests.

### Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/openlit/openlit/blob/main/LICENSE).

## Summary by Sourcery

Report user-facing CLI command errors consistently without exposing Cobra usage output.

Bug Fixes:
- Restore clear stderr reporting and non-zero exit status for user-facing CLI validation errors, including invalid flags, invalid values, missing required flags, and unknown commands.

Enhancements:
- Centralize CLI execution and error handling while preserving suppressed Cobra usage output and isolation of telemetry-hook failures.

Tests:
- Add command-level regression tests covering representative invalid CLI invocations and ensuring errors are prefixed, emitted once to stderr, and absent from stdout.