### PR TITLE
fix(python-sdk): end together streaming spans on early exit

### DIFF
--- a/sdk/python/src/openlit/instrumentation/together/async_together.py
+++ b/sdk/python/src/openlit/instrumentation/together/async_together.py
@@ -67,13 +67,20 @@ def async_completion(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._streaming_response_processed = False
 
         async def __aenter__(self):
             await self.__wrapped__.__aenter__()
             return self
 
         async def __aexit__(self, exc_type, exc_value, traceback):
-            await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+            try:
+                await self.__wrapped__.__aexit__(exc_type, exc_value, traceback)
+            finally:
+                # Finalize on every exit: breaking out of the async loop
+                # never hits StopIteration, so the span would leak.
+                if not exc_type:
+                    self._finalize_streaming_span()
 
         def __aiter__(self):
             return self
@@ -88,23 +95,33 @@ def async_completion(
                 process_chunk(self, chunk)
                 return chunk
             except StopIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
+
+        def _finalize_streaming_span(self):
+            """Complete and end the span exactly once.
+
+            Called on stream exhaustion and again from manager exit; the
+            flag keeps the double call a no-op so early exits that never
+            see StopIteration still export the span instead of leaking it.
+            """
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
 
     async def wrapper(wrapped, instance, args, kwargs):
         """

--- a/sdk/python/src/openlit/instrumentation/together/together.py
+++ b/sdk/python/src/openlit/instrumentation/together/together.py
@@ -67,13 +67,20 @@ def completion(
             self._tbt = 0
             self._server_address = server_address
             self._server_port = server_port
+            self._streaming_response_processed = False
 
         def __enter__(self):
             self.__wrapped__.__enter__()
             return self
 
         def __exit__(self, exc_type, exc_value, traceback):
-            self.__wrapped__.__exit__(exc_type, exc_value, traceback)
+            try:
+                self.__wrapped__.__exit__(exc_type, exc_value, traceback)
+            finally:
+                # Finalize on every exit: a break before exhaustion never
+                # hits StopIteration, so the span would leak otherwise.
+                if not exc_type:
+                    self._finalize_streaming_span()
 
         def __iter__(self):
             return self
@@ -88,23 +95,40 @@ def completion(
                 process_chunk(self, chunk)
                 return chunk
             except StopIteration:
-                try:
-                    with self._span:
-                        process_streaming_chat_response(
-                            self,
-                            pricing_info=pricing_info,
-                            environment=environment,
-                            application_name=application_name,
-                            metrics=metrics,
-                            capture_message_content=capture_message_content,
-                            disable_metrics=disable_metrics,
-                            version=version,
-                        )
-
-                except Exception as e:
-                    handle_exception(self._span, e)
-
+                self._finalize_streaming_span()
                 raise
+
+        def _finalize_streaming_span(self):
+            """Complete and end the span exactly once.
+
+            Called on stream exhaustion and again from close()/manager exit;
+            the flag keeps the double call a no-op so early exits that never
+            see StopIteration still export the span instead of leaking it.
+            """
+            if self._streaming_response_processed:
+                return
+            self._streaming_response_processed = True
+            try:
+                with self._span:
+                    process_streaming_chat_response(
+                        self,
+                        pricing_info=pricing_info,
+                        environment=environment,
+                        application_name=application_name,
+                        metrics=metrics,
+                        capture_message_content=capture_message_content,
+                        disable_metrics=disable_metrics,
+                        version=version,
+                    )
+            except Exception as e:
+                handle_exception(self._span, e)
+
+        def close(self):
+            """Close the wrapped stream and finalize the span if not ended."""
+            try:
+                self.__wrapped__.close()
+            finally:
+                self._finalize_streaming_span()
 
     def wrapper(wrapped, instance, args, kwargs):
         """

--- a/sdk/python/tests/test_together_stream_span_lifecycle.py
+++ b/sdk/python/tests/test_together_stream_span_lifecycle.py
@@ -1,0 +1,175 @@
+# pylint: disable=protected-access, missing-function-docstring
+"""Regression tests: the Together AI streaming wrappers must end their span on
+every exit path.
+
+`TracedSyncStream.__exit__` / `TracedAsyncStream.__aexit__` only forwarded to
+the wrapped stream, and the span ended solely in the `StopIteration` /
+`StopAsyncIteration` handler. Leaving iteration early (a `break` before
+exhaustion, or a bare `stream.close()`) left the span recording forever, so
+it was never exported and its telemetry was lost — the Together AI instance of the
+early-close streaming bug filed for OpenAI in #1454 and fixed for
+Anthropic in #1461 and AI21 in #1553. These tests drive the real `chat` / `async_chat` wrapper factories
+with synthetic OpenAI-shaped dict chunks, and assert the span ends exactly
+once on each exit path.
+"""
+
+import time
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from openlit._config import OpenlitConfig
+from openlit.instrumentation.together import together as sync_mod
+from openlit.instrumentation.together import async_together as async_mod
+
+REQUEST_KWARGS = {
+    "model": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    "messages": [{"role": "user", "content": "hi"}],
+    "stream": True,
+}
+
+CHUNKS = [
+    {"id": "together-test", "choices": [{"delta": {"content": "pa"}, "finish_reason": None}]},
+    {"id": "together-test", "choices": [{"delta": {"content": "rtial answer"}, "finish_reason": None}]},
+    {"id": "together-test", "choices": [{"delta": {}, "finish_reason": "stop"}]},
+]
+
+
+def _tracer_with_exporter():
+    OpenlitConfig.reset_to_defaults()
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider.get_tracer(__name__), exporter
+
+
+def _factory(tracer, *, is_async):
+    mod = async_mod if is_async else sync_mod
+    make = mod.async_completion if is_async else mod.completion
+    return make(
+        version="test",
+        environment="test",
+        application_name="test",
+        tracer=tracer,
+        pricing_info={},
+        capture_message_content=True,
+        metrics=None,
+        disable_metrics=True,
+    )
+
+
+class FakeRawStream:
+    """Sync/async event stream shaped like an OpenAI-style chunk iterator."""
+
+    def __init__(self):
+        self._it = iter(CHUNKS)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._it)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._it)
+        except StopIteration:
+            raise StopAsyncIteration from None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def close(self):
+        """Record that the caller closed the stream without draining it."""
+        self.closed = True
+
+
+async def _fake_create_async(*a, **k):
+    return FakeRawStream()
+
+
+def test_sync_early_break_ends_span():
+    """Leaving iteration after one chunk must still end the span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        next(stream)  # consume one chunk, then leave the block early
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "early exit must still end and export the span"
+
+
+def test_sync_full_consumption_exports_exactly_one_span():
+    """Draining the sync stream must export exactly one finished span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        for _ in stream:
+            pass
+
+    time.sleep(0.1)
+    assert len(exporter.get_finished_spans()) == 1
+
+
+def test_sync_close_finalizes_span():
+    """Calling close() mid-iteration must finalize the span once."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=False)
+
+    stream = wrap(lambda *a, **k: FakeRawStream(), None, (), REQUEST_KWARGS)
+    with stream:
+        next(stream)
+        stream.close()
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "close() must finalize the span exactly once"
+
+
+async def test_async_early_break_ends_span():
+    """Leaving async iteration after one chunk must still end the span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=True)
+
+    stream = await wrap(_fake_create_async, None, (), REQUEST_KWARGS)
+    async with stream:
+        await anext(stream)
+
+    time.sleep(0.1)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, "early async exit must still end and export the span"
+
+
+async def test_async_full_consumption_exports_exactly_one_span():
+    """Draining the async stream must export exactly one finished span."""
+    tracer, exporter = _tracer_with_exporter()
+    wrap = _factory(tracer, is_async=True)
+
+    stream = await wrap(_fake_create_async, None, (), REQUEST_KWARGS)
+    async with stream:
+        async for _ in stream:
+            pass
+
+    time.sleep(0.1)
+    assert len(exporter.get_finished_spans()) == 1


### PR DESCRIPTION
**Issue number**: #1555

### Change description:
Same idempotent-finalizer shape as #1461 (Anthropic) and #1554 (AI21), ported onto the Together AI sync/async streaming wrappers. `__exit__`/`__aexit__` previously only forwarded to the wrapped stream, so a `break` before exhaustion (or a bare `close()`) never hit the `StopIteration` handler and the span stayed recording forever.

- `__exit__`/`__aexit__` finalize on non-exception exit (try/finally)
- new `close()` on the sync wrapper
- `_finalize_streaming_span()` guarded by `_streaming_response_processed`
- regression tests `sdk/python/tests/test_together_stream_span_lifecycle.py` (early-break / full-drain / close, sync + async)

Bonus finding while verifying: the async wrapper's `__anext__` catches `StopIteration`, but an exhausted async iterator raises `StopAsyncIteration` — so async spans leaked even on full drain. The exit-path finalizer covers that too. Verified locally: 4 fail pre-fix / 5 pass post-fix (harness: real wrapper factories + synthetic OpenAI-shaped chunks + in-memory exporter). Full matrix left to CI.

Root cause: single exit path for span end (exhaustion only). Diff scope: 3 files, small (2 source + 1 test).

### Checklist
* [x] PR title follows Conventional Commit format.
* [x] I have reviewed the contributing guidelines
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change? (searched: no together early-close issue/PR; cohere/bedrock/groq/mistral/ai21 ones cover other providers)
* [x] I have performed a self-review of this change
* [x] Changes have been tested (new lifecycle tests, pre/post verified locally; full matrix left to CI)
* [x] Changes are documented (docstrings on the new methods)

### Acknowledgment
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the project license.

## Summary by Sourcery

Ensure Together AI streaming spans are finalized reliably across all normal stream termination paths.

New Features:
- Add explicit synchronous stream closing that finalizes Together AI streaming telemetry.

Bug Fixes:
- Ensure Together AI synchronous and asynchronous streaming spans end on early exit, explicit close, and full stream exhaustion.
- Prevent duplicate streaming span finalization across exhaustion and wrapper exit paths.

Tests:
- Add regression coverage for synchronous and asynchronous Together AI stream lifecycle and exactly-once span export.