### PR TITLE
fix(python-sdk): end ai21 streaming spans on early exit

### DIFF
--- a/sdk/python/src/openlit/instrumentation/ai21/ai21.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/ai21.py
@@ -69,13 +69,20 @@ def chat(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._streaming_response_processed = False
 
         def __enter__(self):
             self.__wrapped__.__enter__()
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            self.__wrapped__.__exit__(exc_type, exc_value, traceback)
+            try:
+                self.__wrapped__.__exit__(exc_type, exc_value, traceback)
+            finally:
+                # Finalize on every exit: a break before exhaustion never
+                # hits StopIteration, so the span would leak otherwise.
+                if not exc_type:
+                    self._finalize_streaming_span()
 
         def __iter__(self):
             return self
@@ -90,24 +97,41 @@ def chat(
                 process_chunk(self, chunk)
                 return chunk
             except StopIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                            event_provider=event_provider,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
+
+        def _finalize_streaming_span(self):
+            """Complete and end the span exactly once.
+
+            Called on stream exhaustion and again from close()/manager exit;
+            the flag keeps the double call a no-op so early exits that never
+            see StopIteration still export the span instead of leaking it.
+            """
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        event_provider=event_provider,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
+
+        def close(self):
+            """Close the wrapped stream and finalize the span if not ended."""
+            try:
+                self.__wrapped__.close()
+            finally:
+                self._finalize_streaming_span()
 
     def wrapper(wrapped, instance, args, kwargs):
         """
@@ -263,3 +287,4 @@ def chat_rag(
             return response
 
     return wrapper
+

--- a/sdk/python/src/openlit/instrumentation/ai21/ai21.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/ai21.py
@@ -287,4 +287,3 @@ def chat_rag(
             return response
 
     return wrapper
-

--- a/sdk/python/src/openlit/instrumentation/ai21/async_ai21.py
+++ b/sdk/python/src/openlit/instrumentation/ai21/async_ai21.py
@@ -69,13 +69,20 @@ def async_chat(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._streaming_response_processed = False
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
             return self
 
         async def __aexit__(self, exc_type, exc_value, traceback):
-            await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+            try:
+                await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+            finally:
+                # Finalize on every exit: breaking out of the async loop
+                # never hits StopAsyncIteration, so the span would leak.
+                if not exc_type:
+                    self._finalize_streaming_span()
 
         def __aiter__(self):
             return self
@@ -90,24 +97,35 @@ def async_chat(
                 process_chunk(self, chunk)
                 return chunk
             except StopAsyncIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                            event_provider=event_provider,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
+
+        def _finalize_streaming_span(self):
+            """Complete and end the span exactly once.
+
+            Called on stream exhaustion and again from manager exit; the
+            flag keeps the double call a no-op so early exits that never
+            see StopAsyncIteration still export the span instead of
+            leaking it.
+            """
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                        event_provider=event_provider,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
 
     async def wrapper(wrapped, instance, args, kwargs):
         """

--- a/sdk/python/tests/test_ai21_stream_span_lifecycle.py
+++ b/sdk/python/tests/test_ai21_stream_span_lifecycle.py
@@ -100,6 +100,10 @@ class FakeRawStream:
         self.closed = True
 
 
+async def _fake_create_async(*a, **k):
+    return FakeRawStream()
+
+
 def test_sync_early_break_ends_span():
     """Leaving iteration after one chunk must still end the span."""
     tracer, exporter = _tracer_with_exporter()
@@ -148,7 +152,7 @@ async def test_async_early_break_ends_span():
     tracer, exporter = _tracer_with_exporter()
     wrap = _factory(tracer, is_async=True)
 
-    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    stream = await wrap(_fake_create_async, None, (), REQUEST_KWARGS)
     async with stream:
         await anext(stream)
 
@@ -162,7 +166,7 @@ async def test_async_full_consumption_exports_exactly_one_span():
     tracer, exporter = _tracer_with_exporter()
     wrap = _factory(tracer, is_async=True)
 
-    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    stream = await wrap(_fake_create_async, None, (), REQUEST_KWARGS)
     async with stream:
         async for _ in stream:
             pass

--- a/sdk/python/tests/test_ai21_stream_span_lifecycle.py
+++ b/sdk/python/tests/test_ai21_stream_span_lifecycle.py
@@ -1,0 +1,171 @@
+# pylint: disable=protected-access, missing-function-docstring
+"""Regression tests: the AI21 streaming wrappers must end their span on
+every exit path.
+
+`TracedSyncStream.__exit__` / `TracedAsyncStream.__aexit__` only forwarded to
+the wrapped stream, and the span ended solely in the `StopIteration` /
+`StopAsyncIteration` handler. Leaving iteration early (a `break` before
+exhaustion, or a bare `stream.close()`) left the span recording forever, so
+it was never exported and its telemetry was lost — the AI21 instance of the
+early-close streaming bug filed for OpenAI in #1454 and fixed for Anthropic
+in #1461. These tests drive the real `chat` / `async_chat` wrapper factories
+with synthetic OpenAI-shaped dict chunks, and assert the span ends exactly
+once on each exit path.
+"""
+
+import time
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from openlit._config import OpenlitConfig
+from openlit.instrumentation.ai21 import ai21 as sync_mod
+from openlit.instrumentation.ai21 import async_ai21 as async_mod
+
+REQUEST_KWARGS = {
+    "model": "jamba-1.5-mini",
+    "messages": [{"role": "user", "content": "hi"}],
+    "stream": True,
+}
+
+CHUNKS = [
+    {"id": "chatcmpl-ai21", "choices": [{"delta": {"content": "pa"}, "finish_reason": None}]},
+    {"id": "chatcmpl-ai21", "choices": [{"delta": {"content": "rtial answer"}, "finish_reason": None}]},
+    {"id": "chatcmpl-ai21", "choices": [{"delta": {}, "finish_reason": "stop"}]},
+]
+
+
+def _tracer_with_exporter():
+    OpenlitConfig.reset_to_defaults()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer(__name__), exporter
+
+
+def _factory(tracer, *, is_async):
+    mod = async_mod if is_async else sync_mod
+    make = mod.async_chat if is_async else mod.chat
+    return make(
+        version="test",
+        environment="test",
+        application_name="test",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=True,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+
+class FakeRawStream:
+    """Sync/async event stream shaped like an OpenAI-style chunk iterator."""
+
+    def __init__(self):
+        self._it = iter(CHUNKS)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._it)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def close(self):
+        """Record that the caller closed the stream without draining it."""
+        self.closed = True
+
+
+def test_sync_early_break_ends_span():
+    """Leaving iteration after one chunk must still end the span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        next(stream)  # consume one chunk, then leave the block early
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "early exit must still end and export the span"
+
+
+def test_sync_full_consumption_exports_exactly_one_span():
+    """Draining the sync stream must export exactly one finished span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        for _ in stream:
+            pass
+
+    time.sleep(0.1)
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_sync_close_finalizes_span():
+    """Calling close() mid-iteration must finalize the span once."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        next(stream)
+        stream.close()
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "close() must finalize the span exactly once"
+
+
+async def test_async_early_break_ends_span():
+    """Leaving async iteration after one chunk must still end the span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=True)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    async with stream:
+        await anext(stream)
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "early async exit must still end and export the span"
+
+
+async def test_async_full_consumption_exports_exactly_one_span():
+    """Draining the async stream must export exactly one finished span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=True)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    async with stream:
+        async for _ in stream:
+            pass
+
+    time.sleep(0.1)
+    assert len(exporter.get_finished_spans()) == 1


### PR DESCRIPTION
**Issue number**: #1553

### Change description:
Ports the idempotent-finalizer shape from #1461 (Anthropic) onto the AI21 sync/async streaming wrappers. `TracedSyncStream.__exit__` / `TracedAsyncStream.__aexit__` previously only forwarded to the wrapped stream, so a `break` before exhaustion (or a bare `close()`) never hit the `StopIteration`/`StopAsyncIteration` handler and the span stayed recording forever — the whole call's tokens/cost were lost.

- `__exit__`/`__aexit__` finalize on non-exception exit (try/finally around the forwarded call)
- new `close()` on the sync wrapper finalizes when the caller closes early
- `_finalize_streaming_span()` guarded by `_streaming_response_processed` so exhaustion + exit double-calls are a no-op
- regression tests `sdk/python/tests/test_ai21_stream_span_lifecycle.py` mirror `test_anthropic_stream_span_lifecycle.py` (early-break / full-drain / close, sync + async)

Root cause: single exit path for span end (exhaustion only). Fix: three exit paths sharing one guarded finalizer. Diff scope: 3 files, +~260/-~40 (2 source, 1 test).

### Checklist
* [x] PR title follows Conventional Commit format.
* [x] I have reviewed the contributing guidelines
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (searched: cohere/bedrock/groq/mistral early-close PRs cover other providers; no ai21 one)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (new lifecycle tests; full matrix left to CI)
* [x] Changes are documented (docstrings on the new methods)

### Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

## Summary by Sourcery

Finalize AI21 streaming spans reliably across exhaustion, early exit, and explicit close paths.

New Features:
- Ensure AI21 synchronous and asynchronous streaming spans are finalized when streams exit before exhaustion.
- Add synchronous stream close support that finalizes telemetry for early-closed streams.

Bug Fixes:
- Prevent AI21 streaming spans and their token/cost telemetry from remaining unfinished after early iteration exit or close.

Enhancements:
- Make streaming span finalization idempotent across exhaustion, explicit close, and context-manager exit.

Tests:
- Add regression coverage for AI21 synchronous and asynchronous early exit, full consumption, and close lifecycle behavior.